### PR TITLE
Sign in and sign out semantics

### DIFF
--- a/docs/DesignDocs/UserNameEmailRules.md
+++ b/docs/DesignDocs/UserNameEmailRules.md
@@ -1,0 +1,37 @@
+## Rules for managing usernames and email addresses in HydroShare 
+
+###1.	Purpose
+1.1.	Usernames are used by HydroShare for users to identify themselves at sign in.  They should in general not be displayed or used as identifiers anywhere else in the system.  A user may use their email address as their username, but they do not have to.
+
+1.2.	Email addresses are used by HydroShare to uniquely identify users and validate who they are, going by the premise that the identity of person behind an email account is sufficiently verifiable for HydroShare.  When resources in HydroShare are shared, it really means that they are shared with users who have gained entry to the system with this email address.  
+
+1.3.	To achieve the above purposes both username and email address should be associated with only one HydroShare account.
+###2.	Usernames
+2.1.	Each user account should have a separate and unique username that they specify at the time of account creation.  
+
+2.2.	In the case that a user requests a username that exists in the system generate a message that the username is already taken and that they need to request another username.  
+
+2.3.	A user may change their username using their profile page.  If when changing a username a user requests a username that exists in the system generate a message that the username is already taken and that they need to request another username 
+###3.	Email addresses
+3.1.	Each user account should have a separate and unique email address that they specify at the time of account creation.
+
+3.2.	In the case that a user requests to create an account and an account already exists that uses that email address the user is informed that an account with that email address exists.  This message should provide links to retrieve forgotten username and password.
+
+3.3.	Email addresses should be validated by an email being sent to the user and the user being required to click on a link in the email.  An account should not be created until the email address has been validated (Technically this may mean that there is an account that exists but is activated by the clicking).  A time limit should be set for a user to click on the link and validate the email.  This time limit should be adjustable by a HydroShare system administrator via a system administrator interface.  The initial value of this time limit should be 24 hours and conveyed to the user in the email and in the request account landing page.
+
+3.4.	If the user does not validate the account within the time limit any temporary information retained in the system about creating their account should be deleted.
+
+3.5.	If a user attempts to create an account with an email address for which a validation is pending the user should receive a message that indicates that creation of this account is pending validation of the email address.  This message should suggest the user look in their junk mail in case the validation email is there.  This message should provide a button for the validation email to be resent.  
+
+3.6.	A user may change their email address using their profile page.  If when changing an email address the user requests an email address that exists in the system generate a message that an account with that email address already exists.  This message should provide links to retrieve forgotten username and password.
+
+3.7.	The request to change an email should generate validation emails sent to both the new and the old email address.
+
+3.8.	The email change validation email sent to the new email address should include a link for the user to click on to validate the new email address.  Changes in the email address should only be enacted when this is clicked.  This validation should be active for the same time limit as validation of account creation email.
+
+3.9.	The email change validation sent to the old email address should indicate that a user (probably you) have requested to change the email address for your HydroShare account to <give new email address>.  If this is correct no action is needed.  If this is incorrect (which may mean someone is tampering with the account without your permission) provide a link to click on and revoke the email change.  This link to revoke the email change is intended to reduce the chance that someone can hijack a HydroShare account and should never expire.  So while an email change in the profile is made as soon as the new email account is verified, information needs to be retained so that this may be rolled back if the link to revoke the change is ever clicked.  
+###4.	Privacy
+4.1.	Email addresses in HydroShare are not private.  They are used for disambiguation in the identification of users when sharing resources and inviting users to groups.  
+
+4.2.	HydroShare should not publish email addresses on user profiles as this provides a way for spammers to discover emails.  Rather a button should be provided on the public user page "Send message" that allows a user to type a message to another user that HydroShare will then send to the user.  The from and reply to field in this email should have the email address of the originating user.
+

--- a/ga_resources/templates/includes/ga_editable_toolbar.html
+++ b/ga_resources/templates/includes/ga_editable_toolbar.html
@@ -5,7 +5,7 @@
     {% csrf_token %}
 
     <a id="editable-toolbar-toggle" href="#">&gt;&gt;</a>
-    <a id="editable-toolbar-logout" href="#">{% trans "Log out" %}</a>
+    <a id="editable-toolbar-logout" href="#">{% trans "Sign out" %}</a>
 </form>
 
 <img id="editable-loading" src="{% static "mezzanine/img/loadingAnimation.gif" %}"/>

--- a/hs_core/templates/400.html
+++ b/hs_core/templates/400.html
@@ -95,7 +95,7 @@
                         <ul class="dropdown-menu">
                             <li class="account">
                                 <p><b>{{ request.user }}</b>{% if request.user.email %}<br />{{ request.user.email }}{% endif %}</p>
-                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Log out</a>
+                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Sign out</a>
                                 <div class="clearfix"></div>
                             </li>
                         </ul>

--- a/hs_core/templates/404.html
+++ b/hs_core/templates/404.html
@@ -95,7 +95,7 @@
                         <ul class="dropdown-menu">
                             <li class="account">
                                 <p><b>{{ request.user }}</b>{% if request.user.email %}<br />{{ request.user.email }}{% endif %}</p>
-                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Log out</a>
+                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Sign out</a>
                                 <div class="clearfix"></div>
                             </li>
                         </ul>

--- a/hs_core/templates/500.html
+++ b/hs_core/templates/500.html
@@ -95,7 +95,7 @@
                         <ul class="dropdown-menu">
                             <li class="account">
                                 <p><b>{{ request.user }}</b>{% if request.user.email %}<br />{{ request.user.email }}{% endif %}</p>
-                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Log out</a>
+                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Sign out</a>
                                 <div class="clearfix"></div>
                             </li>
                         </ul>

--- a/hs_core/templates/503.html
+++ b/hs_core/templates/503.html
@@ -95,7 +95,7 @@
                         <ul class="dropdown-menu">
                             <li class="account">
                                 <p><b>{{ request.user }}</b>{% if request.user.email %}<br />{{ request.user.email }}{% endif %}</p>
-                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Log out</a>
+                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Sign out</a>
                                 <div class="clearfix"></div>
                             </li>
                         </ul>

--- a/theme/templates/accounts/account_login.html
+++ b/theme/templates/accounts/account_login.html
@@ -4,7 +4,7 @@
 {% block main %}
 
 {% if request.user.is_authenticated %}
-    <p>{% trans "You're already logged in. If you'd like to log in as a different user, you'll need to log out first." %}</p>
+    <p>{% trans "You're already signed in. If you'd like to sign in as a different user, you'll need to sign out first." %}</p>
 {% else %}
     {{ block.super }}
 
@@ -38,7 +38,7 @@
         </fieldset>
     </form>
 
-    <p>{% blocktrans with request.GET.next as next %}If you don't have an account you can <a href="/?next={{ next }}">sign up</a> for one now.{% endblocktrans %}</p>
+    <p>{% blocktrans with request.GET.next as next %}If you don't have an account you can <a href="/?next={{ next }}">join HydroShare</a> now.{% endblocktrans %}</p>
     {% url "mezzanine_password_reset" as password_reset_url %}
     {% url "profile_update" as profile_update_url %}
     {% blocktrans %}<p>You can also <a href="{{ password_reset_url }}?next={{ profile_update_url }}">reset your password</a> if you've forgotten it.</p>{% endblocktrans %}</p>

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -98,7 +98,7 @@
                         <ul class="dropdown-menu">
                             <li class="account">
                                 <p><b>{{ request.user }}</b>{% if request.user.email %}<br />{{ request.user.email }}{% endif %}</p>
-                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Log out</a>
+                                <p><a href="{% url 'profile_update' %}">Profile</a> | <a href="{% url 'logout' %}" id="signout-menu">Sign out</a>
                                 <div class="clearfix"></div>
                             </li>
                         </ul>

--- a/theme/templates/pages/homepage.html
+++ b/theme/templates/pages/homepage.html
@@ -131,7 +131,7 @@
 
                                 <div id="recaptcha-div" style="margin-bottom: 0.5em; background: white; border-radius: 4px; border: 1px solid"></div>
 
-                                <input class="hl-btn hl-btn-green btn-block" type="button" id="signup" value="Sign up & start collaborating.">
+                                <input class="hl-btn hl-btn-green btn-block" type="button" id="signup" value="Join HydroShare & start collaborating.">
                             </div>
                           </form>
                         </div>


### PR DESCRIPTION
This is a relatively minor set of semantic changes done as I learn to push to github.  There is still an inconsistency in the accounts/login page where the title is "log in" and the button label inherits from the title.  I was unable to find where to change this in code and suspect it may be in the mezzanine pages.  This is issue #72 in HydroShare that came from issue #60 in HydroShare2.