### PR TITLE
Update Profile on Alpha does not work

### DIFF
--- a/hs_docker_base/requirements.txt
+++ b/hs_docker_base/requirements.txt
@@ -24,6 +24,7 @@ django-picklefield
 django-tastypie
 django-tastypie-swagger==0.1.2
 django-timedeltafield==0.7.0
+django-widget-tweaks==1.3
 docutils==0.11
 ecdsa==0.10
 filebrowser-safe==0.3.1

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -284,7 +284,8 @@ INSTALLED_APPS = (
     "django_docker_processes",
     "hs_geo_raster_resource",
     "djcelery",
-    "ref_ts"
+    "ref_ts",
+    "widget_tweaks",
 )
 
 # List of processors used by RequestContext to populate the context.

--- a/theme/templates/includes/checkbox_field.html
+++ b/theme/templates/includes/checkbox_field.html
@@ -6,7 +6,7 @@
     <fieldset class="form-group form-group-checkbox input_{{ field.id_for_label }} {{ field.field.type }}
         {% if field.errors %} has-error{% endif %} {{ field_classes }}">
 
-        {% if readonly }
+        {% if readonly %}
             {% render_field field readonly="readonly" %}
         {% else %}
             {% render_field field %}

--- a/theme/templates/includes/checkbox_field.html
+++ b/theme/templates/includes/checkbox_field.html
@@ -1,10 +1,12 @@
+{% load widget_tweaks %}
+
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <fieldset {% if readonly %}disabled="disabled"{% endif %} class="form-group form-group-checkbox input_{{ field.id_for_label }} {{ field.field.type }}
+    <fieldset class="form-group form-group-checkbox input_{{ field.id_for_label }} {{ field.field.type }}
         {% if field.errors %} has-error{% endif %} {{ field_classes }}">
 
-        {{ field }}
+        {% render_field field readonly=readonly %}
 
         {% if field.label %}
             <label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>

--- a/theme/templates/includes/checkbox_field.html
+++ b/theme/templates/includes/checkbox_field.html
@@ -6,7 +6,11 @@
     <fieldset class="form-group form-group-checkbox input_{{ field.id_for_label }} {{ field.field.type }}
         {% if field.errors %} has-error{% endif %} {{ field_classes }}">
 
-        {% render_field field readonly=readonly %}
+        {% if readonly }
+            {% render_field field readonly="readonly" %}
+        {% else %}
+            {% render_field field %}
+        {% endif %}
 
         {% if field.label %}
             <label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>

--- a/theme/templates/includes/file_field.html
+++ b/theme/templates/includes/file_field.html
@@ -1,8 +1,8 @@
-<fieldset {% if readonly %}disabled="disabled"{% endif %} class="{{ field_classes }}">
+<fieldset class="{{ field_classes }}">
     <div id="{{ field.auto_id }}-upload-name"></div>
     <img id="{{ field.auto_id }}-preview" width="100%" />
     <span class="btn btn-default btn-file">
-        <label id="{{ field.auto_id}}-label">{{ field_label|default:field.label }}</label> <input type="file" id="{{ field.auto_id }}" name="{{ field.name }}" />
+        <label id="{{ field.auto_id}}-label">{{ field_label|default:field.label }}</label> <input type="file" id="{{ field.auto_id }}" name="{{ field.name }}" {% if readonly %}readonly="readonly"{% endif %} />
         <script>
             $('#{{ field.auto_id }}').change(function() {
                 var imageType = /image.*/;

--- a/theme/templates/includes/form_field.html
+++ b/theme/templates/includes/form_field.html
@@ -10,7 +10,11 @@
         <label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>
     {% endif %}
 
-    {% render_field field readonly=readonly %}
+    {% if readonly }
+        {% render_field field readonly="readonly" %}
+    {% else %}
+        {% render_field field %}
+    {% endif %}
 
     {% if field.errors %}
         <p class="help-block">

--- a/theme/templates/includes/form_field.html
+++ b/theme/templates/includes/form_field.html
@@ -1,14 +1,16 @@
+{% load widget_tweaks %}
+
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <fieldset {% if readonly %}disabled="disabled"{% endif %} class="form-group input_{{ field.id_for_label }} {{ field.field.type }}
+    <fieldset class="form-group input_{{ field.id_for_label }} {{ field.field.type }}
     {% if field.errors %} has-error{% endif %} {{ field_classes }}">
 
     {% if field.label %}
         <label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>
     {% endif %}
 
-    {{ field }}
+    {% render_field field readonly=readonly %}
 
     {% if field.errors %}
         <p class="help-block">

--- a/theme/templates/includes/form_field.html
+++ b/theme/templates/includes/form_field.html
@@ -10,7 +10,7 @@
         <label class="control-label" for="{{ field.auto_id }}">{{ field.label }}</label>
     {% endif %}
 
-    {% if readonly }
+    {% if readonly %}
         {% render_field field readonly="readonly" %}
     {% else %}
         {% render_field field %}


### PR DESCRIPTION
Update Profile on Alpha does not work.  When selecting the "Update Profile" button at the bottom of the page after updating one's profile, the page erases one's email address and requests that the issue be corrected, but it cannot be since the email field is not editable.