### PR TITLE
issue [#41] fixed

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1812,7 +1812,7 @@ def resource_creation_signal_handler(sender, instance, created, **kwargs):
             # res_json = utils.serialize_science_metadata(instance)
             # res_dict = json.loads(res_json)
             instance.metadata.create_element('identifier', name='hydroShareIdentifier', url='http://hydroshare.org/resource{0}{1}'.format('/', instance.short_id))
-
+            instance.set_slug('resource{0}{1}'.format('/', instance.short_id))
         else:
             resource_update_signal_handler(sender, instance, created, **kwargs)
 


### PR DESCRIPTION
resource URL issue is fixed, now the resource's landing page's URL has the pattern http://hydroshare.org/resource/{id}. The fix is only one line addition, should be easily merged in automatically.