### PR TITLE
[#9] change order of jquery-ui and bootstap calls in base.html

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -38,12 +38,12 @@
 
 {% compress js %}
 <script src="{% static "mezzanine/js/"|add:settings.JQUERY_FILENAME %}"></script>
-<script src="{% static "js/bootstrap.3.0.2.min.js" %}"></script>
-<script src="{% static "js/bootstrap-extras.js" %}"></script>
 <script src="{% static "js/custom.js" %}"></script>
 <script src="{% static "js/scrolltopcontrol.js" %}"></script><!-- Scroll to top javascript -->
 <script src="{% static "js/jqcsrf.js" %}"></script>
 <script src='{% static 'js/jquery-ui.js' %}'></script>
+<script src="{% static "js/bootstrap.3.0.2.min.js" %}"></script>
+<script src="{% static "js/bootstrap-extras.js" %}"></script>
 {% block extra_js %}{% endblock %}
 {% endcompress %}
 {% include 'autocomplete_light/static.html' %}


### PR DESCRIPTION
Change order of imports to work with ref_ts resource type