### PR TITLE
[#217] Abstract and alert message hotfix

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -14,12 +14,9 @@
                   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                   <strong>Data for the following required elements are missing:</strong>
                     <ul>
-                    {% if not abstract %}
-                       <li>Abstract</li>
-                    {% endif %}
-                    {% if not keywords %}
-                       <li>Keywords</li>
-                    {% endif %}
+                    {% for element in missing_metadata_elements %}
+                        <li>{{ element }}</li>
+                    {% endfor %}
                     {% if title|stringformat:"s" == "Untitled resource" %}
                        <li>Title: needs to be changed</li>
                     {% endif %}

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -538,7 +538,7 @@ def add_dublin_core(request, page):
 
     return {
         'dublin_core' : [t for t in cm.dublin_metadata.all().exclude(term='AB')],
-        'abstract' : abstract,
+        # 'abstract' : abstract,
         'resource_type' : cm._meta.verbose_name,
         'dcterm_frm' : DCTerm(),
         'bag' : cm.bags.first(),


### PR DESCRIPTION
[#217] Fixed an issue where some missing metadata elements where not listed in the alert message.
[#217] Fixed abstract field not showing up for non-generic resources