### PR TITLE
fixed issue #324

### DIFF
--- a/hs_geo_raster_resource/forms.py
+++ b/hs_geo_raster_resource/forms.py
@@ -44,11 +44,12 @@ class OriginalCoverageSpatialForm(forms.Form):
             for field in self.fields.values():
                 field.widget.attrs['readonly'] = True
                 field.widget.attrs['style'] = "background-color:white;"
-        else:
-            self.fields['projection'].widget.attrs['readonly'] = True
-            self.fields['projection'].widget.attrs['style'] = "background-color:white;"
-            self.fields['units'].widget.attrs['readonly'] = True
-            self.fields['units'].widget.attrs['style'] = "background-color:white;"
+        # enabling all element fields for editing
+        # else:
+        #     self.fields['projection'].widget.attrs['readonly'] = True
+        #     self.fields['projection'].widget.attrs['style'] = "background-color:white;"
+        #     self.fields['units'].widget.attrs['readonly'] = True
+        #     self.fields['units'].widget.attrs['style'] = "background-color:white;"
 
     def clean(self):
         # modify the form's cleaned_data dictionary
@@ -119,20 +120,21 @@ class CellInfoForm(ModelForm):
         super(CellInfoForm, self).__init__(*args, **kwargs)
         self.helper = CellInfoFormHelper(allow_edit, res_short_id, element_id, element_name='CellInformation')
 
-        # only noDataValue field needs to be set up read-only or not depending on whether the value is extracted from file or not
         if not allow_edit:
-            self.fields['noDataValue'].widget.attrs['readonly'] = "readonly"
+            for field in self.fields.values():
+                field.widget.attrs['readonly'] = True
+                field.widget.attrs['style'] = "background-color:white;"
 
     class Meta:
         model = CellInformation
         fields = ['rows', 'columns', 'cellSizeXValue', 'cellSizeYValue', 'cellSizeUnit', 'cellDataType', 'noDataValue']
         exclude = ['content_object']
-        widgets = { 'rows': forms.TextInput(attrs={'readonly':'readonly'}),
-                    'columns': forms.TextInput(attrs={'readonly':'readonly'}),
-                    'cellSizeXValue': forms.TextInput(attrs={'readonly':'readonly'}),
-                    'cellSizeYValue': forms.TextInput(attrs={'readonly':'readonly'}),
-                    'cellSizeUnit': forms.TextInput(attrs={'readonly':'readonly'}),
-                    'cellDataType': forms.TextInput(attrs={'readonly':'readonly'}),
+        widgets = { 'rows': forms.TextInput(), #(attrs={'readonly':'readonly'}),
+                    'columns': forms.TextInput(), #(attrs={'readonly':'readonly'}),
+                    'cellSizeXValue': forms.TextInput(), #(attrs={'readonly':'readonly'}),
+                    'cellSizeYValue': forms.TextInput(), #(attrs={'readonly':'readonly'}),
+                    'cellSizeUnit': forms.TextInput(), #(attrs={'readonly':'readonly'}),
+                    'cellDataType': forms.TextInput(), #(attrs={'readonly':'readonly'}),
                     'noDataValue': forms.TextInput()}
 
 class CellInfoValidationForm(forms.Form):

--- a/hs_geo_raster_resource/page_processors.py
+++ b/hs_geo_raster_resource/page_processors.py
@@ -36,7 +36,7 @@ def landing_page(request, page):
         context['bandInformation'] = content_model.metadata.bandInformation
     else:
         cellinfo_form = CellInfoForm(instance=content_model.metadata.cellInformation, res_short_id=content_model.short_id,
-                                     allow_edit = True if content_model.metadata.cellInformation.noDataValue is None else False,
+                                     allow_edit = True,
                                     element_id=content_model.metadata.cellInformation.id if content_model.metadata.cellInformation else None)
 
         BandInfoFormSetEdit = formset_factory(wraps(BandInfoForm)(partial(BandInfoForm, allow_edit=edit_resource)), formset=BaseBandInfoFormSet, extra=0)
@@ -53,7 +53,7 @@ def landing_page(request, page):
             ori_coverage_data_dict['southlimit'] = content_model.metadata.originalCoverage.value['southlimit']
             ori_coverage_data_dict['westlimit'] = content_model.metadata.originalCoverage.value['westlimit']
 
-            allow_edit_flag = True #if content_model.metadata.originalCoverage.value['projection']=='Unnamed' else False
+            allow_edit_flag = True
             ori_coverage_form = OriginalCoverageSpatialForm(initial=ori_coverage_data_dict, res_short_id=content_model.short_id,
                                                             allow_edit = allow_edit_flag, element_id=content_model.metadata.originalCoverage.id)
             ori_coverage_layout = AccordionGroup('Original Coverage (required)',

--- a/hs_geo_raster_resource/receivers.py
+++ b/hs_geo_raster_resource/receivers.py
@@ -21,11 +21,8 @@ def raster_pre_create_resource_trigger(sender, **kwargs):
             res_md_dict = raster_meta_extract.get_raster_meta_dict(infile.file.name)
 
             wgs_cov_info = res_md_dict['spatial_coverage_info']['wgs84_coverage_info']
-            if wgs_cov_info is not None:
-                # add core metadata coverage - box
-                box = {'coverage': {'type': 'box', 'value': wgs_cov_info }}
-            else:
-                box = {'coverage': {'type': 'box', 'value': res_md_dict['spatial_coverage_info']['original_coverage_info'] }}
+            # add core metadata coverage - box
+            box = {'coverage': {'type': 'box', 'value': wgs_cov_info }}
             metadata.append(box)
 
             # Save extended meta to metadata variable
@@ -53,19 +50,19 @@ def raster_pre_create_resource_trigger(sender, **kwargs):
                 ('columns', 0),
                 ('cellSizeXValue', 0),
                 ('cellSizeYValue', 0),
-                ('cellSizeUnit', "Unnamed"),
-                ('cellDataType', "Unnamed"),
+                ('cellSizeUnit', "NA"),
+                ('cellDataType', "NA"),
                 ('noDataValue', 0)
             ])
             metadata.append({'CellInformation': cell_info})
             bcount = 1
             spatial_coverage_info = OrderedDict([
-                 ('units', "Unnamed"),
-                 ('projection', 'Unnamed'),
-                 ('northlimit', 0),
-                 ('southlimit', 0),
-                 ('eastlimit', 0),
-                 ('westlimit', 0)
+                 ('units', "NA"),
+                 ('projection', 'NA'),
+                 ('northlimit', 'NA'),
+                 ('southlimit', 'NA'),
+                 ('eastlimit', 'NA'),
+                 ('westlimit', 'NA')
             ])
             # add core metadata coverage - box
             box = {'coverage': {'type': 'box', 'value': spatial_coverage_info}}
@@ -99,11 +96,7 @@ def raster_pre_add_files_to_resource_trigger(sender, **kwargs):
             #res.metadata.update_element('coverage', cov_box.id, type='box', value=res_md_dict['spatial_coverage_info']['wgs84_coverage_info'])
 
             wgs_cov_info = res_md_dict['spatial_coverage_info']['wgs84_coverage_info']
-            if wgs_cov_info is not None:
-                # add core metadata coverage - box
-                res.metadata.create_element('Coverage', type='box', value=res_md_dict['spatial_coverage_info']['wgs84_coverage_info'])
-            else:
-                res.metadata.create_element('Coverage', type='box', value=res_md_dict['spatial_coverage_info']['original_coverage_info'])
+            res.metadata.create_element('Coverage', type='box', value=res_md_dict['spatial_coverage_info']['wgs84_coverage_info'])
 
             # update extended original box coverage
             #ori_cov_box = res.metadata.originalCoverage
@@ -138,8 +131,8 @@ def raster_pre_delete_file_from_resource_trigger(sender, **kwargs):
         #cov_box = res.metadata.coverages.all().filter(type='box').first()
         # from collections import OrderedDict
         # spatial_coverage_info = OrderedDict([
-        #         ('units', "Unnamed"),
-        #         ('projection', 'Unnamed'),
+        #         ('units', "NA"),
+        #         ('projection', 'NA'),
         #         ('northlimit', 0),
         #         ('southlimit', 0),
         #         ('eastlimit', 0),
@@ -162,8 +155,8 @@ def raster_pre_delete_file_from_resource_trigger(sender, **kwargs):
         res.metadata.cellInformation.delete()
         res.metadata.create_element('CellInformation', name=res.title, rows=0, columns = 0,
                                         cellSizeXValue = 0, cellSizeYValue = 0,
-                                        cellSizeUnit = "Unnamed",
-                                        cellDataType = "Unnamed",
+                                        cellSizeUnit = "NA",
+                                        cellDataType = "NA",
                                         noDataValue = 0)
 
         # reset extended metadata BandInformation now that the only file is deleted


### PR DESCRIPTION
Make raster metadata editing more flexible to accommodate various use cases, especially the future use case that allows users to edit metadata and update geotiff file accordingly, while fixing this issue. All changes are isolated in raster resource type app.