### PR TITLE
321 change resource names

### DIFF
--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -245,7 +245,7 @@ class NetcdfResource(Page, AbstractResource):
         return AbstractResource.can_view(self, request)
 
     class Meta:
-            verbose_name = 'Multidimensional NetCDF Resource'
+            verbose_name = 'Multidimensional (NetCDF)'
 
 processor_for(NetcdfResource)(resource_processor)
 

--- a/hs_app_timeseries/models.py
+++ b/hs_app_timeseries/models.py
@@ -193,7 +193,7 @@ class TimeSeriesResult(AbstractMetaDataElement):
 
 class TimeSeriesResource(Page, AbstractResource):
     class Meta:
-        verbose_name = 'Time Series Resource'
+        verbose_name = 'Time Series'
 
     @property
     def metadata(self):

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1521,7 +1521,7 @@ class Bags(models.Model):
 class GenericResource(Page, AbstractResource):
 
     class Meta:
-        verbose_name = 'Generic Hydroshare Resource'
+        verbose_name = 'Generic'
 
     def can_add(self, request):
         return AbstractResource.can_add(self, request)

--- a/hs_core/templates/pages/create-resource.html
+++ b/hs_core/templates/pages/create-resource.html
@@ -23,13 +23,13 @@
         <label for="" class="col-sm-2 control-label">Select a resource type</label>
         <div class="col-sm-10">
             <select class="form-control" name="resource-type" id="resource-type">
-                <option value="GenericResource">Generic Resource</option>
-                <option value="RasterResource">Geographic Raster Resource</option>
-                <option value="TimeSeriesResource">Time Series Resource</option>
+                <option value="GenericResource">Generic</option>
+                <option value="RasterResource">Geographic Raster</option>
+                <option value="TimeSeriesResource">Time Series</option>
 {#                <option value="InstResource">RHESSys Instance Resource</option> #}
                 <option value="RefTimeSeries">HIS Referenced Time Series</option>
                 <option value="ModelInstanceResource">Model Instance Resource</option>
-                <option value="NetcdfResource">Multidimensional NetCDF Resource</option>
+                <option value="NetcdfResource">Multidimensional (NetCDF)</option>
                 <option value="ModelProgramResource">Model Program Resource</option>
                 <option value="ToolResource">Tool Resource</option>
             </select>

--- a/hs_geo_raster_resource/models.py
+++ b/hs_geo_raster_resource/models.py
@@ -231,7 +231,7 @@ class CellInformation(AbstractMetaDataElement):
 #
 class RasterResource(Page, AbstractResource):
     class Meta:
-        verbose_name = 'Geographic Raster Resource'
+        verbose_name = 'Geographic Raster'
 
     @property
     def metadata(self):

--- a/ref_ts/models.py
+++ b/ref_ts/models.py
@@ -10,7 +10,7 @@ from django.contrib.contenttypes import generic
 class RefTimeSeries(Page, AbstractResource):
 
         class Meta:
-                verbose_name = "Referenced HIS Time Series Resource"
+                verbose_name = "Referenced HIS Time Series"
 
         def extra_capabilities(self):
             return None

--- a/ref_ts/models.py
+++ b/ref_ts/models.py
@@ -10,7 +10,7 @@ from django.contrib.contenttypes import generic
 class RefTimeSeries(Page, AbstractResource):
 
         class Meta:
-                verbose_name = "Referenced HIS Time Series"
+                verbose_name = "HIS Referenced Time Series"
 
         def extra_capabilities(self):
             return None


### PR DESCRIPTION
The names of the resource types supported in 1.5 release are changed as the following:
"Multidimensional (NetCDF)"
"Geographic Raster"
"Generic"
"Time Series"
"HIS Referenced Time Series"