### PR TITLE
328 download access control

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -109,9 +109,7 @@ class ResourcePermissionsMixin(Ownable):
     def can_delete(self, request):
         user = get_user(request)
         if user.is_authenticated():
-            if user.is_superuser:
-                return True
-            elif user.pk in { o.pk for o in self.owners.all() }:
+            if user.is_superuser | self.owners.filter(pk=user.pk).exists():
                 return True
             else:
                 return False
@@ -125,7 +123,7 @@ class ResourcePermissionsMixin(Ownable):
         if user.is_authenticated():
             if user.is_superuser:
                 return True
-            elif user.pk in { o.pk for o in self.owners.all() }:
+            elif self.owners.filter(pk=user.pk).exists():
                 return True
             elif self.edit_users.filter(pk=user.pk).exists():
                 return True
@@ -144,7 +142,7 @@ class ResourcePermissionsMixin(Ownable):
         if user.is_authenticated():
             if user.is_superuser:
                 return True
-            elif user.pk in { o.pk for o in self.owners.all() }:
+            elif self.owners.filter(pk=user.pk).exists():
                 return True
             elif self.edit_users.filter(pk=user.pk).exists():
                 return True
@@ -158,8 +156,6 @@ class ResourcePermissionsMixin(Ownable):
                 return False
         else:
             return False
-
-
 
 # this should be used as the page processor for anything with pagepermissionsmixin
 # page_processor_for(MyPage)(ga_resources.views.page_permissions_page_processor)

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -109,7 +109,7 @@ class ResourcePermissionsMixin(Ownable):
     def can_delete(self, request):
         user = get_user(request)
         if user.is_authenticated():
-            if user.is_superuser | self.owners.filter(pk=user.pk).exists():
+            if user.is_superuser or self.owners.filter(pk=user.pk).exists():
                 return True
             else:
                 return False


### PR DESCRIPTION
Resolved issue #328 - now HydroShare access control permissions are honored with this fix when downloading a resource or resource file from a URL. The change made is in django_irods submodule. I also added back the suggestion Calvin made for my last pull request, i.e., use self.owners.filter(pk=user.pk).exists() to check whether a request user is in the owners list. @ironfroggy Could you give a quick review for this pull request at your earliest conveience so that it can be merged in for the team to test on dev for release 1.5? Thanks!