### PR TITLE
Refactor GET /hsapi/resource/<RESOURCE_ID> to always return a summary

### DIFF
--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -177,7 +177,7 @@ class ResourceListRetrieveCreateUpdateDelete(generics.RetrieveUpdateDestroyAPIVi
         else:
             creator_name = r.creator.username
 
-        sharing_status = 'Public' if r.public else 'Private'
+        public = True if r.public else False
 
         bag_url = hydroshare.utils.current_site_url() + resource_bag.bag.url
         science_metadata_url = hydroshare.utils.current_site_url() + reverse('get_update_science_metadata', args=[r.short_id])
@@ -185,7 +185,7 @@ class ResourceListRetrieveCreateUpdateDelete(generics.RetrieveUpdateDestroyAPIVi
                                                           resource_id=r.short_id,
                                                           resource_title=r.title,
                                                           creator=creator_name,
-                                                          sharing_status=sharing_status,
+                                                          public=public,
                                                           date_created=r.created,
                                                           date_last_updated=r.updated,
                                                           bag_url=bag_url,

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -75,7 +75,7 @@ class ResourceListItemSerializer(serializers.Serializer):
     creator = serializers.CharField(max_length=100)
     date_created = serializers.DateTimeField(format='%m-%d-%Y')
     date_last_updated = serializers.DateTimeField(format='%m-%d-%Y')
-    sharing_status = serializers.CharField(max_length=20)
+    public = serializers.BooleanField()
     bag_url = serializers.URLField()
     science_metadata_url = serializers.URLField()
 
@@ -85,7 +85,7 @@ ResourceListItem = namedtuple('ResourceListItem',
                               'resource_id, '
                               'resource_title, '
                               'creator, '
-                              'sharing_status, '
+                              'public, '
                               'date_created, '
                               'date_last_updated, '
                               'bag_url, '


### PR DESCRIPTION
of system metadata summary for the requested resource.  The reason for
this was that the django-rest framework did not seem to like it when
the Accept HTTP header was set to application/zip.  Now, to get the
bag, or the science metadata, REST API users will need to fetch the
respective URL from the system metadata returned by GET
/hsapi/resource/<RESOURCE_ID>.

Addresses #345 