### PR TITLE
Owned by me link does not work

### DIFF
--- a/hs_core/templates/pages/my-resources.html
+++ b/hs_core/templates/pages/my-resources.html
@@ -10,7 +10,7 @@
     <div class="row">
         <div class="col-lg-2" id="folders">
             <ul class="nav nav-stacked">
-                <li><a href="?creator={{ user.pk }}">Owned by me</a></li>
+                <li><a href="?owner={{ user.username }}">Owned by me</a></li>
                 <li><a href="?user={{ user.pk }}&edit_permission=true">Editable by me</a></li>
                 {% if user.pk %}
                     <li><a href="?user={{ user.pk }}">Viewable by me</a></li>


### PR DESCRIPTION
On the latest Dev deployment Owned by me does not work on the resources listing page.  @mjstealey pointed out that this link is http://dev.hydroshare.org/my-resources/?creator=<user>, but it should probably be http://dev.hydroshare.org/my-resources/?owner=<user>.  If I change the "creator" to "owner" in the URL it appears to work.

This may relate to filtering changes by @ironfroggy, so Calvin, please take a look.  