### PR TITLE
remove old bag deletion code

### DIFF
--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -140,7 +140,7 @@ def serialize_system_metadata(res):
     return json.dumps(resd)
 
 
-def resource_modified(resource, by_user=None):
+def resource_modified(resource, by_user=None, overwrite_bag=True):
     resource.last_changed_by = by_user
 
     resource.updated = now().isoformat()
@@ -148,6 +148,13 @@ def resource_modified(resource, by_user=None):
     if resource.metadata.dates.all().filter(type='modified'):
         res_modified_date = resource.metadata.dates.all().filter(type='modified')[0]
         resource.metadata.update_element('date', res_modified_date.id)
+
+    if overwrite_bag:
+        for bag in resource.bags.all():
+            try:
+                bag.delete()
+            except:
+                pass
 
     hs_bagit.create_bag(resource)
 

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -140,7 +140,7 @@ def serialize_system_metadata(res):
     return json.dumps(resd)
 
 
-def resource_modified(resource, by_user=None, overwrite_bag=True):
+def resource_modified(resource, by_user=None):
     resource.last_changed_by = by_user
 
     resource.updated = now().isoformat()
@@ -148,18 +148,6 @@ def resource_modified(resource, by_user=None, overwrite_bag=True):
     if resource.metadata.dates.all().filter(type='modified'):
         res_modified_date = resource.metadata.dates.all().filter(type='modified')[0]
         resource.metadata.update_element('date', res_modified_date.id)
-
-    if overwrite_bag:
-        for bag in resource.bags.all():
-            try:
-                bag.bag.delete()
-            except:
-                pass
-
-            try:
-                bag.delete()
-            except:
-                pass
 
     hs_bagit.create_bag(resource)
 


### PR DESCRIPTION
remove old bag deletion code which caused wasteful executions when a resource is modified. It will not cause issues for NFIE release since the exception is ignored, but it will be nice to remove it. Have searched across the whole codebase and made sure it does not break any existing code including REST code. Also tested to make sure it works without causing any issues.