### PR TITLE
extend from base.html instead of accounts/account_form.html

### DIFF
--- a/theme/templates/accounts/account_login.html
+++ b/theme/templates/accounts/account_login.html
@@ -1,6 +1,8 @@
-{% extends "accounts/account_form.html" %}
+{% extends "base.html" %}
 {% load i18n future %}
 {% block title %}Sign In{% endblock %}
+
+{% block main_cols %}col-md-6 col-md-offset-3{% endblock %}
 
 {% block main %}
 

--- a/theme/templates/accounts/account_password_reset.html
+++ b/theme/templates/accounts/account_password_reset.html
@@ -1,5 +1,7 @@
-{% extends "accounts/account_form.html" %}
+{% extends "base.html" %}
 {% load i18n %}
+
+{% block main_cols %}col-md-6 col-md-offset-3{% endblock %}
 
 {% block main %}
 {{ block.super }}


### PR DESCRIPTION
Since we've overloaded our own forms from Mezzanine there is some unexpected rendering when the DEBUG setting goes from True to False for some forms.