### PR TITLE
446 improve res mod perf

### DIFF
--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -158,17 +158,6 @@ def create_bag_by_irods(resource_id, istorage = None):
     if not istorage:
         istorage = IrodsStorage()
 
-    # make sure bag is not locked by another request before creating a bag to resolve potential race condition
-    bag_lock = istorage.getAVU(resource_id, "bag_lock")
-
-    if bag_lock:
-        while bag_lock == "true":
-            sleep(5) # delay for 5 seconds before checking bag_lock AVU from iRODS again
-            bag_lock = istorage.getAVU(resource_id, "bag_lock")
-
-    # lock the bag so it will not be updated by another request while the bag is being created
-    istorage.setAVU(resource_id, "bag_lock", "true")
-
     # call iRODS bagit rule here
     irods_dest_prefix = "/" + settings.IRODS_ZONE + "/home/" + settings.IRODS_USERNAME
     irods_bagit_input_path = os.path.join(irods_dest_prefix, resource_id)
@@ -180,9 +169,6 @@ def create_bag_by_irods(resource_id, istorage = None):
 
     # call iRODS ibun command to zip the bag
     istorage.zipup(irods_bagit_input_path, 'bags/{res_id}.zip'.format(res_id=resource_id))
-
-    # release the lock so other requests can update the bag
-    istorage.setAVU(resource_id, "bag_lock", "false")
 
 def create_bag(resource):
     """

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -135,10 +135,11 @@ def create_bag_by_irods(resource_id, istorage = None):
     # call iRODS bagit rule here
     irods_dest_prefix = "/" + settings.IRODS_ZONE + "/home/" + settings.IRODS_USERNAME
     irods_bagit_input_path = os.path.join(irods_dest_prefix, resource_id)
-    bagit_input = "*BAGITDATA='{path}'".format(path=irods_bagit_input_path)
+    bagit_input_path = "*BAGITDATA='{path}'".format(path=irods_bagit_input_path)
+    bagit_input_resource = "*DESTRESC='{def_res}'".format(def_res=settings.IRODS_DEFAULT_RESOURCE)
     bagit_rule_file = getattr(settings, 'IRODS_BAGIT_RULE', 'hydroshare/irods/ruleGenerateBagIt_HS.r')
 
-    istorage.runBagitRule(bagit_rule_file, bagit_input)
+    istorage.runBagitRule(bagit_rule_file, bagit_input_path, bagit_input_resource)
 
     # call iRODS ibun command to zip the bag
     istorage.zipup(irods_bagit_input_path, 'bags/{res_id}.zip'.format(res_id=resource_id))

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -34,10 +34,7 @@ def delete_bag(resource):
 
     # delete the bags table
     for bag in resource.bags.all():
-        try:
-            bag.delete()
-        except Exception as ex:
-            raise Exception(ex.message)
+        bag.delete()
 
 def create_bag_files(resource):
     """

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -10,7 +10,7 @@ from hs_core.hydroshare import hs_bagit
 from hs_core.hydroshare.utils import get_resource_types
 from hs_core.models import ResourceFile
 from hs_core import signals
-from . import utils
+from hs_core.hydroshare import utils
 
 file_size_limit = 10*(1024 ** 3)
 file_size_limit_for_display = '10G'

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -149,15 +149,7 @@ def resource_modified(resource, by_user=None, overwrite_bag=True):
         res_modified_date = resource.metadata.dates.all().filter(type='modified')[0]
         resource.metadata.update_element('date', res_modified_date.id)
 
-    if overwrite_bag:
-        for bag in resource.bags.all():
-            try:
-                bag.delete()
-            except:
-                pass
-
-    hs_bagit.create_bag(resource)
-
+    hs_bagit.create_bag_files(resource)
 
 # def _get_user_info(user):
 #     from hs_core.api import UserResource

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -16,8 +16,8 @@ from mezzanine.conf import settings
 
 from hs_core.signals import *
 from hs_core.models import AbstractResource
-from . import hs_bagit
-
+from hs_core.hydroshare.hs_bagit import create_bag_files
+from django_irods.storage import IrodsStorage
 
 class ResourceFileSizeException(Exception):
     pass
@@ -149,7 +149,12 @@ def resource_modified(resource, by_user=None, overwrite_bag=True):
         res_modified_date = resource.metadata.dates.all().filter(type='modified')[0]
         resource.metadata.update_element('date', res_modified_date.id)
 
-    hs_bagit.create_bag_files(resource)
+    create_bag_files(resource)
+
+    istorage = IrodsStorage()
+    # set bag_modified-true AVU pair for the modified resource in iRODS to indicate
+    # the resource is modified for on-demand bagging.
+    istorage.setAVU(resource.short_id, "bag_modified", "true")
 
 # def _get_user_info(user):
 #     from hs_core.api import UserResource

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -149,7 +149,8 @@ def resource_modified(resource, by_user=None, overwrite_bag=True):
         res_modified_date = resource.metadata.dates.all().filter(type='modified')[0]
         resource.metadata.update_element('date', res_modified_date.id)
 
-    create_bag_files(resource)
+    if overwrite_bag:
+        create_bag_files(resource)
 
     istorage = IrodsStorage()
     # set bag_modified-true AVU pair for the modified resource in iRODS to indicate

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -24,6 +24,7 @@
             {%  endif %}
         {% endblock %}
 
+            {# ======= Missing fields notification =======#}
             {% if not metadata_form and page.perms.change %}
                 {% if missing_metadata_elements or title|stringformat:"s" == "Untitled resource" %}
                     <div class="alert alert-success alert-dismissible" role="alert">

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -14,7 +14,7 @@
         <input type="hidden" id="supported-file-types" value="{{ cm.get_supported_upload_file_types }}">
         <input type="hidden" id="allow-multiple-file-upload" value={{ cm.can_have_multiple_files }}>
         <input type="hidden" id="file-count" value={{ cm.files.all.count }}>
-        <img id="ajax-wait" width='100' height='100' src="{{STATIC_URL}}img/ajax-loader.gif" align='center' style="position:absolute;z-index:100000;top:40%;left:50%;display: none;">
+
         {% block error %}
             {%  if file_validation_error %}
                 <div class="alert alert-danger alert-dismissible" role="alert">
@@ -24,7 +24,6 @@
             {%  endif %}
         {% endblock %}
 
-            {#  ======= Missing fields notification =======#}
             {% if not metadata_form and page.perms.change %}
                 {% if missing_metadata_elements or title|stringformat:"s" == "Untitled resource" %}
                     <div class="alert alert-success alert-dismissible" role="alert">
@@ -688,11 +687,11 @@
                     {% endif %}
                     <!-- Buttons -->
                     {% for b in cm.bags.all %}
-                        <button id="btn-download-all" type="button" class="btn btn-default" onclick="download_bag_ajax('{{ bag_url }}');">
+                        <a id="btn-download-all" type="button" class="btn btn-default" href="{{ bag_url }}">
                             <span class="glyphicon glyphicon-download-alt">
                                 <span title='Download All Content as Zipped BagIt Archive' class="button-label">Download All Content as Zipped BagIt Archive</span>
                             </span>
-                        </button>
+                        </a>
                     {% endfor %}
 
                     {% if page.perms.change %}
@@ -2256,22 +2255,6 @@
         }
 
         $("#id-subject").find("#id_value").val(keywords);
-    }
-
-    function download_bag_ajax(url) {
-        $('#ajax-wait').show();
-        $.ajax({
-            url: url,
-            type: "GET",
-            success: function(result) {
-                $('#ajax-wait').hide();
-                window.location = url;
-            },
-            error: function(xhr, errmsg, err) {
-                console.log(xhr.status + ": " + xhr.responseText + ". Error message: " + errmsg);
-                $('#ajax-wait').hide();
-            }
-        });
     }
 
     function metadata_update_ajax_submit(form_id){

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -14,7 +14,7 @@
         <input type="hidden" id="supported-file-types" value="{{ cm.get_supported_upload_file_types }}">
         <input type="hidden" id="allow-multiple-file-upload" value={{ cm.can_have_multiple_files }}>
         <input type="hidden" id="file-count" value={{ cm.files.all.count }}>
-
+        <img id="ajax-wait" width='100' height='100' src="{{STATIC_URL}}img/ajax-loader.gif" align='center' style="position:absolute;z-index:100000;top:40%;left:50%;display: none;">
         {% block error %}
             {%  if file_validation_error %}
                 <div class="alert alert-danger alert-dismissible" role="alert">
@@ -688,11 +688,11 @@
                     {% endif %}
                     <!-- Buttons -->
                     {% for b in cm.bags.all %}
-                        <a id="btn-download-all" type="button" class="btn btn-default" href="{{ bag_url }}">
+                        <button id="btn-download-all" type="button" class="btn btn-default" onclick="download_bag_ajax('{{ bag_url }}');">
                             <span class="glyphicon glyphicon-download-alt">
                                 <span title='Download All Content as Zipped BagIt Archive' class="button-label">Download All Content as Zipped BagIt Archive</span>
                             </span>
-                        </a>
+                        </button>
                     {% endfor %}
 
                     {% if page.perms.change %}
@@ -2253,6 +2253,22 @@
         }
 
         $("#id-subject").find("#id_value").val(keywords);
+    }
+
+    function download_bag_ajax(url) {
+        $('#ajax-wait').show();
+        $.ajax({
+            url: url,
+            type: "GET",
+            success: function(result) {
+                $('#ajax-wait').hide();
+                window.location = url;
+            },
+            error: function(xhr, errmsg, err) {
+                console.log(xhr.status + ": " + xhr.responseText + ". Error message: " + errmsg);
+                $('#ajax-wait').hide();
+            }
+        });
     }
 
     function metadata_update_ajax_submit(form_id){

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -2283,7 +2283,7 @@
             $alert_error = '<div class="alert alert-danger" id="error-alert"> \
                 <button type="button" class="close" data-dismiss="alert">x</button> \
                 <strong>Error! </strong> \
-                Metadata updated failed.\
+                Metadata failed to update.\
             </div>'
             $form=$('#' + form_id);
             var datastring = $form.serialize();

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -148,9 +148,6 @@ def add_metadata_element(request, shortkey, element_name, *args, **kwargs):
                 is_add_success = True
                 resource_modified(res, request.user)
 
-    if is_add_success:
-        request.session['bag_modified'] = True
-
     if request.is_ajax():
         if is_add_success:
             if res.metadata.has_all_required_elements():
@@ -200,9 +197,6 @@ def update_metadata_element(request, shortkey, element_name, element_id, *args, 
                 resource_modified(res, request.user)
                 is_update_success = True
 
-    if is_update_success:
-        request.session['bag_modified'] = True
-
     if request.is_ajax():
         if is_update_success:
             if res.metadata.has_all_required_elements():
@@ -233,7 +227,6 @@ def delete_metadata_element(request, shortkey, element_name, element_id, *args, 
     res.metadata.delete_element(element_name, element_id)
     resource_modified(res, request.user)
     request.session['resource-mode'] = 'edit'
-    request.session['bag_modified'] = True
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
 
@@ -259,7 +252,6 @@ def publish(request, shortkey, *args, **kwargs):
     res.doi = "to be assigned"
     res.save()
     resource_modified(res, request.user)
-    request.session['bag_modified'] = True
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
 
@@ -571,7 +563,7 @@ def create_resource(request, *args, **kwargs):
 
     # go to resource landing page
     request.session['just_created'] = True
-    request.session['bag_modified'] = False
+
     return HttpResponseRedirect(resource.get_absolute_url())
 
 

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -148,6 +148,9 @@ def add_metadata_element(request, shortkey, element_name, *args, **kwargs):
                 is_add_success = True
                 resource_modified(res, request.user)
 
+    if is_add_success:
+        request.session['bag_modified'] = True
+
     if request.is_ajax():
         if is_add_success:
             if res.metadata.has_all_required_elements():
@@ -197,6 +200,9 @@ def update_metadata_element(request, shortkey, element_name, element_id, *args, 
                 resource_modified(res, request.user)
                 is_update_success = True
 
+    if is_update_success:
+        request.session['bag_modified'] = True
+
     if request.is_ajax():
         if is_update_success:
             if res.metadata.has_all_required_elements():
@@ -227,6 +233,7 @@ def delete_metadata_element(request, shortkey, element_name, element_id, *args, 
     res.metadata.delete_element(element_name, element_id)
     resource_modified(res, request.user)
     request.session['resource-mode'] = 'edit'
+    request.session['bag_modified'] = True
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
 
@@ -252,6 +259,7 @@ def publish(request, shortkey, *args, **kwargs):
     res.doi = "to be assigned"
     res.save()
     resource_modified(res, request.user)
+    request.session['bag_modified'] = True
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
 
@@ -563,6 +571,7 @@ def create_resource(request, *args, **kwargs):
 
     # go to resource landing page
     request.session['just_created'] = True
+    request.session['bag_modified'] = False
     return HttpResponseRedirect(resource.get_absolute_url())
 
 

--- a/hydroshare/irods/ruleGenerateBagIt_HS.r
+++ b/hydroshare/irods/ruleGenerateBagIt_HS.r
@@ -25,7 +25,7 @@ generateBagIt {
   ### - writes bagit.txt to NEWBAGITROOT/bagit.txt
   writeLine("stdout","BagIt-Version: 0.96");
   writeLine("stdout","Tag-File-Character-Encoding: UTF-8");
-  msiDataObjCreate("*BAGITDATA" ++ "/bagit.txt","forceFlag=",*FD);
+  msiDataObjCreate("*BAGITDATA" ++ "/bagit.txt","destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=",*FD);
   msiDataObjWrite(*FD,"stdout",*WLEN);
   msiDataObjClose(*FD,*Status);
   msiFreeBuffer("stdout");
@@ -54,7 +54,7 @@ generateBagIt {
   }
 
   ### - writes payload manifest to BAGITDATA/manifest-md5.txt
-  msiDataObjCreate("*BAGITDATA" ++ "/manifest-md5.txt","forceFlag=",*FD);
+  msiDataObjCreate("*BAGITDATA" ++ "/manifest-md5.txt","destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=",*FD);
   msiDataObjWrite(*FD,"stdout",*WLEN);
   msiDataObjClose(*FD,*Status);
   msiFreeBuffer("stdout");
@@ -66,7 +66,7 @@ generateBagIt {
   writeString("stdout","manifest-md5.txt    ");
   msiDataObjChksum("*BAGITDATA" ++ "/manifest-md5.txt","forceChksum",*CHKSUM);
   writeLine("stdout",*CHKSUM);
-  msiDataObjCreate("*BAGITDATA" ++ "/tagmanifest-md5.txt","forceFlag=",*FD);
+  msiDataObjCreate("*BAGITDATA" ++ "/tagmanifest-md5.txt","destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=",*FD);
   msiDataObjWrite(*FD,"stdout",*WLEN);
   msiDataObjClose(*FD,*Status);
   msiFreeBuffer("stdout");
@@ -74,5 +74,5 @@ generateBagIt {
   ### - writes to rodsLog
   msiWriteRodsLog("BagIt bag files created in place: *BAGITDATA <- *BAGITDATA",*Status);
 }
-INPUT *BAGITDATA="/dummy/dummy/dummy" 
+INPUT *BAGITDATA="/hydrotest41Zone/home/hyi", *DESTRESC="demoResc"
 OUTPUT ruleExecOut

--- a/hydroshare/irods/ruleGenerateBagIt_HS.r
+++ b/hydroshare/irods/ruleGenerateBagIt_HS.r
@@ -74,5 +74,5 @@ generateBagIt {
   ### - writes to rodsLog
   msiWriteRodsLog("BagIt bag files created in place: *BAGITDATA <- *BAGITDATA",*Status);
 }
-INPUT *BAGITDATA="/hydrotest41Zone/home/hyi", *DESTRESC="demoResc"
+INPUT *BAGITDATA="/dummy/dummy/dummy", *DESTRESC="dummy"
 OUTPUT ruleExecOut

--- a/irods_browser_app/static/js/irods.js
+++ b/irods_browser_app/static/js/irods.js
@@ -34,6 +34,7 @@ $('#btn-signin-irods').on('click',function(){
 $('#btn-select-irods-file').on('click',function(){
     $('#res_type').val($('#resource-type').val());
     $('#file_struct').children().remove();
+    $('.ajax-loader').hide();
     var store = '';
     if (sessionStorage.IRODS_signininfo) {
         $("#irods_content_label").text(sessionStorage.IRODS_username);


### PR DESCRIPTION
This branch is slated for NFIE hotfix release, and deployed on park for testing. Please review the code at your earliest convenience so that it can be merged into develop for the NFIE hotfix. It mainly resolves the performance issue with big resource metadata editing by doing on-demand bagging. Another two issues below are also resolved in this branch:

1. Hide the ajax spin wheel icon when irods browser gets invoked again - a minor bug fix.
2. bagit rule fix that stores generated bagit files such as bagit.txt and manifest files to HydroShare default resource rather than the default iRODS demoResc resource. 