### PR TITLE
Hsaccess integration

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -4,30 +4,28 @@
 
 ## Overview
 
-Users: Admin, Test
-	- Admin is actually an admin, i.e. superuser
-	- Test is an arbitrary non-superuser user
+Users: `Admin, Test`
+- `Admin` is actually an admin, i.e. superuser
+- `Test` is an arbitrary non-superuser user
 
 Future users:
-	- FakeAdmin is a normal user whose username is 'admin'
+	- `FakeAdmin` is a normal user whose username is 'admin'
 
-Resources Types: GENERIC
+Resources Types: `GENERIC`
 	- we use only generic resources for now to limit the manual labor
 
-Permissions: NONE, VIEW, EDIT, OWN
-	- VIEW allows another user READONLY access
-	- EDIT lets another user make changes to the content/metadata
-	- OWN lets another user delete the resource
+Permissions: `NONE, VIEW, EDIT, OWN`
+- `VIEW` allows another user READONLY access
+- `EDIT` lets another user make changes to the content/metadata
+- `OWN` lets another user delete the resource
 
 Actions:
-	1. VIEW resource page
-
-	2. VIEW edit button
-	3. VIEW edit page (load page in edit_mode)
-	4. COMMIT EDITS in the edit page
-
-	5. VIEW delete button
-	6. DELETE resource
+1. `VIEW` resource page
+2. `VIEW` edit button
+3. `VIEW` edit page (load page in edit_mode)
+4. `COMMIT EDITS` in the edit page
+5. `VIEW` delete button
+6. `DELETE` resource
 
 For each pair of (permissions X actions) we evaluate whether a user with the
 given permissions can perform the given action. 

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -28,7 +28,9 @@ Actions:
 6. `DELETE` resource
 
 For each pair of (permissions X actions) we evaluate whether a user with the
-given permissions can perform the given action. 
+given permissions can perform the given action.
+
+We also consider the case of a user whose username is 'Admin'. 
 
 ## Test Results
 
@@ -56,8 +58,8 @@ Test & Admin:
 5. NO
 6. N/A
 
--- as expected: can see resource, but cant see edit buttons so cant (easily) load 
-		edit page or delete the resource
+-- as expected: can see resource, but cant see edit buttons so cant (easily)
+		load edit page or delete the resource
 
 -- NB: injecting a form to load the page in edit mode results in the edit page
 	loading, but saving changes results in a 500 (internal server error)

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,0 +1,97 @@
+
+# Access Control Tests
+### Tests cases to check proper implementation of Hydroshare access control policies.
+
+## Overview
+
+Users: Admin, Test
+	- Admin is actually an admin, i.e. superuser
+	- Test is an arbitrary non-superuser user
+
+Future users:
+	- FakeAdmin is a normal user whose username is 'admin'
+
+Resources Types: GENERIC
+	- we use only generic resources for now to limit the manual labor
+
+Permissions: NONE, VIEW, EDIT, OWN
+	- VIEW allows another user READONLY access
+	- EDIT lets another user make changes to the content/metadata
+	- OWN lets another user delete the resource
+
+Actions:
+	1. VIEW resource page
+
+	2. VIEW edit button
+	3. VIEW edit page (load page in edit_mode)
+	4. COMMIT EDITS in the edit page
+
+	5. VIEW delete button
+	6. DELETE resource
+
+For each pair of (permissions X actions) we evaluate whether a user with the
+given permissions can perform the given action. 
+
+## Test Results
+
+======================
+with NO permissions:
+===========
+Test & Admin:
+1. NO
+2. N/A
+3. N/A
+4. N/A
+5. N/A
+6. N/A
+
+-- as expected: cant see, so cant do anything. access denied w/ 403 Forbidden.
+		Error should probably be 'Unknown Resource' to not divulge the
+		existence of the resource
+
+======================
+with VIEW permissions:
+===========
+
+Test & Admin:
+1. YES 
+2. NO
+3. N/A
+4. N/A
+5. NO
+6. N/A
+
+-- as expected: can see resource, but cant see edit buttons so cant (easily) load 
+		edit page or delete the resource
+
+-- NB: injecting a form to load the page in edit mode results in the edit page
+	loading, but saving changes results in a 500 (internal server error)
+
+======================
+with EDIT permissions:
+===========
+
+Test & Admin:
+1. YES
+2. YES
+3. YES
+4. YES
+5. NO
+6. N/A
+
+-- as expected: can view & edit, but cant see delete button
+
+======================
+with OWN permissions:
+===========
+
+Test & Admin:
+1. YES 
+2. YES
+3. YES
+4. YES
+5. YES
+6. YES
+
+-- as expected: can view, edit, and delete
+

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -110,3 +110,11 @@ with username = 'admin', then normal users will not be able to create a user
 that can masquerade as the superuser. However, this is pretty flimsy, and 
 reimplementing access control such that it does not manually inspect the 
 username would be more robust.
+
+* Changing Ownership
+The existing implementation compares the user making the request to the user
+who created the resource, and if equal grants access. However, while this seems
+to lead to a security hole wherein the creator could lose access to a resource
+but still be listed as the creator does not occur. In testing, trying to view
+a resource which the user had originally created but then been removed from
+ownership resulted in a 403, which makes sense.

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -9,10 +9,10 @@ Users: `Admin, Test`
 - `Test` is an arbitrary non-superuser user
 
 Future users:
-	- `FakeAdmin` is a normal user whose username is 'admin'
+- `FakeAdmin` is a normal user whose username is 'admin'
 
 Resources Types: `GENERIC`
-	- we use only generic resources for now to limit the manual labor
+- we use only generic resources for now to limit the manual labor
 
 Permissions: `NONE, VIEW, EDIT, OWN`
 - `VIEW` allows another user READONLY access
@@ -86,3 +86,25 @@ Test & Admin:
 
 -- as expected: can view, edit, and delete
 
+## Conclusions
+
+* Permissions:
+The existing implementation of the permissions model works mostly as expected.
+I could not get it to commit the ultimate failure of letting a user mutate a 
+resource without adequate permissions. However, the user (with some form 
+trickery) can view pages they should not, even if they cannot make any changes
+once there. 
+
+Specific changes:
+1. Server should respond with a 404 when asking for a resource that the user
+does not have permission to see, so as not to leak info about the existence
+of the resource
+2. Server should not respond with a 500 when a user attempts to save changes
+they are not authorized to make. Instead, send a 403 (forbidden) or 404. 
+
+* Admin Username:
+Usernames must be unique, so as long as the DB comes configured with a user
+with username = 'admin', then normal users will not be able to create a user
+that can masquerade as the superuser. However, this is pretty flimsy, and 
+reimplementing access control such that it does not manually inspect the 
+username would be more robust.

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -34,9 +34,8 @@ given permissions can perform the given action.
 
 ## Test Results
 
-======================
-with NO permissions:
-===========
+#### with NO permissions:
+
 Test & Admin:
 1. NO
 2. N/A
@@ -49,9 +48,7 @@ Test & Admin:
 		Error should probably be 'Unknown Resource' to not divulge the
 		existence of the resource
 
-======================
-with VIEW permissions:
-===========
+#### with VIEW permissions:
 
 Test & Admin:
 1. YES 
@@ -67,9 +64,7 @@ Test & Admin:
 -- NB: injecting a form to load the page in edit mode results in the edit page
 	loading, but saving changes results in a 500 (internal server error)
 
-======================
-with EDIT permissions:
-===========
+#### with EDIT permissions:
 
 Test & Admin:
 1. YES
@@ -81,9 +76,7 @@ Test & Admin:
 
 -- as expected: can view & edit, but cant see delete button
 
-======================
-with OWN permissions:
-===========
+#### with OWN permissions:
 
 Test & Admin:
 1. YES 

--- a/docs/resource-hsaccess.txt
+++ b/docs/resource-hsaccess.txt
@@ -1,0 +1,35 @@
+/home/igray/hydroshare/hs_modelinstance/models.py
+	uses base page_processor (which is problematic)
+	can_* methods return corresponding AbstractResource method
+
+/home/igray/hydroshare/hs_rhessys_inst_resource/models.py
+	no page_processor.
+	can_* methods return corresponding AbstractResource method
+
+/home/igray/hydroshare/hs_geo_raster_resource/models.py
+	uses base page_processor (which is problematic)
+	can_* methods return corresponding AbstractResource method
+
+/home/igray/hydroshare/hs_app_timeseries/models.py
+	uses base page_processor (which is problematic)
+	does not override can* methods
+	
+/home/igray/hydroshare/ref_ts/models.py
+	no page_processor.
+	can_* methods return corresponding AbstractResource method
+
+/home/igray/hydroshare/hs_swat_modelinstance/models.py
+	uses base page_processor (which is problematic)
+	can_* methods return corresponding AbstractResource method
+
+/home/igray/hydroshare/hs_model_program/models.py
+	uses base page_processor (which is problematic)
+	can_* methods return corresponding AbstractResource method
+
+/home/igray/hydroshare/hs_tools_resource/models.py
+	uses base page_processor (which is problematic)
+	can_* methods return corresponding AbstractResource method
+
+/home/igray/hydroshare/hs_app_netCDF/models.py
+	uses base page_processor (which is problematic)
+	can_* methods return corresponding AbstractResource method

--- a/hs_app_timeseries/page_processors.py
+++ b/hs_app_timeseries/page_processors.py
@@ -9,9 +9,18 @@ from hs_core.views import *
 @processor_for(TimeSeriesResource)
 # TODO: problematic permissions
 def landing_page(request, page):
+    """
+        A typical Mezzanine page processor.
+
+        TODO: refactor to make it clear that there are two different modes = EDITABLE | READONLY
+                - split into two helper functions: readonly_landing_page(...) and editable_landing_page(...)
+    """
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)
+
+    # view depends on whether the resource is being edited
     if not edit_resource:
+        # READONLY
         # get the context from hs_core
         context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=None, request=request)
         extended_metadata_exists = False
@@ -29,6 +38,9 @@ def landing_page(request, page):
         context['processing_level'] = content_model.metadata.processing_level
         context['timeseries_result'] = content_model.metadata.time_series_result
     else:
+        # EDIT MODE
+
+        # add some forms
         site_form = SiteForm(instance=content_model.metadata.site, res_short_id=content_model.short_id,
                              element_id=content_model.metadata.site.id if content_model.metadata.site else None)
 
@@ -78,6 +90,7 @@ def landing_page(request, page):
         # get the context from hs_core
         context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout)
 
+        # customize base context
         context['resource_type'] = 'Time Series Resource'
         context['site_form'] = site_form
         context['variable_form'] = variable_form
@@ -86,6 +99,7 @@ def landing_page(request, page):
         context['timeseries_result_form'] = timeseries_result_form
 
 
+    # TODO: can we refactor to make it impossible to skip adding the generic context
     hs_core_context = add_generic_context(request, page)
     context.update(hs_core_context)
     return context

--- a/hs_app_timeseries/page_processors.py
+++ b/hs_app_timeseries/page_processors.py
@@ -7,6 +7,7 @@ from hs_core import page_processors
 from hs_core.views import *
 
 @processor_for(TimeSeriesResource)
+# TODO: problematic permissions
 def landing_page(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)

--- a/hs_core/authorization.py
+++ b/hs_core/authorization.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+# TODO: not used anywhere. delete.
 class HydroshareAuthorization(object):
     def read_list(self, object_list, bundle):
         return filter(lambda x: x.can_view(bundle.request), object_list)

--- a/hs_core/page_processors.py
+++ b/hs_core/page_processors.py
@@ -8,6 +8,7 @@ from django_irods.storage import IrodsStorage
 
 @processor_for(GenericResource)
 def landing_page(request, page):
+    # TODO: this if/else is an exact copy of the function 'check_resource_mode', defined below
     if request.method == "GET":
         resource_mode = request.session.get('resource-mode', None)
         if resource_mode == 'edit':
@@ -22,6 +23,8 @@ def landing_page(request, page):
 
 # resource type specific app needs to call this method to inject a crispy_form layout
 # object for displaying metadata UI for the extended metadata for their resource
+# TODO: fix hand-coded user permissions
+# TODO: someone tell me what these ~280 lines do?
 def get_page_context(page, user, resource_edit=False, extended_metadata_layout=None, request=None):
     file_type_error=''
     if request:
@@ -32,6 +35,8 @@ def get_page_context(page, user, resource_edit=False, extended_metadata_layout=N
     content_model = page.get_content_model()
     edit_mode = False
     file_validation_error = None
+    # should not be implemented manually. defer to can_edit, can_view, etc
+    # should be: if page.can_change():
     if user.username == 'admin' or \
                     content_model.creator == user or \
                     user in (content_model.owners.all() | content_model.edit_users.all()):

--- a/hs_core/page_processors.py
+++ b/hs_core/page_processors.py
@@ -46,7 +46,12 @@ def get_page_context(page, user, resource_edit=False, extended_metadata_layout=N
     content_model = page.get_content_model()
     edit_mode = False
     file_validation_error = None
-    # TODO: fix hand-coded user permissions. should be something like: `if page.can_change():`
+    # TODO: fix hand-coded user permissions. should be something like: `edit_mode = page.can_change()`
+    # Problems with this implementation:
+    #   1. does not check if user is in a group that has edit permissions
+    #   2. checks username directly (what if i make a new acc with uname = 'admin')
+    #   3. does not check user.is_superuser (which is probably what the 'admin' username check should be)
+    #   4. does not check if the user is authenticated at all (user.is_authenticated())
     if user.username == 'admin' or \
                     content_model.creator == user or \
                     user in (content_model.owners.all() | content_model.edit_users.all()):
@@ -93,7 +98,7 @@ def get_page_context(page, user, resource_edit=False, extended_metadata_layout=N
             spatial_coverage_data_dict['name'] = spatial_coverage.value.get('name', None)
             spatial_coverage_data_dict['units'] = spatial_coverage.value['units']
             spatial_coverage_data_dict['zunits'] = spatial_coverage.value.get('zunits', None)
-            spatial_coverage_data_dict['projection'] = spatial_coverage.value.get('projection', None)
+            spatial_coverage_data_dict['projection'] = +spatial_coverage.value.get('projection', None)
             spatial_coverage_data_dict['type'] = spatial_coverage.type
             if spatial_coverage.type == 'point':
                 spatial_coverage_data_dict['east'] = spatial_coverage.value['east']

--- a/hs_geo_raster_resource/page_processors.py
+++ b/hs_geo_raster_resource/page_processors.py
@@ -10,6 +10,7 @@ from functools import partial, wraps
 
 # page processor to populate raster resource specific metadata into my-resources template page
 @processor_for(RasterResource)
+# TODO: problematic permissions
 def landing_page(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)

--- a/hs_model_program/page_processors.py
+++ b/hs_model_program/page_processors.py
@@ -9,6 +9,7 @@ from hs_core.views import *
 
 @processor_for(ModelProgramResource)
 # when the resource is created this page will be shown
+# TODO: problematic permissions
 def landing_page(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)

--- a/hs_modelinstance/page_processors.py
+++ b/hs_modelinstance/page_processors.py
@@ -6,6 +6,7 @@ from hs_core.views import *
 
 
 @processor_for(ModelInstanceResource)
+# TODO: problematic permissions.
 def landing_page(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)

--- a/hs_rhessys_inst_resource/models.py
+++ b/hs_rhessys_inst_resource/models.py
@@ -26,6 +26,7 @@ import os
 #
 # To create a new resource, use these two super-classes.
 #
+# TODO: doesnt have a page_processors.py????
 class InstResource(Page, AbstractResource):
     class Meta:
         verbose_name = 'RHESSys Instance Resource'

--- a/hs_tools_resource/page_processors.py
+++ b/hs_tools_resource/page_processors.py
@@ -10,6 +10,7 @@ from functools import *
 from hs_core.views import *
 
 @processor_for(ToolResource)
+# TODO: problematic permissions
 def landing_page(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)


### PR DESCRIPTION
Initially, access control was implemented inline in `hs_core/page_processor.py`. This is bad because:
1. It is not a correct implementation. For example, it does not inspect group permissions.
2. Bypassing the `ResourcePermissionsMixin` denies resources the opportunity to customize permissions.

Thus, this PR switches the implementation from an inline comparison to delegating to `ResourcePermissionsMixin`.