### PR TITLE
fixed issue #510

### DIFF
--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -208,14 +208,16 @@ def check_file_dict_for_error(file_validation_dict):
             error_message = file_validation_dict.get('message', "Uploaded file(s) failed validation.")
             raise ResourceFileValidationException(error_message)
 
+def raise_file_size_exception():
+    from .resource import file_size_limit_for_display
+    error_msg = 'The resource file is larger than the supported size limit: %s.' % file_size_limit_for_display
+    raise ResourceFileSizeException(error_msg)
 
 def validate_resource_file_size(resource_files):
-    from .resource import check_resource_files, file_size_limit_for_display
+    from .resource import check_resource_files
     valid = check_resource_files(resource_files)
     if not valid:
-        error_msg = 'The resource file is larger than the supported size limit: %s.' % file_size_limit_for_display
-        raise ResourceFileSizeException(error_msg)
-
+        raise_file_size_exception()
 
 def resource_pre_create_actions(resource_type, resource_title, page_redirect_url_key, files=(), metadata=None,  **kwargs):
     from.resource import check_resource_type

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -35,7 +35,6 @@ from . import user_rest_api
 
 from hs_core.hydroshare import utils
 from . import utils as view_utils
-from hs_core.hydroshare import file_size_limit_for_display
 from hs_core.signals import *
 
 def short_url(request, *args, **kwargs):
@@ -517,6 +516,9 @@ def create_resource(request, *args, **kwargs):
         try:
             upload_from_irods(username=user, password=password, host=host, port=port,
                                   zone=zone, irods_fname=irods_fname, res_files=resource_files)
+        except utils.ResourceFileSizeException as ex:
+            context = {'file_size_error': ex.message}
+            return render_to_response('pages/create-resource.html', context, context_instance=RequestContext(request))
         except Exception as ex:
             context = {'resource_creation_error': ex.message}
             return render_to_response('pages/create-resource.html', context, context_instance=RequestContext(request))


### PR DESCRIPTION
With this fix, the files loaded from iRODS file browser will be subject to file size limit (currently set to be 10GB) as files loaded from local disk. @rayi113 this means the 12GB NFIE file we have been experimenting with will trigger a file size error message when using it to create a HydroShare resource unless we increase the 10GB file size limit. 