### PR TITLE
fixed issue #[515]

### DIFF
--- a/hs_app_netCDF/page_processors.py
+++ b/hs_app_netCDF/page_processors.py
@@ -113,7 +113,7 @@ def landing_page(request, page):
 
         )
 
-        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout)
+        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout, request=request)
         context['variable_formset'] = variable_formset
         context['add_variable_modal_form'] = add_variable_modal_form
         context['original_coverage_form'] = ori_cov_form

--- a/hs_app_timeseries/page_processors.py
+++ b/hs_app_timeseries/page_processors.py
@@ -88,7 +88,7 @@ def landing_page(request, page):
 
 
         # get the context from hs_core
-        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout)
+        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout, request=request)
 
         # customize base context
         context['resource_type'] = 'Time Series Resource'

--- a/hs_geo_raster_resource/page_processors.py
+++ b/hs_geo_raster_resource/page_processors.py
@@ -80,7 +80,7 @@ def landing_page(request, page):
                                 cellinfo_layout,
                                 BandInfoLayoutEdit
         )
-        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout)
+        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout, request=request)
         context['ori_coverage_form'] = ori_coverage_form
         context['cellinfo_form'] = cellinfo_form
         context['bandinfo_formset'] = bandinfo_formset

--- a/hs_model_program/page_processors.py
+++ b/hs_model_program/page_processors.py
@@ -40,7 +40,7 @@ def landing_page(request, page):
 
         # get the context from hs_core
         context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource,
-                                                   extended_metadata_layout=ext_md_layout)
+                                                   extended_metadata_layout=ext_md_layout, request=request)
 
         context['resource_type'] = 'Model Program Resource'
         context['output_form'] = output_form

--- a/hs_modelinstance/page_processors.py
+++ b/hs_modelinstance/page_processors.py
@@ -51,7 +51,7 @@ def landing_page(request, page):
 
         # get the context from hs_core
         context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource,
-                                                   extended_metadata_layout=ext_md_layout)
+                                                   extended_metadata_layout=ext_md_layout, request=request)
 
         context['resource_type'] = 'Model Instance Resource'
         context['model_output_form'] = model_output_form

--- a/hs_rhessys_inst_resource/models.py
+++ b/hs_rhessys_inst_resource/models.py
@@ -147,7 +147,7 @@ processor_for(InstResource)(resource_processor)
 def main_page(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)
-    context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=None)
+    context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=None, request=request)
     extended_metadata_exists = False
     context['extended_metadata_exists'] = extended_metadata_exists
     if(request.method == 'POST'):

--- a/hs_swat_modelinstance/page_processors.py
+++ b/hs_swat_modelinstance/page_processors.py
@@ -109,7 +109,7 @@ def landing_page(request, page):
 
 
         # get the context from hs_core
-        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout)
+        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout, request=request)
 
         context['resource_type'] = 'SWAT Model Instance Resource'
         context['model_output_form'] = model_output_form

--- a/hs_tools_resource/page_processors.py
+++ b/hs_tools_resource/page_processors.py
@@ -74,7 +74,7 @@ def landing_page(request, page):
 
 
         # get the context from hs_core
-        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout)
+        context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=ext_md_layout, request=request)
 
         res_type_names = []
         for res_type_class in get_resource_types():

--- a/ref_ts/views.py
+++ b/ref_ts/views.py
@@ -182,7 +182,7 @@ def create_ref_time_series(request, *args, **kwargs):
 def add_dublin_core(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)
-    context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=None)
+    context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource, extended_metadata_layout=None, request=request)
     extended_metadata_exists = False
     if content_model.metadata.sites.all().first() or \
             content_model.metadata.variables.all().first() or \


### PR DESCRIPTION
This issue is indeed triggered by @ilangray's recent change to hs_core/page_processors.py, which now requires request object to be passed in when retrieving page context. The default value for request is None if nothing is passed in, hence the error. Passing in request object resolves this issue. I have made changes across the board to all specific resource apps (the only change is to pass in request object when retrieving page context, which should be risk-free). Although I think this fix is safe without risk, @pkdash, could you take a quick look to confirm? @mjstealey could you merge this pull request into develop after @pkdash give a +1 since the current develop branch raises errors when editing metadata for any specific resource type without this fix