### PR TITLE
Hsaccess

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -509,7 +509,7 @@ def update_resource(
             # TODO: remove view_groups
             resource.view_groups.add(group)
 
-    # WTF: why does checking view_groups lead to mutating edit_groups?
+    # FIXME: why does checking view_groups lead to mutating edit_groups & view_groups?
     if view_groups:
         # TODO: remove edit_groups
         resource.edit_groups.clear()

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -378,7 +378,9 @@ def create_resource(
         if edit_users:
             for user in edit_users:
                 user = utils.user_from_id(user)
+                # TODO: remove edit_users
                 resource.edit_users.add(user)
+                # TODO: remove view_users
                 resource.view_users.add(user)
         if view_users:
             for user in view_users:
@@ -388,11 +390,14 @@ def create_resource(
         if edit_groups:
             for group in edit_groups:
                 group = utils.group_from_id(group)
+                # TODO: remove edit_groups
                 resource.edit_groups.add(group)
+                # TODO: remove view_groups
                 resource.view_groups.add(group)
         if view_groups:
             for group in view_groups:
                 group = utils.group_from_id(group)
+                # TODO: remove view_groups
                 resource.view_groups.add(group)
 
         if keywords:
@@ -478,29 +483,39 @@ def update_resource(
         resource.owners.add(owner)
 
     if edit_users:
+        # TODO: remove edit_users
         resource.edit_users.clear()
         for user in edit_users:
             user = utils.user_from_id(user)
+            # TODO remove edit_users
             resource.edit_users.add(user)
+            # TODO: remove view_users
             resource.view_users.add(user)
 
     if view_users:
+        # TODO: remove view_users
         resource.view_users.clear()
         for user in view_users:
             user = utils.user_from_id(user)
+            # TODO: remove view_users
             resource.view_users.add(user)
 
     if edit_groups:
+        # TODO: remove edit_groups
         resource.edit_groups.clear()
         for group in edit_groups:
             group = utils.group_from_id(group)
             resource.edit_groups.add(group)
+            # TODO: remove view_groups
             resource.view_groups.add(group)
 
+    # WTF: why does checking view_groups lead to mutating edit_groups?
     if view_groups:
+        # TODO: remove edit_groups
         resource.edit_groups.clear()
         for group in view_groups:
             group = utils.group_from_id(group)
+            # TODO: remove view_groups
             resource.view_groups.add(group)
 
     if keywords:

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -77,10 +77,12 @@ class ResourcePermissionsMixin(Ownable):
         default=True
     )
 
+    # TODO: remove 'owners' property?
     owners = models.ManyToManyField(User,
                                     related_name='owns_%(app_label)s_%(class)s',
                                     help_text='The person who has total ownership of the resource'
     )
+
     frozen = models.BooleanField(
         help_text='If this is true, the resource should not be modified',
         default=False
@@ -98,6 +100,7 @@ class ResourcePermissionsMixin(Ownable):
         default=False
     )
 
+    # TODO: remove these properties (view_users, view_groups, edit_users, edit_groups)
     view_users = models.ManyToManyField(User,
                                         related_name='user_viewable_%(app_label)s_%(class)s',
                                         help_text='This is the set of Hydroshare Users who can view the resource',
@@ -125,6 +128,7 @@ class ResourcePermissionsMixin(Ownable):
     def permissions_store(self):
         return s.PERMISSIONS_DB
 
+# TODO: since PagePermissionsMixin is in GA, and GA should die, CAN WE REMOVE THIS ENTIRE FUNCTION?
 # this should be used as the page processor for anything with pagepermissionsmixin
 # page_processor_for(MyPage)(ga_resources.views.page_permissions_page_processor)
 def page_permissions_page_processor(request, page):
@@ -132,11 +136,21 @@ def page_permissions_page_processor(request, page):
     user = get_user(request)
 
     return {
+        # TODO: remove edit_groups?
         "edit_groups": set(page.edit_groups.all()),
+
+        # TODO: remove view_groups?
         "view_groups": set(page.view_groups.all()),
+
+        # TODO: remove edit_users?
         "edit_users": set(page.edit_users.all()),
+
+        # TODO: remove view_users?
         "view_users": set(page.view_users.all()),
+
         "owners": set(page.owners.all()),
+
+        # TODO: oh god why is this implemented by hand??
         "can_edit": (user in set(page.edit_users.all())) \
                     or (len(set(page.edit_groups.all()).intersection(set(user.groups.all()))) > 0)
     }
@@ -2025,6 +2039,7 @@ class CoreMetaData(models.Model):
         allowed_elements = [el.lower() for el in self.get_supported_element_names()]
         return element_name.lower() in allowed_elements
 
+# TODO: is this dead code?
 def resource_processor(request, page):
     extra = page_permissions_page_processor(request, page)
     extra['res'] = page.get_content_model()

--- a/hs_core/urls.py
+++ b/hs_core/urls.py
@@ -1,54 +1,67 @@
 from django.conf.urls import patterns, url
 from hs_core import views
 
+# 'appears sin-free' = EXCLUSIVELY uses the hydroshare module to update resource/persmission/etc state
 urlpatterns = patterns('',
 
     # resource API
-     url(r'^resourceTypes/$', views.resource_rest_api.ResourceTypes.as_view(),
-        name='list_resource_types'),
 
+    # appears sin-free
+    url(r'^resourceTypes/$', views.resource_rest_api.ResourceTypes.as_view(),
+        name='list_resource_types'),
     url(r'^resourceList/$', views.resource_rest_api.ResourceList.as_view(),
         name='list_resources'),
-
     url(r'^resource/$', views.resource_rest_api.ResourceCreate.as_view(),
         name='create_resource'),
-
     url(r'^resource/(?P<pk>[A-z0-9]+)/$', views.resource_rest_api.ResourceReadUpdateDelete.as_view(),
         name='get_update_delete_resource'),
 
+    # SINFUL! directly manipulates `res.public`
     url(r'^resource/accessRules/(?P<pk>[A-z0-9]+)/$', views.resource_rest_api.AccessRulesUpdate.as_view(),
         name='update_access_rules'),
 
+    # appears sin-free
     url(r'^sysmeta/(?P<pk>[A-z0-9]+)/$', views.resource_rest_api.SystemMetadataRetrieve.as_view(),
         name='get_system_metadata'),
-
     url(r'^scimeta/(?P<pk>[A-z0-9]+)/$', views.resource_rest_api.ScienceMetadataRetrieveUpdate.as_view(),
         name='get_update_science_metadata'),
-
     url(r'^resource/(?P<pk>[A-z0-9]+)/files/$', views.resource_rest_api.ResourceFileCRUD.as_view(),
         name='add_resource_file'),
-
     url(r'^resource/(?P<pk>[A-z0-9]+)/files/(?P<filename>[^/]+)/$',
         views.resource_rest_api.ResourceFileCRUD.as_view(), name='get_update_delete_resource_file'),
 
     # internal API
 
+    # sin-free
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/add-file-to-resource/$', views.add_file_to_resource),
+
+    # **** directly manipulates metadata, but thats probably OK by HSAccess
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/(?P<element_name>[A-z]+)/add-metadata/$', views.add_metadata_element),
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/(?P<element_name>[A-z]+)/(?P<element_id>[A-z0-9]+)/update-metadata/$', views.update_metadata_element),
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/(?P<element_name>[A-z]+)/(?P<element_id>[A-z0-9]+)/delete-metadata/$', views.delete_metadata_element),
+
+    # HSAccess does not care about resource files
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/delete-resource-file/(?P<f>[0-9]+)/$', views.delete_file),
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/delete-resource/$', views.delete_resource),
+
+    # **** SINFUL!
+    # changes needed: mirror updates to HSAcccess
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/change-permissions/$', views.change_permissions),
+
+    # N/A
     url(r'^_internal/verify_captcha/$', views.verify_captcha),
+
+    # **** SINFUL! manipulates BAD resource properties
+    # changes needed: mirror updates to HSAccess
     url(r'^_internal/publish/$', views.publish),
+
+    # sinless
     url(r'^_internal/create-resource/$', views.create_resource_select_resource_type),
     url(r'^_internal/create-resource/do/$', views.create_resource),
     url(r'^_internal/verify-account/$', views.verify_account),
     url(r'^_internal/resend_verification_email/$', views.resend_verification_email),
     url(r'^_internal/(?P<resource_type>[A-z]+)/supported-file-types/$', views.get_supported_file_types_for_resource_type),
     url(r'^_internal/(?P<resource_type>[A-z]+)/allow-multiple-file/$', views.is_multiple_file_allowed_for_resource_type),
-
     url(r'^_internal/search/autocomplete/', "hs_core.views.autocomplete.autocomplete"),
 )
 

--- a/hs_core/urls.py
+++ b/hs_core/urls.py
@@ -1,12 +1,15 @@
 from django.conf.urls import patterns, url
 from hs_core import views
 
-# 'appears sin-free' = EXCLUSIVELY uses the hydroshare module to update resource/persmission/etc state
+#
+# 'sinless' = EXCLUSIVELY uses the hydroshare module to update resource/persmission/etc state
+#
+
 urlpatterns = patterns('',
 
     # resource API
 
-    # appears sin-free
+    # sinless
     url(r'^resourceTypes/$', views.resource_rest_api.ResourceTypes.as_view(),
         name='list_resource_types'),
     url(r'^resourceList/$', views.resource_rest_api.ResourceList.as_view(),
@@ -17,10 +20,11 @@ urlpatterns = patterns('',
         name='get_update_delete_resource'),
 
     # SINFUL! directly manipulates `res.public`
+    # changes needed: mirror updates to HSAccess
     url(r'^resource/accessRules/(?P<pk>[A-z0-9]+)/$', views.resource_rest_api.AccessRulesUpdate.as_view(),
         name='update_access_rules'),
 
-    # appears sin-free
+    # sinless
     url(r'^sysmeta/(?P<pk>[A-z0-9]+)/$', views.resource_rest_api.SystemMetadataRetrieve.as_view(),
         name='get_system_metadata'),
     url(r'^scimeta/(?P<pk>[A-z0-9]+)/$', views.resource_rest_api.ScienceMetadataRetrieveUpdate.as_view(),
@@ -32,7 +36,7 @@ urlpatterns = patterns('',
 
     # internal API
 
-    # sin-free
+    # sinless
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/add-file-to-resource/$', views.add_file_to_resource),
 
     # **** directly manipulates metadata, but thats probably OK by HSAccess
@@ -40,7 +44,7 @@ urlpatterns = patterns('',
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/(?P<element_name>[A-z]+)/(?P<element_id>[A-z0-9]+)/update-metadata/$', views.update_metadata_element),
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/(?P<element_name>[A-z]+)/(?P<element_id>[A-z0-9]+)/delete-metadata/$', views.delete_metadata_element),
 
-    # HSAccess does not care about resource files
+    # sinless
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/delete-resource-file/(?P<f>[0-9]+)/$', views.delete_file),
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/delete-resource/$', views.delete_resource),
 
@@ -51,7 +55,7 @@ urlpatterns = patterns('',
     # N/A
     url(r'^_internal/verify_captcha/$', views.verify_captcha),
 
-    # **** SINFUL! manipulates BAD resource properties
+    # **** SINFUL! directly manipulates res.public
     # changes needed: mirror updates to HSAccess
     url(r'^_internal/publish/$', views.publish),
 

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -220,6 +220,7 @@ class ResourceReadUpdateDelete(generics.RetrieveUpdateDestroyAPIView, ResourceTo
     def delete(self, request, pk):
         view_utils.authorize(request, pk, full=True)
         hydroshare.delete_resource(pk)
+
         # spec says we need return the id of the resource that got deleted - otherwise would have used status code 204
         # and not 200
         return Response(data={'resource_id': pk}, status=status.HTTP_200_OK)
@@ -382,6 +383,8 @@ class AccessRulesUpdate(APIView):
             raise ValidationError(detail=access_rules_validator.errors)
 
         validated_request_data = access_rules_validator.validated_data
+
+        # TODO: STOP VIOLATING INTERFACES. use update_resources(...) to change permissions
         res = get_resource_by_shortkey(pk)
         res.public = validated_request_data['public']
         res.save()


### PR DESCRIPTION
Made a mistake and pushed to the wrong branch.

This branch contains a lot of `TODO` markups (and some `FIXME`s) that point to uses of the following deprecated properties in `ResourcePermissionsMixin`:
1. `view_users`
2. `edit_users`
3. `view_groups`
4. `edit_groups`

Someone should find all of the `TODO`s and fix them.