### PR TITLE
further fix to issue [#529]

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -170,7 +170,7 @@
                         <div id="div_id_abstract" class="control-group">
                             <div class="controls"><textarea class="form-control input-sm textarea" cols="40"
                                                             id="id_abstract" name="abstract"
-                                                            rows="10">{{ cm.metadata.description|linebreaks }}</textarea></div>
+                                                            rows="10">{{ cm.metadata.description }}</textarea></div>
                         </div>
                         <div style="margin-top:10px">
                             <button type="button" class="btn btn-primary pull-right"


### PR DESCRIPTION
While verifying on dev, found although it works initially meaning linebreak is indeed retained after editing abstract to add linebreaks, the second time when editing the same abstract again, the additional HTML linebreak tag <br> shows in the abstract editing box. This can be further fixed by removing the Django linebreak filter being added to the abstract text displayed in the metadata editing box. This pull request includes this follow-up fix which, once merged, should fix this issue in subsequent edits to the same abstract as well. 