### PR TITLE
[#319] Fix on 'send mail to' link

### DIFF
--- a/theme/templates/accounts/profile.html
+++ b/theme/templates/accounts/profile.html
@@ -46,7 +46,11 @@
             {% endif %}
 
             {% if u.email %}
-            <li><strong>Email:</strong> <a href="mailto:{{ u.email }}">Send email to {{ u.first_name }}</a></li>
+                {% if user.pk %}
+                    <li><strong>Email:</strong> <a href="mailto:{{ u.email }}">Send email to {{ u.first_name }}</a></li>
+                {% else %}
+                    <li><strong>Email:</strong> (<a href="/accounts/login/">Log in to send email</a>)</li>
+                {% endif %}
             {% endif %}
             {% if profile.cv %}
             <li><a href="{{ profile.cv.url }}">Download a curriculum vitae</a></li>


### PR DESCRIPTION
On the user profile page, the 'send mail to' link no longer shows email to users who are not logged in.