### PR TITLE
fixed issue [#563]

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -16,7 +16,7 @@
 <link rel="alternate" type="application/atom+xml" title="Atom" href="{% url "blog_post_feed" "atom" %}">
 {% endifinstalled %}
 
-<link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 
 {% compress css %}


### PR DESCRIPTION
Sorry - the pull request I just created was wrongly against master rather than develop, so closed that one and recreating this one against develop. 

following @rayi113's suggestion with changing http to https for google api font url in base.html, I made this change on sandbox for testing. After checking following recommended security settings for my IE browser, I can reproduce this issue #563. I made sure I could see this unsecure content warning on IE before I made this change on sandbox, then after making this change, I don't see this unsecure content warning anymore on IE. So I am pretty confident this change will resolve this issue. Setting it to ready to use since it does not break anything with the only change from http to https in base.html.