### PR TITLE
fixed issue [#579]

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -2584,6 +2584,7 @@
         $(".dateinput").each(function(){
             $(this).datepicker({
                 format: 'mm-dd-yyyy',
+                yearRange: "-100:+0",
                 changeMonth: true,
                 changeYear: true
              });


### PR DESCRIPTION
Fixed issue [#579] to set temporary startdate and enddate datepicker box year range to be 100 year rather than the default 10 year range. Coverage test coverage stays the same with this change.