### PR TITLE
fixed issue [#592]

### DIFF
--- a/hs_core/forms.py
+++ b/hs_core/forms.py
@@ -1145,8 +1145,8 @@ class CoverageTemporalForm(forms.Form):
             if len(self.cleaned_data['name']) == 0:
                 del self.cleaned_data['name']
 
-        self.cleaned_data['start'] = self.cleaned_data['start'].strftime('%m/%d/%Y')
-        self.cleaned_data['end'] = self.cleaned_data['end'].strftime('%m/%d/%Y')
+        self.cleaned_data['start'] = self.cleaned_data['start'].isoformat()
+        self.cleaned_data['end'] = self.cleaned_data['end'].isoformat()
         self.cleaned_data['value'] = copy.deepcopy(self.cleaned_data)
         self.cleaned_data['type'] = 'period'
         if 'name' in self.cleaned_data:

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -2583,7 +2583,7 @@
         })
         $(".dateinput").each(function(){
             $(this).datepicker({
-                format: 'mm-dd-yyyy',
+                dateFormat: 'yy-mm-dd',
                 yearRange: "-1000:+1000",
                 changeMonth: true,
                 changeYear: true


### PR DESCRIPTION
Replaced strftime() with isoformat() as @ironfroggy suggested to fix metadata update failure when the selected year is less than 1900. As a result, the start date and end date of the temporal coverage have the string representation format of YYYY-MM-DD as specified in ISO 8601 which is returned from isoformat() as opposed to the previous format of MM/DD/YYYY. I think this should be fine. With this fix, users can select year before 1900 and successfully save changes with metadata updated successfully. 
@ironfroggy @pkdash Could you review the code and raise issues if any? 