### PR TITLE
615 irods file browser session processes

### DIFF
--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -24,6 +24,7 @@ from inplaceeditform.views import _get_http_response, _get_adaptor
 from django_irods.storage import IrodsStorage
 from hs_access_control.models import PrivilegeCodes, HSAccessException
 
+from django_irods.icommands import SessionException
 from hs_core import hydroshare
 from hs_core.hydroshare import get_resource_list
 from hs_core.hydroshare.utils import get_resource_by_shortkey, resource_modified
@@ -561,8 +562,8 @@ def create_resource(request, *args, **kwargs):
         except utils.ResourceFileSizeException as ex:
             context = {'file_size_error': ex.message}
             return render_to_response('pages/create-resource.html', context, context_instance=RequestContext(request))
-        except Exception as ex:
-            context = {'resource_creation_error': ex.message}
+        except SessionException as ex:
+            context = {'resource_creation_error': ex.stderr}
             return render_to_response('pages/create-resource.html', context, context_instance=RequestContext(request))
 
     url_key = "page_redirect_url"

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -30,6 +30,9 @@ def upload_from_irods(username, password, host, port, zone, irods_fnames, res_fi
     :param zone: iRODS login zone used to download irods data object for uploading
     :param irods_fnames: the data object file name to download to local for uploading
     :param res_files: list of files for uploading to create resources
+    :raises SessionException(proc.returncode, stdout, stderr) defined in django_irods/icommands.py
+            to capture iRODS exceptions raised from iRODS icommand subprocess run triggered from
+            any method calls from IrodsStorage() if an error or exception ever occurs
     :return: None, but the downloaded file from the iRODS will be appended to res_files list for uploading
     """
     irods_storage = IrodsStorage()

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -17,23 +17,31 @@ from hs_core.signals import pre_metadata_element_create
 from hs_core.hydroshare import file_size_limit
 from hs_core.hydroshare.utils import raise_file_size_exception
 from django_irods.storage import IrodsStorage
-from irods.exception import iRODSException
 
-# use iget to transfer selected data object from irods zone to local as a NamedTemporaryFile
+# Since an SessionException will be raised for all irods-related operations from django_irods module,
+# there is no need to raise iRODS SessionException from within this function
 def upload_from_irods(username, password, host, port, zone, irods_fnames, res_files):
-    try:
-        irods_storage = IrodsStorage()
-        irods_storage.set_user_session(username=username, password=password, host=host, port=port, zone=zone)
-        ifnames = string.split(irods_fnames, ',')
-        for ifname in ifnames:
-            size = irods_storage.size(ifname)
-            if size > file_size_limit:
-                raise_file_size_exception()
-            tmpFile = irods_storage.download(ifname)
-            fname = os.path.basename(ifname.rstrip(os.sep))
-            res_files.append(UploadedFile(file=tmpFile, name=fname, size=size))
-    except Exception as ex:
-        raise iRODSException(ex.message)
+    """
+    use iget to transfer selected data object from irods zone to local as a NamedTemporaryFile
+    :param username: iRODS login account username used to download irods data object for uploading
+    :param password: iRODS login account password used to download irods data object for uploading
+    :param host: iRODS login host used to download irods data object for uploading
+    :param port: iRODS login port used to download irods data object for uploading
+    :param zone: iRODS login zone used to download irods data object for uploading
+    :param irods_fnames: the data object file name to download to local for uploading
+    :param res_files: list of files for uploading to create resources
+    :return: None, but the downloaded file from the iRODS will be appended to res_files list for uploading
+    """
+    irods_storage = IrodsStorage()
+    irods_storage.set_user_session(username=username, password=password, host=host, port=port, zone=zone)
+    ifnames = string.split(irods_fnames, ',')
+    for ifname in ifnames:
+        size = irods_storage.size(ifname)
+        if size > file_size_limit:
+            raise_file_size_exception()
+        tmpFile = irods_storage.download(ifname)
+        fname = os.path.basename(ifname.rstrip(os.sep))
+        res_files.append(UploadedFile(file=tmpFile, name=fname, size=size))
 
 def authorize(request, res_id, edit=False, view=False, full=False, superuser=False, raises_exception=True):
     """

--- a/irods_browser_app/views.py
+++ b/irods_browser_app/views.py
@@ -64,6 +64,7 @@ def login(request):
             response_data['login_message'] = 'iRODS login failed'
             response_data['irods_file_names'] = ''
             response_data['error'] = "iRODS collection does not exist"
+            irods_sess.cleanup()
             return HttpResponse(
                 json.dumps(response_data),
                 content_type="application/json"
@@ -77,6 +78,7 @@ def login(request):
             response_data['datastore'] = datastore
             response_data['irods_loggedin'] = True
             response_data['irods_file_names'] = ''
+            irods_sess.cleanup()
             return HttpResponse(
                 json.dumps(response_data),
                 content_type = "application/json"
@@ -98,9 +100,10 @@ def store(request):
 
     return_object['files'] = store['files']
     return_object['folder'] = store['folder']
-
+    jsondump = json.dumps(return_object)
+    irods_sess.cleanup()
     return HttpResponse(
-        json.dumps(return_object),
+        jsondump,
         content_type = "application/json"
     )
 

--- a/irods_browser_app/views.py
+++ b/irods_browser_app/views.py
@@ -4,6 +4,7 @@ import string
 from django.http import HttpResponse, HttpResponseRedirect
 from irods.session import iRODSSession
 from irods.exception import CollectionDoesNotExist
+from django_irods.icommands import SessionException
 from hs_core import hydroshare
 from hs_core.views.utils import authorize, upload_from_irods
 from hs_core.hydroshare import utils
@@ -162,8 +163,8 @@ def upload_add(request):
         try:
             upload_from_irods(username=user, password=password, host=host, port=port,
                               zone=zone, irods_fnames=irods_fnames, res_files=res_files)
-        except Exception as ex:
-            request.session['file_validation_error'] = ex.message
+        except SessionException as ex:
+            request.session['file_validation_error'] = ex.stderr
             return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
     try:


### PR DESCRIPTION
Fixed the issue [#615] by always terminating iRODS session process after creating one throughout irods file browsing process and monitored the irods server during irods file browsing operations through some complex workflow and made sure there is no additional iRODS process lingering around after irods file browser login and file browsing dialogs are dismissed. Also fixed an issue with iRODS Session exceptions not properly being displayed to resource creation and resource landing pages to inform users of exception errors when there is an issue with resource creation or when adding files to existing resources. This may provide more info to large 7GB file uploading issue if the issue comes from iRODS side as well as some other iRODS-related transfer failures. 