### PR TITLE
Adding isPublic and resourceType irods metadata as outlined in [#621]

### DIFF
--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -197,10 +197,8 @@ def create_bag(resource):
     # set bag_modified-true AVU pair for on-demand bagging.to indicate the resource bag needs to be created when user clicks on download button
     istorage.setAVU(resource.short_id, "bag_modified", "true")
 
-    # set isPublic metadata AVU isPublic accordingly
     istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
 
-    # set resourceType metadata AVU resourceType accordingly
     istorage.setAVU(resource.short_id, "resourceType", resource._meta.object_name)
 
     # link the zipped bag file in IRODS via bag_url for bag downloading

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -197,6 +197,12 @@ def create_bag(resource):
     # set bag_modified-true AVU pair for on-demand bagging.to indicate the resource bag needs to be created when user clicks on download button
     istorage.setAVU(resource.short_id, "bag_modified", "true")
 
+    # set isPublic metadata AVU isPublic accordingly
+    istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
+
+    # set resourceType metadata AVU resourceType accordingly
+    istorage.setAVU(resource.short_id, "resourceType", resource._meta.object_name)
+
     # link the zipped bag file in IRODS via bag_url for bag downloading
     b = Bags.objects.create(
         content_object=resource.baseresource,

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -294,9 +294,11 @@ def change_permissions(request, shortkey, *args, **kwargs):
         frm = AddUserForm(data=request.POST)
         _share_resource_with_user(request, frm, res, user, PrivilegeCodes.OWNER)
     elif t == 'make_public':
-        _set_resource_sharing_status(request, user, res, True)
-    elif t == 'make_private':
-        _set_resource_sharing_status(request, user, res, False)
+        _set_resource_sharing_status(request, user, res, is_public=True)
+    elif t == 'make_private' or t == 'make_not_discoverable':
+        _set_resource_sharing_status(request, user, res, is_public=False)
+    elif t == 'make_discoverable':
+        _set_resource_sharing_status(request, user, res, is_public=False, is_discoverable=True)
 
     # due to self unsharing of a private resource the user will have no access to that resource
     # so need to redirect to the resource listing page
@@ -670,15 +672,25 @@ def _unshare_resource_with_users(request, requesting_user, users_to_unshare_with
     return go_to_resource_listing_page
 
 
-def _set_resource_sharing_status(request, user, resource, is_public):
+def _set_resource_sharing_status(request, user, resource, is_public, is_discoverable=False):
+    if not user.uaccess.can_change_resource_flags(resource):
+        messages.error(request, "You don't have permission to change resource sharing status")
+        return
+
     if is_public and not resource.can_be_public:
         messages.error(request, "Resource may not have sufficient required metadata to be public")
     else:
-        if user.uaccess.can_change_resource_flags(resource):
-            resource.raccess.public = is_public
-            resource.raccess.save()
-            # set isPublic metadata AVU isPublic accordingly
-            istorage = IrodsStorage()
-            istorage.setAVU(resource.short_id, "isPublic", str(is_public))
+        if is_discoverable:
+            if resource.can_be_public:
+                resource.raccess.public = False
+                resource.raccess.discoverable = True
+            else:
+                messages.error(request, "Resource may not have sufficient required metadata to be discoverable")
         else:
-            messages.error(request, "You don't have permission to change resource sharing status")
+            resource.raccess.public = is_public
+            resource.raccess.discoverable = is_public
+
+        resource.raccess.save()
+        # set isPublic metadata AVU accordingly
+        istorage = IrodsStorage()
+        istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -677,5 +677,8 @@ def _set_resource_sharing_status(request, user, resource, is_public):
         if user.uaccess.can_change_resource_flags(resource):
             resource.raccess.public = is_public
             resource.raccess.save()
+            # set isPublic metadata AVU isPublic accordingly
+            istorage = IrodsStorage()
+            istorage.setAVU(resource.short_id, "isPublic", str(is_public))
         else:
             messages.error(request, "You don't have permission to change resource sharing status")


### PR DESCRIPTION
Added resourceType and isPublic metadata to Hydroshare resources in iRODS when resource is initially created and change isPublic metadata accordingly when public/private status is changed for the resource from resource landing page. @pkdash could you review the code?