### PR TITLE
Error during using internal API for model resources

### DIFF
--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -217,7 +217,7 @@ class Variable(AbstractMetaDataElement):
 
 # Define the netCDF resource
 class NetcdfResource(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("NetcdfResource")
 
     @property
     def metadata(self):

--- a/hs_app_timeseries/models.py
+++ b/hs_app_timeseries/models.py
@@ -194,7 +194,7 @@ class TimeSeriesResult(AbstractMetaDataElement):
 #
 
 class TimeSeriesResource(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("TimeSeriesResource")
 
     class Meta:
         verbose_name = 'Time Series'

--- a/hs_geo_raster_resource/models.py
+++ b/hs_geo_raster_resource/models.py
@@ -232,7 +232,7 @@ class CellInformation(AbstractMetaDataElement):
 # To create a new resource, use these two super-classes.
 #
 class RasterResource(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("RasterResource")
 
     class Meta:
         verbose_name = 'Geographic Raster'

--- a/hs_model_program/models.py
+++ b/hs_model_program/models.py
@@ -90,7 +90,7 @@ class MpMetadata(AbstractMetaDataElement):
 
 
 class ModelProgramResource(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("ModelProgramResource")
 
     class Meta:
         verbose_name = 'Model Program Resource'

--- a/hs_modelinstance/models.py
+++ b/hs_modelinstance/models.py
@@ -95,7 +95,7 @@ class ExecutedBy(AbstractMetaDataElement):
 
 # Model Instance Resource type
 class ModelInstanceResource(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("ModelInstanceResource")
 
     class Meta:
         verbose_name = 'Model Instance Resource'

--- a/hs_rhessys_inst_resource/models.py
+++ b/hs_rhessys_inst_resource/models.py
@@ -27,7 +27,7 @@ from .forms import InputForm
 
 
 class InstResource(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("InstResource")
 
     class Meta:
         verbose_name = 'RHESSys Instance Resource'

--- a/hs_swat_modelinstance/models.py
+++ b/hs_swat_modelinstance/models.py
@@ -395,7 +395,7 @@ class ModelInput(AbstractMetaDataElement):
 
 #SWAT Model Instance Resource type
 class SWATModelInstanceResource(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("SWATModelInstanceResource")
 
     class Meta:
         verbose_name = 'SWAT Model Instance Resource'

--- a/ref_ts/models.py
+++ b/ref_ts/models.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes import generic
 
 
 class RefTimeSeries(BaseResource):
-    objects = ResourceManager()
+    objects = ResourceManager("RefTimeSeries")
 
     class Meta:
         verbose_name = "HIS Referenced Time Series"


### PR DESCRIPTION
I created a generic resource and three different model resources in my local development environment as the following figure:

![image](https://cloud.githubusercontent.com/assets/5543781/10076347/1da4ba2c-62a9-11e5-9c80-ba5a02c9a0f9.png)

After that, I tested the internal API to get the objects for each resource type with these steps:
[1] $  docker exec -ti hydroshare_hydroshare_1 python manage.py shell
[2] For Generic Resource, inside the shell I wrote the following:

     In [1]: from hs_core.models import GenericResource
     In [2]: GenericResource.objects.all()
    Out[2]: [<GenericResource: Generic resource creation>]

     The output was as expected which is the created Generic Resource: Generic resource creation.

![image](https://cloud.githubusercontent.com/assets/5543781/10076386/5424bf2a-62a9-11e5-8363-8861f84877ea.png)

[3] I did the same for the Model Instance resource (Figure below) and I got unexpected results. All the four created resource show up as Model instance resource.

![image](https://cloud.githubusercontent.com/assets/5543781/10076417/6f8efc62-62a9-11e5-8f59-65d82cea30e1.png)

[4] I did the same trial but this time for the Model Program Resource (Figure below) and also all the resources were listed as Model Program resource.

![image](https://cloud.githubusercontent.com/assets/5543781/10076436/8504a394-62a9-11e5-817a-d6c80e8b9b1f.png)
