### PR TITLE
fixed the issue with anonymous users

### DIFF
--- a/theme/templatetags/ratings_tags.py
+++ b/theme/templatetags/ratings_tags.py
@@ -20,13 +20,18 @@ def rating_for(context, obj):
     context["rated"] = (rating_string in ratings)
     rating_name = obj.get_ratingfield_name()
     rating_manager = getattr(obj, rating_name)
-    try:
-        user = context["request"].user
-        rating_instance = rating_manager.get(user=user)
-    except Rating.DoesNotExist:
+
+    user = context["request"].user
+    if not user.is_authenticated():
         context["you_rated"] = False
     else:
-        context["you_rated"] = True
+        try:
+            rating_instance = rating_manager.get(user=user)
+        except Rating.DoesNotExist:
+            context["you_rated"] = False
+        else: # rating for the requesting user exists
+            context["you_rated"] = True
+
     for f in ("average", "count", "sum"):
         context["rating_" + f] = getattr(obj, "%s_%s" % (rating_name, f))
     return context


### PR DESCRIPTION
Follow-up fix to make ratings work. Without this fix, when anonymous users click on a public resource, a TypeError is raised. This needs to be merged for release 1.6.