### PR TITLE
[#660] freeze version for coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN rm irods-runtime.deb
 RUN rm irods-icommands.deb
 
 # Install test coverage module
-RUN pip install coverage
+RUN pip install coverage==3.7.1
 
 WORKDIR /home/docker/hydroshare
 


### PR DESCRIPTION
Set version for coverage at 3.7.1 as current default is 4.0 which breaks our jenkins workflow