### PR TITLE
457 update help dev status

### DIFF
--- a/hs_core/templates/pages/help.html
+++ b/hs_core/templates/pages/help.html
@@ -66,7 +66,7 @@
                             </div>
                             <div id="faq-cat-1-sub-3" class="panel-collapse collapse">
                                 <div class="panel-body">
-                                    Hydroshare is currently in Release 1.5.2 of development.
+                                    Hydroshare is in active development. The current release is <span id="release_no"></span>.
                                 </div>
                             </div>
                         </div>
@@ -160,4 +160,15 @@
         </div>
     </div>
 
+    {% block extra_js %}
+        <script type="text/javascript">
+            $(document).ready(function () {
+                var url = 'https://api.github.com/repos/hydroshare/hydroshare/releases/latest';
+                $.get(url).done(function (data) {
+                  var version = data.tag_name;
+                  $('#release_no').html(version);
+                });
+            });
+        </script>
+    {% endblock %}
 {% endblock %}

--- a/hs_core/templates/pages/help.html
+++ b/hs_core/templates/pages/help.html
@@ -148,8 +148,7 @@
                                         <li><a href="{% url 'login' %}">Sign in</a> to HydroShare.</li>
                                         <li>Click on "Resources" in the navigation bar at the top of the page.</li>
                                         <li>Select the Title of the resource you would like to rate or comment on.</li>
-                                        <li>A new page will appear where you can Comment on a resource as well as perform various options on it. </li>
-                                        <li><strong>Currently HydroShare does not support rating resources.</strong> You may, however, rate a comment by clicking the "+1" next to the comment.</li>
+                                        <li>A new page will appear where you can comment on or rate a resource as well as perform various options on it. You may also rate a comment by clicking the "+1" next to the comment.</li>
                                     </ol>
                                 </div>
                             </div>


### PR DESCRIPTION
resolved the issue [#457] to automatically populate the current release number on hydroshare help page using github api to retrieve tag_name from latest release, so that @mjstealey does not have to manually update release number after each deploy. Also updated the section "How do I comment or rate a resource" on help page since the current content does not reflect our current implementation, specifically, we do support rating a resource now. @mjstealey @rayi113 @dtarb please review the wording change I made and give me feedback if further changes are needed. @ironfroggy @pkdash it'd be great if you can give a quick code review to raise issues if any. I am targeting this PR for release 1.6 since it can be directly leveraged, at least save a little bit of work on @mjstealey's part.