### PR TITLE
free text search for resource filtering raises AttributeError on dev 

### DIFF
--- a/hs_core/hydroshare/users.py
+++ b/hs_core/hydroshare/users.py
@@ -669,8 +669,17 @@ def get_resource_list(creator=None,
         flt = flt.filter(q)
 
         if full_text_search:
-            flt = Description.objects.filter(abstract__icontains=full_text_search).values_list('object_id', flat=True)
-            flt = Title.objects.filter(value__icontains=full_text_search).values_list('object_id', flat=True)
+            desc_ids = Description.objects.filter(abstract__icontains=full_text_search).values_list('object_id', flat=True)
+            title_ids = Title.objects.filter(value__icontains=full_text_search).values_list('object_id', flat=True)
+
+            # Full text search must match within the title or abstract
+            if desc_ids:
+                flt = flt.filter(object_id__in=desc_ids)
+            elif title_ids:
+                flt = flt.filter(object_id__in=title_ids)
+            else:
+                # No matches on title or abstract, so treat as no results of search
+                flt = flt.none()
 
     qcnt = 0
     if flt:

--- a/hs_core/hydroshare/users.py
+++ b/hs_core/hydroshare/users.py
@@ -669,7 +669,6 @@ def get_resource_list(creator=None,
         flt = flt.filter(q)
 
         if full_text_search:
-            flt = flt.search(full_text_search)
             flt = Description.objects.filter(abstract__icontains=full_text_search).values_list('object_id', flat=True)
             flt = Title.objects.filter(value__icontains=full_text_search).values_list('object_id', flat=True)
 

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -507,7 +507,7 @@ def my_resources(request, page):
         if(start+res_cnt > total_res_cnt):
             res_cnt = total_res_cnt-start
 
-        reslst = reslst[start:start+res_cnt]
+        reslst = reslst[start : start + res_cnt]
 
         # TODO sorts should be in SQL not python
         res = sorted(reslst, key=lambda x: x.title)


### PR DESCRIPTION
During migration dry-run process this morning, we found free text search for resource filtering raises AttributeError on dev, while working on www. You can reproduce this issue by typing in "error" into resource filter search box which produce 0 resources as expected on www, but generates Attribute Error on dev. Stack trace is copied below for reference:

```
Environment:


Request Method: GET
Request URL: https://dev.hydroshare.org/my-resources/?&text=rhye

Django Version: 1.7.8
Python Version: 2.7.6
Installed Applications:
(u'mezzanine.boot',
 u'django.contrib.auth',
 u'django.contrib.contenttypes',
 u'django.contrib.redirects',
 u'django.contrib.sessions',
 u'django.contrib.sites',
 u'django.contrib.sitemaps',
 u'django.contrib.gis',
 u'inplaceeditform',
 u'django_nose',
 u'django_irods',
 u'theme',
 u'theme.blog_mods',
 u'mezzanine.conf',
 u'mezzanine.core',
 u'mezzanine.generic',
 u'mezzanine.blog',
 u'mezzanine.forms',
 u'mezzanine.pages',
 u'mezzanine.galleries',
 u'crispy_forms',
 u'mezzanine.accounts',
 u'mezzanine.mobile',
 u'autocomplete_light',
 u'jquery_ui',
 u'rest_framework',
 u'ga_ows',
 u'ga_resources',
 u'hs_core',
 u'hs_access_control',
 u'hs_metrics',
 u'irods_browser_app',
 u'django_docker_processes',
 u'hs_geo_raster_resource',
 u'djcelery',
 u'ref_ts',
 u'hs_app_timeseries',
 u'widget_tweaks',
 u'hs_app_netCDF',
 u'hs_model_program',
 u'hs_modelinstance',
 u'hs_tools_resource',
 u'hs_swat_modelinstance',
 u'debug_toolbar',
 u'django_extensions',
 u'filebrowser_safe',
 u'grappelli_safe',
 u'django.contrib.admin',
 u'django.contrib.staticfiles',
 u'django.contrib.comments')
Installed Middleware:
(u'django.contrib.sessions.middleware.SessionMiddleware',
 u'django.middleware.locale.LocaleMiddleware',
 u'django.contrib.auth.middleware.AuthenticationMiddleware',
 u'django.middleware.common.CommonMiddleware',
 u'django.middleware.csrf.CsrfViewMiddleware',
 u'django.contrib.messages.middleware.MessageMiddleware',
 u'mezzanine.core.request.CurrentRequestMiddleware',
 u'mezzanine.core.middleware.RedirectFallbackMiddleware',
 u'mezzanine.core.middleware.TemplateForDeviceMiddleware',
 u'mezzanine.core.middleware.TemplateForHostMiddleware',
 u'mezzanine.core.middleware.AdminLoginInterfaceSelectorMiddleware',
 u'mezzanine.core.middleware.SitePermissionMiddleware',
 u'mezzanine.pages.middleware.PageMiddleware',
 u'ga_resources.middleware.PagePermissionsViewableMiddleware',
 u'debug_toolbar.middleware.DebugToolbarMiddleware')


Traceback:
File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py" in get_response
  104.                     response = middleware_method(request, callback, callback_args, callback_kwargs)
File "/usr/local/lib/python2.7/dist-packages/mezzanine/pages/middleware.py" in process_view
  115.             processor_response = processor(request, page)
File "./hs_core/views/__init__.py" in my_resources
  496.             **search_items
File "./hs_core/hydroshare/users.py" in get_resource_list
  674.             flt = flt.search(full_text_search)

Exception Type: AttributeError at /my-resources/
Exception Value: 'QuerySet' object has no attribute 'search'
```