### PR TITLE
[#676] nginx maintenance page

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -30,6 +30,8 @@ display_usage() {
 	echo "*** HydroShare Control script ***"
 	echo "usage: $0 deploy      # deletes all database and container contents and deploys from scratch"
 	echo "usage: $0 loaddb      # loads database specified in hydroshare-config.yaml into running container"
+	echo "usage: $0 maint_off   # removes maintenance page (only if USE_NGINX = true)"
+	echo "usage: $0 maint_on    # displays maintenance page (only if USE_NGINX = true)"
 	echo "usage: $0 rebuild     # deletes hydroshare container contents only and deploys using exsiting database"
 	echo "usage: $0 restart     # restarts the hydroshare container without rebuilding"
 	echo "usage: $0 start       # attempts to start all containers"
@@ -58,6 +60,26 @@ restart_hs() {
     docker start hydroshare_hydroshare_1
     if [ "${USE_NGINX,,}" = true ]; then
         start_nginx
+    fi
+}
+
+maint_on_hs() {
+    if [ "${USE_NGINX,,}" = true ]; then
+        cd $NGINX_DIR
+        ./run-nginx maint_on
+        cd -
+    else
+        echo "*** Unable to apply: USE_NGINX = ${USE_NGINX} ***"
+    fi
+}
+
+maint_off_hs() {
+    if [ "${USE_NGINX,,}" = true ]; then
+        cd $NGINX_DIR
+        ./run-nginx maint_off
+        cd -
+    else
+        echo "*** Unable to apply: USE_NGINX = ${USE_NGINX} ***"
     fi
 }
 
@@ -235,6 +257,10 @@ case "$1" in
     deploy) deploy_hs $1
         ;;
     loaddb) loaddb_hs $1
+        ;;
+    maint_off) maint_off_hs $1
+        ;;
+    maint_on) maint_on_hs $1
         ;;
     rebuild) rebuild_hs $1
         ;;

--- a/nginx/config-files/hydroshare-nginx.conf
+++ b/nginx/config-files/hydroshare-nginx.conf
@@ -1,26 +1,35 @@
-# hydroshare-nginx.conf
+# hydroshare-nginx.conf                                                         
 
 upstream app_server {
-    server hydroshare:8001;
+   server hydroshare:8001;
 }
 
 server {
-    listen          80;
-    server_name     FQDN_OR_IP;
-    charset         utf-8;
+   listen          80;
+   server_name     FQDN_OR_IP;
+   charset         utf-8;
+   root            /home/docker/hydroshare/hydroshare/static/;
 
-    client_max_body_size 0;
+   client_max_body_size 0;
 
-    location /static/ {
-        alias /home/docker/hydroshare/hydroshare/static/;
-    }
+   location /static/ {
+       alias /home/docker/hydroshare/hydroshare/static/;
+   }
 
-    location /media/ {
-        alias /home/docker/hydroshare/hydroshare/static/media/;
-    }
+   location /media/ {
+       alias /home/docker/hydroshare/hydroshare/static/media/;
+   }
 
-    location / {
-        uwsgi_pass  app_server;
-        include     /home/docker/hydroshare/uwsgi_params;
-    }
+   location / {
+       if (-f $document_root/maintenance_on.html) {
+          return 503;
+       }
+       uwsgi_pass  app_server;
+       include     /home/docker/hydroshare/uwsgi_params;
+   }
+
+   error_page 503 @maintenance;
+   location @maintenance {
+            rewrite ^(.*)$ /maintenance_on.html break;
+   }
 }

--- a/nginx/config-files/hydroshare-ssl-nginx.conf
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf
@@ -15,6 +15,7 @@ server {
     server_name     FQDN_OR_IP;
     access_log      /var/log/nginx/hydroshare_access.log combined;
     error_log       /var/log/nginx/hydroshare_error.log error;
+    root            /home/docker/hydroshare/hydroshare/static/;
 
     charset         utf-8;
 
@@ -32,7 +33,16 @@ server {
     }
 
     location / {
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
         uwsgi_pass  app_server;
         include     /home/docker/hydroshare/uwsgi_params;
     }
+
+    error_page 503 @maintenance;
+    location @maintenance {
+            rewrite ^(.*)$ /maintenance_on.html break;
+    }
+
 }

--- a/nginx/maintenance_on.html
+++ b/nginx/maintenance_on.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding: 150px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<article>
+    <h1>We&rsquo;ll be back soon!</h1>
+    <div>
+        <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment. If you need to you can always <a href="mailto:support@hydroshare.org">contact us</a>, otherwise we&rsquo;ll be back online shortly!</p>
+        <p>&mdash; The HydroShare Team</p>
+    </div>
+</article>

--- a/nginx/run-nginx
+++ b/nginx/run-nginx
@@ -12,6 +12,8 @@ NGINX_DOCKER_CNTR='web-nginx'
 
 display_usage() {
 	echo "*** run-nginx control script ***"
+	echo "usage: $0 maint_off   # removes maintenance page"
+	echo "usage: $0 maint_on    # displays maintenance page"
 	echo "usage: $0 restart     # restarts docker nginx"
 	echo "usage: $0 start       # starts docker nginx"
 	echo "usage: $0 stop        # stops docker nginx"
@@ -87,6 +89,16 @@ restart_nginx() {
     start_nginx START
 }
 
+maint_on_nginx() {
+    echo "*** ${1^^} ***"
+    cp maintenance_on.html ../hydroshare/static/maintenance_on.html
+}
+
+maint_off_nginx() {
+    echo "*** ${1^^} ***"
+    rm ../hydroshare/static/maintenance_on.html
+}
+
 ### Display usage if exactly one argument is not provided ###
 if [  $# -ne 1 ]
 then
@@ -100,6 +112,10 @@ case "$1" in
     start) start_nginx $1
         ;;
     stop) stop_nginx $1
+        ;;
+    maint_on) maint_on_nginx $1
+        ;;
+    maint_off) maint_off_nginx $1
         ;;
     *) display_usage
         ;;


### PR DESCRIPTION
Add nginx maintenance page that is displayed based on the existence of a **maintenance_on.html** file in the `hydroshare/static/` directory.

Two new command in the **hsctl** script.

```bash
$ ./hsctl --help
*** HydroShare Control script ***
usage: ./hsctl deploy      # deletes all database and container contents and deploys from scratch
usage: ./hsctl loaddb      # loads database specified in hydroshare-config.yaml into running container
usage: ./hsctl maint_off   # removes maintenance page (only if USE_NGINX = true)
usage: ./hsctl maint_on    # displays maintenance page (only if USE_NGINX = true)
usage: ./hsctl rebuild     # deletes hydroshare container contents only and deploys using exsiting database
usage: ./hsctl restart     # restarts the hydroshare container without rebuilding
usage: ./hsctl start       # attempts to start all containers
usage: ./hsctl stop        # stops all running containers
```

Maintenance page will look like:
<img width="1005" alt="screen shot 2015-10-16 at 4 17 03 pm" src="https://cloud.githubusercontent.com/assets/5332509/10552354/61a50d10-7421-11e5-830a-6f355119f7a2.png">

contact us is set to **support@hydroshare.org**
