### PR TITLE
[WIP] Add OAuth to REST API

### DIFF
--- a/hs_core/urls.py
+++ b/hs_core/urls.py
@@ -31,6 +31,9 @@ urlpatterns = patterns('',
     url(r'^resource/(?P<pk>[A-z0-9]+)/files/(?P<filename>[^/]+)/$',
         views.resource_rest_api.ResourceFileCRUD.as_view(), name='get_update_delete_resource_file'),
 
+    url(r'^userInfo/$',
+        views.user_rest_api.UserInfo.as_view(), name='get_logged_in_user_info'),
+
     # internal API
 
     url(r'^_internal/(?P<shortkey>[A-z0-9]+)/add-file-to-resource/$', views.add_file_to_resource),

--- a/hs_core/views/user_rest_api.py
+++ b/hs_core/views/user_rest_api.py
@@ -1,10 +1,16 @@
-__author__ = 'Pabitra'
-
-from django.contrib.auth import authenticate
-from rest_framework.decorators import api_view
+from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework import status
-from rest_framework.exceptions import *
-import serializers
-from hs_core.views import utils
+
+
+class UserInfo(APIView):
+    def get(self, request):
+        import logging
+        logger = logging.getLogger('django')
+        logger.debug(str(request.user))
+
+        user_info = {"username": request.user.username}
+        if request.user.email:
+            user_info['email'] = request.user.email
+
+        return Response(user_info)
 

--- a/hs_core/views/user_rest_api.py
+++ b/hs_core/views/user_rest_api.py
@@ -4,10 +4,6 @@ from rest_framework.response import Response
 
 class UserInfo(APIView):
     def get(self, request):
-        import logging
-        logger = logging.getLogger('django')
-        logger.debug(str(request.user))
-
         user_info = {"username": request.user.username}
         if request.user.email:
             user_info['email'] = request.user.email

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -454,6 +454,10 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
     )
 }
 
@@ -497,6 +501,11 @@ LOGGING = {
             'handlers':['syslog', 'djangolog'],
             'propagate': True,
             'level':'DEBUG',
+        },
+        'django.db.backends': {
+            'handlers': ['syslog'],
+            'level': 'DEBUG',
+            'propagate': False,
         },
     }
 }


### PR DESCRIPTION
Enable OAuth2 support for REST API.  Also adds GET /hsapi/userInfo/ end point for use by HydroShare OAuth clients.