### PR TITLE
require content files for resource to be public or discoverable

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -705,9 +705,10 @@ def delete_resource_file(pk, filename_or_id, user):
     else:
         raise ObjectDoesNotExist(filename_or_id)
 
-    if resource.raccess.public:
+    if resource.raccess.public or resource.raccess.discoverable:
         if not resource.can_be_public:
             resource.raccess.public = False
+            resource.raccess.discoverable = False
             resource.raccess.save()
 
     # generate bag

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -706,7 +706,7 @@ def delete_resource_file(pk, filename_or_id, user):
         raise ObjectDoesNotExist(filename_or_id)
 
     if resource.raccess.public or resource.raccess.discoverable:
-        if not resource.can_be_public:
+        if not resource.can_be_public_or_discoverable:
             resource.raccess.public = False
             resource.raccess.discoverable = False
             resource.raccess.save()

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1536,7 +1536,7 @@ class AbstractResource(ResourcePermissionsMixin):
         return citation
 
     @property
-    def can_be_public(self):
+    def can_be_public_or_discoverable(self):
         if self.metadata.has_all_required_elements() and self.has_required_content_files():
             return True
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1537,7 +1537,7 @@ class AbstractResource(ResourcePermissionsMixin):
 
     @property
     def can_be_public(self):
-        if self.metadata.has_all_required_elements():
+        if self.metadata.has_all_required_elements() and self.has_required_content_files():
             return True
 
         return False
@@ -1551,7 +1551,6 @@ class AbstractResource(ResourcePermissionsMixin):
         # by default all file types are supported
         return (".*",)
 
-
     @classmethod
     def can_have_multiple_files(cls):
         # NOTES FOR ANY SUBCLASS OF THIS CLASS TO OVERRIDE THIS FUNCTION:
@@ -1560,6 +1559,16 @@ class AbstractResource(ResourcePermissionsMixin):
         # resource by default can have multiple files
         return True
 
+    def has_required_content_files(self):
+        # Any subclass of this class may need to override this function
+        # to apply specific requirements as it relates to resource content files
+        if len(self.get_supported_upload_file_types()) > 0:
+            if self.files.all().count() > 0:
+                return True
+            else:
+                return False
+        else:
+            return True
 
     class Meta:
         abstract = True

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -25,25 +25,31 @@
 
         {# ======= Missing fields notification =======#}
         {% if not metadata_form and page.perms.change %}
-            {% if missing_metadata_elements or title|stringformat:"s" == "Untitled resource" %}
+            {% if missing_metadata_elements or title|stringformat:"s" == "Untitled resource" or not cm.has_required_content_files %}
                 <div class="col-sm-12">
                     <div class="alert {% if just_created %}alert-success{% else %}alert-warning{% endif %} alert-dismissible" role="alert">
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span
                                 aria-hidden="true">&times;</span></button>
-                        {% if just_created %}
-                            <strong>Congratulations! </strong>
-                            <span>Now that your resource has been created the following metadata are still required to make it public or discoverable:</span>
-                        {% else %}
-                            <span>The following metadata are still required to make the resource public or discoverable:</span>
-                        {% endif %}
-                        <ul>
-                            {% for element in missing_metadata_elements %}
-                                <li>{{ element }}</li>
-                            {% endfor %}
-                            {% if title|stringformat:"s" == "Untitled resource" %}
-                               <li>Title: needs to be changed</li>
+                        {% if missing_metadata_elements  %}
+                            {% if just_created %}
+                                <strong>Congratulations! </strong>
+                                <span>Now that your resource has been created the following metadata are still required to make it public or discoverable:</span>
+                            {% else %}
+                                <span>The following metadata are still required to make the resource public or discoverable:</span>
                             {% endif %}
-                        </ul>
+                            <ul>
+                                {% for element in missing_metadata_elements %}
+                                    <li>{{ element }}</li>
+                                {% endfor %}
+                                {% if title|stringformat:"s" == "Untitled resource" %}
+                                   <li>Title: needs to be changed</li>
+                                {% endif %}
+                            </ul>
+                        {%  endif %}
+                        {%  if not cm.has_required_content_files %}
+                                <br>
+                                <span>Content file(s) is missing. Content file(s) is required to make the resource public.</span>
+                        {% endif %}
                         <hr>
                         <span class="glyphicon glyphicon-question-sign"></span>
                         <small> Click on the edit button ( <span class="glyphicon glyphicon-pencil"></span> ) below to edit this resource.</small>
@@ -382,7 +388,7 @@
                                   method="POST">
                                 {% csrf_token %}
                                 <input name="t" type="hidden" value="make_public"/>
-                                <button {% if metadata_status == 'Insufficient to make public' %} disabled {% endif %}
+                                <button {% if not cm.can_be_public %} disabled {% endif %}
                                         id="btn-public" data-toggle="tooltip" data-placement="auto"
                                         title='Can be viewed and downloaded by anyone.' type="submit"
                                         class="btn btn-default">Public

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -48,7 +48,7 @@
                         {%  endif %}
                         {%  if not cm.has_required_content_files %}
                                 <br>
-                                <span>Content file(s) is missing. Content file(s) is required to make the resource public or discoverable.</span>
+                                <span>Content files are required to make the resource public or discoverable.</span>
                         {% endif %}
                         <hr>
                         <span class="glyphicon glyphicon-question-sign"></span>
@@ -388,7 +388,7 @@
                                   method="POST">
                                 {% csrf_token %}
                                 <input name="t" type="hidden" value="make_public"/>
-                                <button {% if not cm.can_be_public %} disabled {% endif %}
+                                <button {% if not cm.can_be_public_or_discoverable %} disabled {% endif %}
                                         id="btn-public" data-toggle="tooltip" data-placement="auto"
                                         title='Can be viewed and downloaded by anyone.' type="submit"
                                         class="btn btn-default">Public
@@ -408,7 +408,7 @@
                                   method="POST">
                                 <input name="t" type="hidden" value="make_discoverable"/>
                                 {% csrf_token %}
-                                <button {% if not cm.can_be_public %} disabled {% endif %}
+                                <button {% if not cm.can_be_public_or_discoverable %} disabled {% endif %}
                                         id="btn-discoverable" data-toggle="tooltip" data-placement="auto"
                                         title='Metadata is public but data is protected.' type="submit"
                                         class="btn btn-default">Discoverable

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -48,7 +48,7 @@
                         {%  endif %}
                         {%  if not cm.has_required_content_files %}
                                 <br>
-                                <span>Content file(s) is missing. Content file(s) is required to make the resource public.</span>
+                                <span>Content file(s) is missing. Content file(s) is required to make the resource public or discoverable.</span>
                         {% endif %}
                         <hr>
                         <span class="glyphicon glyphicon-question-sign"></span>
@@ -408,7 +408,7 @@
                                   method="POST">
                                 <input name="t" type="hidden" value="make_discoverable"/>
                                 {% csrf_token %}
-                                <button {% if metadata_status == 'Insufficient to make public' %} disabled {% endif %}
+                                <button {% if not cm.can_be_public %} disabled {% endif %}
                                         id="btn-discoverable" data-toggle="tooltip" data-placement="auto"
                                         title='Metadata is public but data is protected.' type="submit"
                                         class="btn btn-default">Discoverable

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -190,7 +190,7 @@ def update_metadata_element(request, shortkey, element_name, element_id, *args, 
                     res.title = res.metadata.title.value
                     res.save()
                     if res.raccess.public:
-                        if not res.can_be_public:
+                        if not res.can_be_public_or_discoverable:
                             res.raccess.public = False
                             res.raccess.save()
 
@@ -680,15 +680,24 @@ def _set_resource_sharing_status(request, user, resource, is_public, is_discover
         messages.error(request, "You don't have permission to change resource sharing status")
         return
 
-    if is_public and not resource.can_be_public:
-        messages.error(request, _get_message_for_setting_resource_flag(resource, resource_flag='public'))
+    has_files = False
+    has_metadata = False
+    can_resource_be_public_or_discoverable = False
+    if is_public or is_discoverable:
+        has_files = resource.has_required_content_files()
+        has_metadata = resource.metadata.has_all_required_elements()
+        can_resource_be_public_or_discoverable = has_files and has_metadata
+
+    if is_public and not can_resource_be_public_or_discoverable:
+        messages.error(request, _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag='public'))
     else:
         if is_discoverable:
-            if resource.can_be_public:
+            if can_resource_be_public_or_discoverable:
                 resource.raccess.public = False
                 resource.raccess.discoverable = True
             else:
-                messages.error(request, _get_message_for_setting_resource_flag(resource, resource_flag='discoverable'))
+                messages.error(request, _get_message_for_setting_resource_flag(has_files, has_metadata,
+                                                                               resource_flag='discoverable'))
         else:
             resource.raccess.public = is_public
             resource.raccess.discoverable = is_public
@@ -699,16 +708,14 @@ def _set_resource_sharing_status(request, user, resource, is_public, is_discover
         istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
 
 
-def _get_message_for_setting_resource_flag(resource, resource_flag):
-    has_files = resource.has_required_content_files()
-    has_metadata = resource.metadata.has_all_required_elements()
+def _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag):
     msg = ''
     if not has_metadata and not has_files:
-        msg = "Resource may not have sufficient required metadata and/or content files to be {flag}".format(
+        msg = "Resource does not have sufficient required metadata and content files to be {flag}".format(
               flag=resource_flag)
     elif not has_metadata:
-        msg = "Resource may not have sufficient required metadata to be {flag}".format(flag=resource_flag)
+        msg = "Resource does not have sufficient required metadata to be {flag}".format(flag=resource_flag)
     elif not has_files:
-        msg = "Resource may not have required content files to be {flag}".format(flag=resource_flag)
+        msg = "Resource does not have required content files to be {flag}".format(flag=resource_flag)
 
     return msg


### PR DESCRIPTION
In addition to required metadata elements, non-reference resource types must have content file(s) before such resource can be made public or discoverable.