### PR TITLE
used relative recaptcha url

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -137,15 +137,11 @@ preflight_hs() {
             yes | cp -rf ${SSL_CERT_DIR}/${SSL_KEY_FILE} ${HOST_SSL_DIR};
         else
             echo "*** Not using SSL: USE_SSL = ${USE_SSL} ***"
-            # use http version of recaptcha
-            sed -i 's!'${HTTPS_RECAPTCHA}'!'${HTTP_RECAPTCHA}'!g' ${HS_PATH}/theme/templates/accounts/_signup_form.html;
         fi
         # use production server to run HydroShare
         sed -i 's/'"${DEV_SERVER}"'/'"${PROD_SERVER}"'/g' ${HS_PATH}/init;
     else
         echo "*** Not using nginx: USE_NGINX = ${USE_NGINX} ***"
-        # use http version of recaptcha
-        sed -i 's!'${HTTPS_RECAPTCHA}'!'${HTTP_RECAPTCHA}'!g' ${HS_PATH}/theme/templates/accounts/_signup_form.html
         # use development server to run HydroShare
         sed -i 's/'"${PROD_SERVER}"'/'"${DEV_SERVER}"'/g' ${HS_PATH}/init;
     fi

--- a/theme/templates/accounts/_signup_form.html
+++ b/theme/templates/accounts/_signup_form.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="http://www.google.com/recaptcha/api/js/recaptcha_ajax.js"></script>
+<script type="text/javascript" src="//www.google.com/recaptcha/api/js/recaptcha_ajax.js"></script>
 <script type="text/javascript">
     $(function() {
         function cb() {


### PR DESCRIPTION
Have consulted @ironfroggy and made changes accordingly to avoid post-processing need for handling http vs https on recaptcha URLs. Tested on both local dev env and the dev.hydroshare.org VM and make sure relative URL works well in both environments. @ironfroggy Please give a quick review so that I can merge it in to get it ready for official release 1.6.2 deployment today.