### PR TITLE
716 access control permission fix

### DIFF
--- a/hs_access_control/models.py
+++ b/hs_access_control/models.py
@@ -1477,14 +1477,14 @@ class UserAccess(models.Model):
             raise HSAccessException("User has insufficient privilege over resource")
 
         # non owner can't downgrade privilege granted by someone else
-        # grantee_priv: current privilege of the grantee
-        # this_privilege: proposed privilege for the grantee
+        # grantee_priv: current privilege of the grantee (this_user)
+        # this_privilege: proposed privilege for the grantee (this_user)
         if whom_priv != PrivilegeCodes.OWNER and grantee_priv < this_privilege:
             record = UserResourcePrivilege.objects.get(resource=access_resource,
                                                        user=access_user,
                                                        privilege=grantee_priv)
 
-            # current granter is not the same as the original granter
+            # current grantor (self) is not the same as the original grantor
             if record.grantor != self:
                 raise HSAccessException("User has insufficient privilege over resource")
 
@@ -1511,7 +1511,7 @@ class UserAccess(models.Model):
                                   privilege=this_privilege,
                                   grantor=self).save()
 
-        # if there exists higher privilege granted by someone else then those needs to be deleted
+        # if there exists higher privileges than what was granted now (this_privilege) then those needs to be deleted
         UserResourcePrivilege.objects.filter(resource=access_resource, user=access_user,
                                              privilege__lt=this_privilege).all().delete()
 

--- a/hs_access_control/models.py
+++ b/hs_access_control/models.py
@@ -1447,6 +1447,9 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise HSAccessException("Requester is not an active user")
 
+        if not this_user.is_active:
+            raise HSAccessException("Grantee is not an active user")
+
         # access control logic: Can change privilege if
         #   Admin
         #   Self-set permission

--- a/hs_access_control/tests/test_access_control.py
+++ b/hs_access_control/tests/test_access_control.py
@@ -178,13 +178,13 @@ class BasicFunction(MockIRODSTestCaseMixin, TestCase):
         self.george.uaccess.unshare_group_with_user(self.bikers, self.alva)
 
         ## test upgrade privilege by non owners
-        # grant change privilege to non owner alva
+        # let george (owner) grant change privilege to alva (non owner)
         self.george.uaccess.share_resource_with_user(self.bikes, self.alva, PrivilegeCodes.CHANGE)
         self.assertTrue(self.bikes.raccess.get_combined_privilege(self.alva) == PrivilegeCodes.CHANGE)
-        # let non owner alva grant view privilege to john (on owner)
+        # let alva (non owner) grant view privilege to john (non owner)
         self.alva.uaccess.share_resource_with_user(self.bikes, self.john, PrivilegeCodes.VIEW)
         self.assertTrue(self.bikes.raccess.get_combined_privilege(self.john) == PrivilegeCodes.VIEW)
-        # let alva grant change privilege (upgrade) to john
+        # let alva (non owner) grant change privilege (upgrade) to john (non owner)
         self.alva.uaccess.share_resource_with_user(self.bikes, self.john, PrivilegeCodes.CHANGE)
         self.assertTrue(self.bikes.raccess.get_combined_privilege(self.john) == PrivilegeCodes.CHANGE)
 
@@ -976,13 +976,11 @@ class T05ShareResource(MockIRODSTestCaseMixin, TestCase):
         self.mouse = hydroshare.create_account(
             'mouse@gmail.com',
             username='mouse',
-            first_name='fisrt_name_mouse',
+            first_name='first_name_mouse',
             last_name='last_name_mouse',
             superuser=False,
             groups=[]
         )
-
-
         self.holes = hydroshare.create_resource(resource_type='GenericResource',
                                                 owner=self.cat,
                                                 title='all about dog holes',


### PR DESCRIPTION
With these changes:

1. Resource non-owners can't downgrade privilege originally granted by someone else.
2. Most recent granted privilege for a resource for a given user always becomes the highest privilege for that user for that resource.
3. Inactive users can't be granted resource access permission.