### PR TITLE
752 Make resource type returned by /hsapi/resourceList reflect the actual type

### DIFF
--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -27,7 +27,7 @@ class ResourceToListItemMixin(object):
         resource_list_item = serializers.ResourceListItem(resource_type=r.resource_type,
                                                           resource_id=r.short_id,
                                                           resource_title=r.metadata.title.value,
-                                                          creator=r.creator.username,
+                                                          creator=r.first_creator.name,
                                                           public=r.raccess.public,
                                                           discoverable=r.raccess.discoverable,
                                                           shareable=r.raccess.shareable,

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -24,7 +24,7 @@ class ResourceToListItemMixin(object):
     def resourceToResourceListItem(self, r):
         bag_url = hydroshare.utils.current_site_url() + AbstractResource.bag_url(r.short_id)
         science_metadata_url = hydroshare.utils.current_site_url() + reverse('get_update_science_metadata', args=[r.short_id])
-        resource_list_item = serializers.ResourceListItem(resource_type=r.__class__.__name__,
+        resource_list_item = serializers.ResourceListItem(resource_type=r.resource_type,
                                                           resource_id=r.short_id,
                                                           resource_title=r.metadata.title.value,
                                                           creator=r.creator.username,


### PR DESCRIPTION
@yirugi Here is the PR for #752.  Thanks for bringing this to my attention.