### PR TITLE
[#790] force blank line after final variable definition

### DIFF
--- a/config/hydroshare-config.template
+++ b/config/hydroshare-config.template
@@ -16,3 +16,5 @@ NGINX_DIR: /home/hydro/hydroshare/nginx
 SSL_CERT_DIR: /home/hydro/hydroshare/nginx/cert-files
 SSL_CERT_FILE: hydrodev-vb.example.org.cert
 SSL_KEY_FILE: hydrodev-vb.example.org.key
+
+### REQUIRES BLANK LINE AFTER LAST VARIABLE DEFINITION ###

--- a/config/hydroshare-config.yaml
+++ b/config/hydroshare-config.yaml
@@ -16,3 +16,5 @@ NGINX_DIR: /home/hydro/hydroshare/nginx
 SSL_CERT_DIR: /home/hydro/hydroshare/nginx/cert-files
 SSL_CERT_FILE: hydrodev-vb.example.org.cert
 SSL_KEY_FILE: hydrodev-vb.example.org.key
+
+### REQUIRES BLANK LINE AFTER LAST VARIABLE DEFINITION ###


### PR DESCRIPTION
Without a blank line the last variable defined is never passed into the environment. In the case of USE_SSL = true it will cause the nginx container to fail with an SSL error as the required key file never gets defined.