### PR TITLE
Check discovery not showing resources

### DIFF
--- a/hs_core/templates/search/search.html
+++ b/hs_core/templates/search/search.html
@@ -102,7 +102,7 @@
                     {% endfor %}
                 </form>
             </div>
-            <table class="table table-striped table-hover" id="item-discovered">
+            <table class="table table-striped table-hover" id="items-discovered">
                 <tr>
                     <th>Title</th>
                     <th>Type</th>

--- a/hs_core/templates/search/search.html
+++ b/hs_core/templates/search/search.html
@@ -102,7 +102,7 @@
                     {% endfor %}
                 </form>
             </div>
-            <table class="table table-striped table-hover" id="item-selectors">
+            <table class="table table-striped table-hover" id="item-discovered">
                 <tr>
                     <th>Title</th>
                     <th>Type</th>


### PR DESCRIPTION
Fixed the discovery page not showing search resources issue. The issue is caused by the result table id conflicts. my-resource.html page's result table has the same id as the result table in search.html. The js for my-resource table conflicts results table in discovery search.html