### PR TITLE
[#823] remove http:// from curl statments

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -188,7 +188,7 @@ rebuild_nodb_hs() {
     sleep 2s
     rebuild_solr_index
     sleep 2s
-    docker exec $CID curl "http://solr:8983/solr/admin/cores?action=RELOAD&core=collection1"
+    docker exec $CID curl "solr:8983/solr/admin/cores?action=RELOAD&core=collection1"
     sleep 2s
     rebuild_solr_index
     if [ "${USE_NGINX,,}" = true ]; then
@@ -221,7 +221,7 @@ loaddb_hs() {
     sleep 2s
     rebuild_solr_index
     sleep 2s
-    docker exec $CID curl "http://solr:8983/solr/admin/cores?action=RELOAD&core=collection1"
+    docker exec $CID curl "solr:8983/solr/admin/cores?action=RELOAD&core=collection1"
     sleep 2s
     rebuild_solr_index
 }


### PR DESCRIPTION
Don't pre-designate http or https in curl statements in hsctl