### PR TITLE
[#606] default to console for the email backend

### DIFF
--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -126,17 +126,11 @@ IRODS_BAGIT_RULE='hydroshare/irods/ruleGenerateBagIt_HS.r'
 IRODS_BAGIT_PATH = 'bags'
 IRODS_BAGIT_POSTFIX = 'zip'
 
-# Email configuration - localhost
-# Run from second terminal: python -m smtpd -n -c DebuggingServer localhost:1025
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'localhost'
-EMAIL_PORT = 1025
-
-# Email configuration - gmail - reference: https://github.com/hydroshare/hydroshare/wiki/hydroshare_email_using_gmail
-# EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-# EMAIL_HOST_USER = 'YOUR_GMAIL_ACCOUNT@gmail.com'
-# EMAIL_HOST_PASSWORD = 'APP_SPECIFIC_PASSWORD'
-# EMAIL_HOST = 'smtp.gmail.com'
-# EMAIL_PORT = 587
-# EMAIL_USE_TLS = True
-# DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+# Email configuration
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+#EMAIL_HOST_USER = ''
+#EMAIL_HOST_PASSWORD = ''
+#EMAIL_HOST = ''
+#EMAIL_PORT = ''
+#EMAIL_USE_TLS = True
+#DEFAULT_FROM_EMAIL = ''


### PR DESCRIPTION
Update to **local_settings.py** to default to console as email backend.

Since Django is running in a daemonized docker container the user will need to attach back to the container to see the output.

Example:

```bash
$ docker attach hydroshare_hydroshare_1
...
```
Fill out new user info in your local development browser and click join
```bash
...
Content-Type: multipart/alternative;
 boundary="===============1573799015647134470=="
MIME-Version: 1.0
Subject: Activate your account in HydroShare
From: webmaster@localhost
To: mjstealey@gmail.com
Date: Mon, 04 Jan 2016 19:58:40 -0000
Message-ID: <20160104195840.40.17919@26223243c15c>

--===============1573799015647134470==
MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: 7bit



Welcome to HydroShare. This email address was used to request an account on www.hydroshare.org.
If you originated the request, please use the link below to verify your email address and activate your account.
http://192.168.56.101:8000/accounts/verify/2/489-94521b86ec6110b4fb48/?next=/
If you did not originate this request you may ignore this email.
The HydroShare Team


--===============1573799015647134470==
MIME-Version: 1.0
Content-Type: text/html; charset="utf-8"
Content-Transfer-Encoding: 7bit



<p>Welcome to HydroShare. This email address was used to request an account on www.hydroshare.org.</p>
<p>If you originated the request, please use the link below to verify your email address and activate your account.</p>
<p><a href="http://192.168.56.101:8000/accounts/verify/2/489-94521b86ec6110b4fb48/?next=/">http://192.168.56.101:8000/accounts/verify/2/489-94521b86ec6110b4fb48/?next=/</a></p>
<p>If you did not originate this request you may ignore this email.</p>
<p>The HydroShare Team</p>


--===============1573799015647134470==--

-------------------------------------------------------------------------------
```