### PR TITLE
913 Hotfix - google map api not running

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -3524,8 +3524,9 @@
 
             });
         </script>
+        <script async defer src="https://maps.googleapis.com/maps/api/js?libraries=drawing&callback=initMap"></script>
     {% endblock %}
-    <script async defer src="https://maps.googleapis.com/maps/api/js?libraries=drawing&callback=initMap"></script>
+
 
     {% block extra_css %}
         {{ block.super }}


### PR DESCRIPTION
As described in #913. This makes the google map api work again for the coverage tab in the resource landing page.