### PR TITLE
web app names shorted with ellipses; tooltip added

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -68,10 +68,14 @@
                         <span class="caret"></span></button>
                     <ul class="dropdown-menu">
                         {% for tool in relevant_tools %}
-                            <li>
+                            <li title="{{ tool.title }}">
                                 <a href="{{ tool.url }}" target="_blank">
                                     <img class="dropdown-user-webapp-icon" src="{{ tool.icon_url }}">
-                                    <span>{{ tool.title }}</span>
+                                    {% if tool.title|length > 20 %}
+                                        <span>{{ tool.title|slice:":21"|add:"..." }}</span>
+                                    {% else %}
+                                        <span>{{ tool.title }}</span>
+                                    {% endif %}
                                 </a>
                             </li>
                         {% endfor %}
@@ -1628,18 +1632,22 @@
                             <!-- ========= RELEVANT TOOLS TAB ========= -->
                         {% if relevant_tools %}
                             <div class="tab-pane" id="relevantTools">
-                            {% if not metadata_form %}
-                                {% for tool in relevant_tools %}
-                                    <a href="{{ tool.url }}" target="_blank">
-                                    <div id="web-app-item">
-                                        <h4>{{ tool.title }}</h4>
-                                        <img class="user-webapp-icon" src="{{ tool.icon_url }}">
-                                    </div>
-                                    </a>
-                                {% endfor %}
-                            {% else %}
-                                ------- Relevant tools form here -------
-                            {%  endif %}
+                                {% if not metadata_form %}
+                                    {% for tool in relevant_tools %}
+                                        <div title="{{ tool.title }}" id="web-app-item">
+                                            <a href="{{ tool.url }}" target="_blank">
+                                                {% if tool.title|length > 20 %}
+                                                    <h4>{{ tool.title|slice:":21"|add:"..." }}</h4>
+                                                {% else %}
+                                                    <h4>{{ tool.title }}</h4>
+                                                {% endif %}
+                                                <img class="user-webapp-icon" src="{{ tool.icon_url }}">
+                                            </a>
+                                        </div>
+                                    {% endfor %}
+                                {% else %}
+                                    ------- Relevant tools form here -------
+                                {%  endif %}
                             </div>
                         {% endif %}
                     </div>

--- a/hs_tools_resource/static/css/toolresource.css
+++ b/hs_tools_resource/static/css/toolresource.css
@@ -1,4 +1,6 @@
 #web-app-item {
+    width: 225px;
+    height: 150px;
     display:inline-block;
     box-sizing: border-box;
     padding-left: 1vw;


### PR DESCRIPTION
If a web app has a title longer than 20 characters (hard-coded) then the name will be shortened with ellipses. A title attribute was added to the container to show the full title on the tool-tip.