### PR TITLE
922 nginx uwsgi fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mjstealey/hydroshare_base
+FROM mjstealey/hs_docker_base:1.6.5
 MAINTAINER Michael J. Stealey <stealey@renci.org>
 
 ### Begin - HydroShare Development Image Additions ###

--- a/docker-compose.template
+++ b/docker-compose.template
@@ -30,6 +30,8 @@ hydroshare:
     # - "/home/hydro/pycharm-debug:/home/docker/pycharm-debug"
     # log files
     - "HS_LOG_FILES:/var/log/hydroshare"
+    # shared location for uwsgi.sock
+    - "/var/run/uwsgi.sock"
   ports:
     - "1338:22"
     - "8000:8000"

--- a/docker-compose.template
+++ b/docker-compose.template
@@ -30,8 +30,8 @@ hydroshare:
     # - "/home/hydro/pycharm-debug:/home/docker/pycharm-debug"
     # log files
     - "HS_LOG_FILES:/var/log/hydroshare"
-    # shared location for uwsgi.sock
-    - "/var/run/uwsgi.sock"
+    # shared location for uwsgi.sock between containers
+    - "/var/run"
   ports:
     - "1338:22"
     - "8000:8000"

--- a/hsctl
+++ b/hsctl
@@ -61,7 +61,6 @@ restart_hs() {
     stop_nginx
     preflight_hs
     docker-compose stop hydroshare
-    docker-compose build hydroshare
     docker-compose up -d hydroshare
     if [ "${USE_NGINX,,}" = true ]; then
         start_nginx

--- a/hsctl
+++ b/hsctl
@@ -24,7 +24,7 @@ OTHER_DOCKER_CONTAINERS=(hydroshare_postgis_1 hydroshare_rabbitmq_1 hydroshare_r
 HTTP_RECAPTCHA='http://www.google.com/recaptcha/api/js/recaptcha_ajax.js'
 HTTPS_RECAPTCHA='https://www.google.com/recaptcha/api/js/recaptcha_ajax.js'
 DEV_SERVER='python manage.py runserver 0.0.0.0:8000'
-PROD_SERVER='uwsgi --socket :8001 --ini uwsgi.ini'
+PROD_SERVER='uwsgi --ini uwsgi.ini'
 
 display_usage() {
 	echo "*** HydroShare Control script ***"
@@ -60,8 +60,9 @@ restart_hs() {
     echo "*** ${1^^} ***"
     stop_nginx
     preflight_hs
-    docker stop hydroshare_hydroshare_1
-    docker start hydroshare_hydroshare_1
+    docker-compose stop hydroshare
+    docker-compose build hydroshare
+    docker-compose up -d hydroshare
     if [ "${USE_NGINX,,}" = true ]; then
         start_nginx
     fi

--- a/nginx/config-files/hydroshare-nginx.conf
+++ b/nginx/config-files/hydroshare-nginx.conf
@@ -1,36 +1,37 @@
 # hydroshare-nginx.conf                                                         
 
 upstream app_server {
-   server hydroshare:8001;
+    server unix:///tmp/uwsgi.sock;
 }
 
 server {
-   listen          80;
-   server_name     FQDN_OR_IP;
+    listen          80;
+    server_name     FQDN_OR_IP;
     access_log      /var/log/nginx/access.log combined;
     error_log       /var/log/nginx/error.log error;
     error_log       /var/log/nginx/system.log notice;
     root            /home/docker/hydroshare/hydroshare/static/;
 
-   charset         utf-8;
+    charset         utf-8;
 
-   client_max_body_size 0;
+    client_max_body_size 0;
 
-   location /static/ {
-       alias /home/docker/hydroshare/hydroshare/static/;
-   }
+    location /static/ {
+        alias /home/docker/hydroshare/hydroshare/static/;
+    }
 
-   location /media/ {
-       alias /home/docker/hydroshare/hydroshare/static/media/;
-   }
+    location /media/ {
+        alias /home/docker/hydroshare/hydroshare/static/media/;
+    }
 
-   location / {
+    location / {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-       uwsgi_pass  app_server;
-       include     /home/docker/hydroshare/uwsgi_params;
-   }
+        uwsgi_pass  app_server;
+        uwsgi_max_temp_file_size 4096m;
+        include     /home/docker/hydroshare/uwsgi_params;
+    }
 
     error_page 503 @maintenance;
     location @maintenance {

--- a/nginx/config-files/hydroshare-nginx.conf
+++ b/nginx/config-files/hydroshare-nginx.conf
@@ -1,7 +1,7 @@
 # hydroshare-nginx.conf                                                         
 
 upstream app_server {
-    server unix:///tmp/uwsgi.sock;
+    server unix:///var/run/uwsgi.sock;
 }
 
 server {

--- a/nginx/config-files/hydroshare-ssl-nginx.conf
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf
@@ -1,7 +1,7 @@
 # hydroshare-ssl-nginx.conf
 
 upstream app_server {
-    server unix:///tmp/uwsgi.sock;
+    server unix:///var/run/uwsgi.sock;
 }
 
 server {

--- a/nginx/config-files/hydroshare-ssl-nginx.conf
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf
@@ -1,7 +1,7 @@
 # hydroshare-ssl-nginx.conf
 
 upstream app_server {
-    server hydroshare:8001;
+    server unix:///tmp/uwsgi.sock;
 }
 
 server {
@@ -38,6 +38,7 @@ server {
             return 503;
         }
         uwsgi_pass  app_server;
+        uwsgi_max_temp_file_size 4096m;
         include     /home/docker/hydroshare/uwsgi_params;
     }
 
@@ -45,5 +46,4 @@ server {
     location @maintenance {
         rewrite ^(.*)$ /maintenance_on.html break;
     }
-
 }

--- a/nginx/run-nginx
+++ b/nginx/run-nginx
@@ -86,7 +86,6 @@ start_nginx() {
 restart_nginx() {
     echo "*** ${1^^} ***"
     stop_nginx STOP
-    #preflight_nginx
     start_nginx START
 }
 

--- a/nginx/run-nginx
+++ b/nginx/run-nginx
@@ -81,12 +81,13 @@ start_nginx() {
             docker start ${NGINX_DOCKER_CNTR};
         fi
     fi
+    docker exec ${HYDROSHARE_CID} chmod 777 /var/run/uwsgi.sock
 }
 
 restart_nginx() {
     echo "*** ${1^^} ***"
     stop_nginx STOP
-    preflight_nginx
+    #preflight_nginx
     start_nginx START
 }
 

--- a/nginx/run-nginx
+++ b/nginx/run-nginx
@@ -81,7 +81,6 @@ start_nginx() {
             docker start ${NGINX_DOCKER_CNTR};
         fi
     fi
-    docker exec ${HYDROSHARE_CID} chmod 777 /var/run/uwsgi.sock
 }
 
 restart_nginx() {

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,5 +8,5 @@ master = True
 processes = 4
 threads = 2
 socket = /var/run/uwsgi.sock
-chmod-socket = 664
+chmod-socket = 666
 vacuum = True

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -5,7 +5,8 @@ chdir = %(base)/%(project)
 module = %(project).wsgi:application
 env = DJANGO_SETTINGS_MODULE=%(project).settings
 master = True
-processes = 5
-;socket = %(base)/%(project)/%(project).sock
-;chmod-socket = 664
+processes = 4
+threads = 2
+socket = /var/run/uwsgi.sock
+chmod-socket = 664
 vacuum = True


### PR DESCRIPTION
Updates to uwsgi and nginx
- accommodate up to 4 GB file download (to be increased at a later date)
- use unix socket for uWSGI server
- update nginx config files for unix socket and 4 GB file download and clean up spacing
- update hsctl restart to use docker-compose calls instead of docker call
- update docker-compose.template for unix socket use
- update Dockerfile to use docker hub tagged build ID