### PR TITLE
[#1008] My Resources table horizontal scroll bar fix for Firefox

### DIFF
--- a/hs_core/templates/pages/my-resources.html
+++ b/hs_core/templates/pages/my-resources.html
@@ -402,7 +402,6 @@
         var resourceTable;
 
         $(document).ready(function () {
-
         /*==================================================
             Table columns
             0 - actions
@@ -469,6 +468,11 @@
                     }
                 ]
             });
+
+            // Fix for horizontal scroll bar appearing unnecessarily on firefox.
+            if ($.browser.mozilla){
+                $("#item-selectors").width($("#item-selectors").width() - 2);
+            }
 
             // Trigger label creation when pressing Enter
             $("#txtLabelName").keyup(function (event) {


### PR DESCRIPTION
Fixed minor scroll bar behavior for my resources table in Firefox.

Note: I had to do this fix in JQuery and not css because this styling issue is caused by DataTables pluggin script rendering.