### PR TITLE
1026 mp pageprocessors bug

### DIFF
--- a/hs_model_program/forms.py
+++ b/hs_model_program/forms.py
@@ -38,7 +38,7 @@ class mp_form_helper(BaseFormHelper):
         field_width = 'form-control input-sm'
         css_multichar = field_width + ' multichar'
         layout = Layout(
-            HTML('<legend>Data files</legend>'),
+            HTML('<legend>Data</legend>'),
             HTML('<div class="col-sm-6 col-xs-12">'),
             Field('modelEngine', css_class=css_multichar, style="display:none"),
             multiselect['modelEngine'],
@@ -76,11 +76,10 @@ class mp_form(ModelForm):
         super(mp_form, self).__init__(*args, **kwargs)
         self.helper = mp_form_helper(allow_edit, res_short_id, element_id, element_name='MpMetadata', files=files)
 
+        # hide the field help text
         for field in self.fields:
             help_text = self.fields[field].help_text
             self.fields[field].help_text = None
-            if help_text != '':
-                self.fields[field].widget.attrs.update({'class':'has-popover', 'data-content':help_text, 'data-placement':'right', 'data-container':'body'})
 
 
     class Meta:

--- a/hs_model_program/page_processors.py
+++ b/hs_model_program/page_processors.py
@@ -25,13 +25,6 @@ def landing_page(request, page):
         context['extended_metadata_exists'] = extended_metadata_exists
         context['mpmetadata'] = content_model.metadata.program
 
-        # get the helptext for each mp field
-        attributes = content_model.metadata.modelprogrammetadata._mpmetadata.model._meta.get_fields_with_model()
-        attribute_dict = {}
-        for att in attributes:
-             attribute_dict[att[0].attname] = att[0].help_text
-        context["mphelptext" ] = attribute_dict
-
     else:
         output_form = mp_form(files=content_model.files, instance=content_model.metadata.program,
                               res_short_id=content_model.short_id,


### PR DESCRIPTION
Fixed a bug that was causing Model Program to fail during resource creation, in `page_processors.py`.  The code which was causing the problem was previously used for displaying field help_text as hover popup dialogs.  This feature is no longer being used so the offending code was removed from the following files:

* hs_model_program/forms.py
* hs_model_program/page_processors.py
