### PR TITLE
Fixes to resource versioning

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -560,11 +560,8 @@ def create_new_version_resource(ori_res, new_res, user):
         new_res.metadata.create_element('date', type='available', start_date=res_avail_date.start_date, end_date=res_avail_date.end_date)
 
     # add or update Relation element to link source and target resources
-    if new_res.metadata.identifiers.all().filter(name="hydroShareIdentifier"):
-        hs_identifier = new_res.metadata.identifiers.all().filter(name="hydroShareIdentifier")[0]
-        ori_res.metadata.create_element('relation', type='isReplacedBy', value=hs_identifier.url)
-    else:
-        ori_res.metadata.create_element('relation', type='isReplacedBy', value=new_res.short_id)
+    hs_identifier = new_res.metadata.identifiers.all().filter(name="hydroShareIdentifier")[0]
+    ori_res.metadata.create_element('relation', type='isReplacedBy', value=hs_identifier.url)
 
     if new_res.metadata.relations.all().filter(type='isVersionOf').exists():
         # the original resource is already a versioned resource, and its isVersionOf relation element
@@ -573,11 +570,8 @@ def create_new_version_resource(ori_res, new_res, user):
         eid = new_res.metadata.relations.all().filter(type='isVersionOf').first().id
         new_res.metadata.delete_element('relation', eid)
 
-    if ori_res.metadata.identifiers.all().filter(name="hydroShareIdentifier"):
-        hs_identifier = ori_res.metadata.identifiers.all().filter(name="hydroShareIdentifier")[0]
-        new_res.metadata.create_element('relation', type='isVersionOf', value=hs_identifier.url)
-    else:
-        new_res.metadata.create_element('relation', type='isVersionOf', value=ori_res.short_id)
+    hs_identifier = ori_res.metadata.identifiers.all().filter(name="hydroShareIdentifier")[0]
+    new_res.metadata.create_element('relation', type='isVersionOf', value=hs_identifier.url)
 
     # create bag for the new resource
     hs_bagit.create_bag(new_res)

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -559,12 +559,19 @@ def create_new_version_resource(ori_res, new_res):
         res_avail_date = new_res.metadata.dates.all().filter(type='available')[0]
         new_res.metadata.create_element('date', type='available', start_date=res_avail_date.start_date, end_date=res_avail_date.end_date)
 
-    # add Relation element to link source and target resources
+    # add or update Relation element to link source and target resources
     if new_res.metadata.identifiers.all().filter(name="hydroShareIdentifier"):
         hs_identifier = new_res.metadata.identifiers.all().filter(name="hydroShareIdentifier")[0]
         ori_res.metadata.create_element('relation', type='isReplacedBy', value=hs_identifier.url)
     else:
         ori_res.metadata.create_element('relation', type='isReplacedBy', value=new_res.short_id)
+
+    if new_res.metadata.relations.all().filter(type='isVersionOf').exists():
+        # the original resource is already a versioned resource, and its isVersionOf relation element
+        # is copied over to this new version resource, needs to delete this element so it can be created
+        # to link to its original resource correctly
+        eid = new_res.metadata.relations.all().filter(type='isVersionOf').first().id
+        new_res.metadata.delete_element('relation', eid)
 
     if ori_res.metadata.identifiers.all().filter(name="hydroShareIdentifier"):
         hs_identifier = ori_res.metadata.identifiers.all().filter(name="hydroShareIdentifier")[0]

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -512,7 +512,7 @@ def create_new_version_empty_resource(pk, user):
 
     return new_resource
 
-def create_new_version_resource(ori_res, new_res):
+def create_new_version_resource(ori_res, new_res, user):
     """
     Populate metadata and contents from ori_res object to new_res object to make new_res object as a new version of the ori_res object
     Args:
@@ -581,6 +581,9 @@ def create_new_version_resource(ori_res, new_res):
 
     # create bag for the new resource
     hs_bagit.create_bag(new_res)
+
+    # since an isReplaceBy relation element is added to original resource, needs to call resource_modified() for original resource
+    utils.resource_modified(ori_res, user)
 
     return new_res
 

--- a/hs_core/tests/api/native/test_create_new_version_resource.py
+++ b/hs_core/tests/api/native/test_create_new_version_resource.py
@@ -79,7 +79,7 @@ class TestNewVersionResource(TestCase):
             hydroshare.create_new_version_empty_resource(self.res_generic.short_id, self.nonowner)
 
         new_res_generic = hydroshare.create_new_version_empty_resource(self.res_generic.short_id, self.owner)
-        new_res_generic = hydroshare.create_new_version_resource(self.res_generic, new_res_generic)
+        new_res_generic = hydroshare.create_new_version_resource(self.res_generic, new_res_generic, self.owner)
 
         # test the new versioned resource has the same resource type as the original resource
         self.assertTrue(isinstance(new_res_generic, GenericResource))
@@ -135,7 +135,7 @@ class TestNewVersionResource(TestCase):
             hydroshare.create_new_version_empty_resource(self.res_raster.short_id, self.nonowner)
 
         new_res_raster = hydroshare.create_new_version_empty_resource(self.res_raster.short_id, self.owner)
-        new_res_raster = hydroshare.create_new_version_resource(self.res_raster, new_res_raster)
+        new_res_raster = hydroshare.create_new_version_resource(self.res_raster, new_res_raster, self.owner)
 
         # test the new versioned resource has the same resource type as the original resource
         self.assertTrue(isinstance(new_res_raster, RasterResource))

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -28,7 +28,7 @@ from django_irods.icommands import SessionException
 from hs_core import hydroshare
 from hs_core.hydroshare.utils import get_resource_by_shortkey, resource_modified
 from .utils import authorize, upload_from_irods, ACTION_TO_AUTHORIZE
-from hs_core.models import GenericResource, resource_processor, CoreMetaData
+from hs_core.models import GenericResource, resource_processor, CoreMetaData, Relation
 from hs_core.hydroshare.resource import METADATA_STATUS_SUFFICIENT, METADATA_STATUS_INSUFFICIENT
 
 from . import resource_rest_api
@@ -480,10 +480,16 @@ def my_resources(request, page):
     user = request.user
     # get a list of resources with effective OWNER privilege
     owned_resources = user.uaccess.get_resources_with_explicit_access(PrivilegeCodes.OWNER)
+    # remove obsoleted resources from the owned_resources
+    owned_resources = owned_resources.exclude(object_id__in=Relation.objects.filter(type='isReplacedBy').values('object_id'))
     # get a list of resources with effective CHANGE privilege
     editable_resources = user.uaccess.get_resources_with_explicit_access(PrivilegeCodes.CHANGE)
+    # remove obsoleted resources from the editable_resources
+    editable_resources = editable_resources.exclude(object_id__in=Relation.objects.filter(type='isReplacedBy').values('object_id'))
     # get a list of resources with effective VIEW privilege
     viewable_resources = user.uaccess.get_resources_with_explicit_access(PrivilegeCodes.VIEW)
+    # remove obsoleted resources from the viewable_resources
+    viewable_resources = viewable_resources.exclude(object_id__in=Relation.objects.filter(type='isReplacedBy').values('object_id'))
 
     owned_resources = list(owned_resources)
     editable_resources = list(editable_resources)

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -278,7 +278,7 @@ def create_new_version_resource(request, shortkey, *args, **kwargs):
         res.locked_time = datetime.datetime.now(pytz.utc)
         res.save()
         new_resource = hydroshare.create_new_version_empty_resource(shortkey, user)
-        new_resource = hydroshare.create_new_version_resource(res, new_resource)
+        new_resource = hydroshare.create_new_version_resource(res, new_resource, user)
     except Exception as ex:
         if new_resource:
             new_resource.delete()

--- a/theme/templates/resource-landing-page/modals.html
+++ b/theme/templates/resource-landing-page/modals.html
@@ -410,10 +410,10 @@
                 <h4 class="modal-title" id="new-version-resource-title">Create New Version of This Resource</h4>
             </div>
             <div class="modal-body">
-                Creating a new version of this resource will obsolete this resource.
-                This resource will be still available in HydroShare, but will not be
-                discoverable via HydroShare search interface. Only one newer version
-                is allowed.
+                Creating a new version will obsolete this resource. This resource will be still available in HydroShare,
+                but only the newer version will be discoverable via the HydroShare search interface. A link to this
+                resource will be created on the landing page of the new version. Only one newer version
+                is allowed for each resource.
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/theme/templates/resource-landing-page/title-section.html
+++ b/theme/templates/resource-landing-page/title-section.html
@@ -10,20 +10,18 @@
     </div>
 {% endif %}
 
-{# ======= Resource new version just created notification if obsoleted resource is public, discoverable or published =======#}
+{# ======= Resource new version just created notification =======#}
 {% if just_created and is_version_of %}
-    {% if cm.raccess.published or cm.raccess.public or cm.raccess.discoverable %}
-        <div class="col-sm-12">
-            <div class="alert {% if just_created %}alert-success{% else %}alert-warning{% endif %} alert-dismissible" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Congratulations! </strong>
-                <span>Your resource has been created as a new version of
-                    <a href="{{ is_version_of }}">this {% if cm.raccess.published %} published {% elif cm.raccess.public %} public {% else %} discoverable {% endif %} resource</a>.
-                    This new version is created as a private resource by default. If you want the new version to be discoverable, you need to
-                    make it public or discoverable or publish it. </span>
-            </div>
+    <div class="col-sm-12">
+        <div class="alert {% if just_created %}alert-success{% else %}alert-warning{% endif %} alert-dismissible" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <strong>Congratulations! </strong>
+            <span>Your new version has been created. A link to the older version has been added below the resource title. To modify this
+                new version or change the sharing status, click the Edit button. To share this new version with individual HydroShare users,
+                click the Manage Access button. Note that this new version is created as a private resource by default. If you want the new
+                version to be discoverable, you need to make it public or discoverable or publish it. </span>
         </div>
-    {% endif %}
+    </div>
 {% endif %}
 
 {# ======= Missing fields notification =======#}

--- a/theme/templates/resource-landing-page/top-right-buttons.html
+++ b/theme/templates/resource-landing-page/top-right-buttons.html
@@ -33,25 +33,27 @@
                 {% if page.perms.change or is_owner_user and cm.raccess.published %}
                     <form class="inline pull-right" action="{{ cm.get_absolute_url }}" method="post">
                         {% csrf_token %}
-                        {% if page.perms.delete %}
-                            {% if cm.can_be_public_or_discoverable %}
-                                <a id="publish" data-toggle="modal" data-target="#submit-for-publication-dialog">
-                                    <span data-toggle="tooltip" data-placement="auto" title="Publish this resource"
-                                          class="glyphicon glyphicon-book icon-button btn-edit"></span>
-                                </a>
-                            {% endif %}
-
-                            <a id="delete" data-toggle="modal" data-target="#delete-resource-dialog">
-                                <span data-toggle="tooltip" data-placement="auto" title="Delete this resource"
-                                      class="glyphicon glyphicon-trash icon-button btn-remove"></span>
+                        {% if page.perms.delete and cm.can_be_public_or_discoverable %}
+                            <a id="publish" data-toggle="modal" data-target="#submit-for-publication-dialog">
+                                <span data-toggle="tooltip" data-placement="auto" title="Publish this resource"
+                                      class="glyphicon glyphicon-book icon-button btn-edit"></span>
                             </a>
                         {% endif %}
+
                         {% if page.perms.delete or cm.raccess.published %}
                             <a id="new-version" data-toggle="modal" data-target="#new-version-resource-dialog">
                                 <span data-toggle="tooltip" data-placement="auto" title="Create a new version of this resource"
                                       class="glyphicon glyphicon-new-window icon-button btn-edit"></span>
                             </a>
                         {% endif %}
+
+                        {% if page.perms.delete %}
+                            <a id="delete" data-toggle="modal" data-target="#delete-resource-dialog">
+                                <span data-toggle="tooltip" data-placement="auto" title="Delete this resource"
+                                      class="glyphicon glyphicon-trash icon-button btn-remove"></span>
+                            </a>
+                        {% endif %}
+
                         {% if page.perms.change  %}
                         <input name="resource-mode" type="hidden" value="edit"/>
                             <button id="edit-metadata" type="submit" data-toggle="tooltip" data-placement="auto"


### PR DESCRIPTION
Addressed further cosmetic code review comments from @horsburgh and fixed one bug discovered along the way when creating a new version for a resource that is the latest version of a resource already. @pkdash Could you give a quick review and see if you can give +1? I want this to be included in the next deployment since without the bug fix included in this PR, an error will be raised which breaks versioning chain when creating a version chain including more than 2 resources. 