### PR TITLE
fixed commenting issue with django 1.8 upgrade

### DIFF
--- a/theme/forms.py
+++ b/theme/forms.py
@@ -101,22 +101,6 @@ class CommentDetailsForm(CommentSecurityForm):
 
         return new
 
-    def clean_comment(self):
-        """
-        If COMMENTS_ALLOW_PROFANITIES is False, check that the comment doesn't
-        contain anything in PROFANITIES_LIST.
-        """
-        comment = self.cleaned_data["comment"]
-        if settings.COMMENTS_ALLOW_PROFANITIES == False:
-            bad_words = [w for w in settings.PROFANITIES_LIST if w in comment.lower()]
-            if bad_words:
-                raise forms.ValidationError(ungettext(
-                    "Watch your mouth! The word %s is not allowed here.",
-                    "Watch your mouth! The words %s are not allowed here.",
-                    len(bad_words)) % get_text_list(
-                        ['"%s%s%s"' % (i[0], '-'*(len(i)-2), i[-1])
-                         for i in bad_words], ugettext('and')))
-        return comment
 
 class CommentForm(CommentDetailsForm):
     honeypot      = forms.CharField(required=False,


### PR DESCRIPTION
This fixes the issue with commenting after upgrading to django 1.8. @mjstealey please review and merge it if it looks good. In a nutshell, we can directly use the function clean_comment() provided by django-contrib-comments 1.6.2 module without customizing that function in our code base, so the fix was just remove the customized version. I have tested it out in my local dev env and everything works after removal of this customized function, so I am positive it will just work. 