### PR TITLE
1059 netcdf hyrax ondemand update

### DIFF
--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -710,12 +710,11 @@ def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_valu
             resource.raccess.discoverable = is_public
 
         resource.raccess.save()
-        if resource.raccess.public:
-            # set isPublic metadata AVU accordingly
-            istorage = IrodsStorage()
-            istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
-            if settings.RUN_HYRAX_UPDATE and resource.resource_type == 'NetcdfResource':
-                run_script_to_update_hyrax_input_files()
+        # set isPublic metadata AVU accordingly
+        istorage = IrodsStorage()
+        istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
+        if settings.RUN_HYRAX_UPDATE and resource.resource_type == 'NetcdfResource':
+            run_script_to_update_hyrax_input_files()
 
 def _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag):
     msg = ''

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -27,7 +27,7 @@ from django_irods.storage import IrodsStorage
 from django_irods.icommands import SessionException
 from hs_core import hydroshare
 from hs_core.hydroshare.utils import get_resource_by_shortkey, resource_modified
-from .utils import authorize, upload_from_irods, ACTION_TO_AUTHORIZE
+from .utils import authorize, upload_from_irods, ACTION_TO_AUTHORIZE, run_script_to_update_hyrax_input_files
 from hs_core.models import GenericResource, resource_processor, CoreMetaData, Relation
 from hs_core.hydroshare.resource import METADATA_STATUS_SUFFICIENT, METADATA_STATUS_INSUFFICIENT
 
@@ -710,9 +710,12 @@ def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_valu
             resource.raccess.discoverable = is_public
 
         resource.raccess.save()
-        # set isPublic metadata AVU accordingly
-        istorage = IrodsStorage()
-        istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
+        if resource.raccess.public:
+            # set isPublic metadata AVU accordingly
+            istorage = IrodsStorage()
+            istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
+            if resource.resource_type == 'NetcdfResource':
+                run_script_to_update_hyrax_input_files()
 
 def _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag):
     msg = ''

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -713,7 +713,9 @@ def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_valu
         # set isPublic metadata AVU accordingly
         istorage = IrodsStorage()
         istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
-        if settings.RUN_HYRAX_UPDATE and resource.resource_type == 'NetcdfResource':
+
+        # run script to update hyrax input files when a private netCDF resource is made public
+        if flag_to_set=='public' and flag_value and settings.RUN_HYRAX_UPDATE and resource.resource_type=='NetcdfResource':
             run_script_to_update_hyrax_input_files()
 
 def _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag):

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -714,7 +714,7 @@ def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_valu
             # set isPublic metadata AVU accordingly
             istorage = IrodsStorage()
             istorage.setAVU(resource.short_id, "isPublic", str(resource.raccess.public))
-            if resource.resource_type == 'NetcdfResource':
+            if settings.RUN_HYRAX_UPDATE and resource.resource_type == 'NetcdfResource':
                 run_script_to_update_hyrax_input_files()
 
 def _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag):

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -61,7 +61,9 @@ def upload_from_irods(username, password, host, port, zone, irods_fnames, res_fi
         fname = os.path.basename(ifname.rstrip(os.sep))
         res_files.append(UploadedFile(file=tmpFile, name=fname, size=size))
 
-
+# run the update script on hyrax server via ssh session for netCDF resources on demand
+# when private netCDF resources are made public so that all links of data services
+# provided by Hyrax service are instantaneously available on demand
 def run_script_to_update_hyrax_input_files():
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -131,6 +131,16 @@ USE_CROSSREF_TEST = True
 CROSSREF_LOGIN_ID = ''
 CROSSREF_LOGIN_PWD = ''
 
+# Since Hyrax server on-demand update is only needed when private netCDF resources on www
+# are made public, in local development environments or VM deployments other than the www
+# production, this should not be run by setting RUN_HYRAX_UPDATE to False. RUN_HYRAX_UPDATE
+# should only be set to True on www.hydroshare.org
+RUN_HYRAX_UPDATE = False
+HYRAX_SSH_HOST = ''
+HYRAX_SSH_PROXY_USER = ''
+HYRAX_SSH_PROXY_USER_PWD = ''
+HYRAX_SCRIPT_RUN_COMMAND = ''
+
 # Email configuration
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #EMAIL_HOST_USER = ''

--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -164,6 +164,11 @@
                     {% endif %}
                 </div>
 
+                {% if is_owner_user and cm.resource_type == "NetcdfResource" and not cm.raccess.public%}
+                    <div class="pull-left label-public">Note that making the resource public may take a little extra time to update
+                            Hyrax server in order to provide OPeNDAP service for this resource. </div>
+                {% endif %}
+
                 {% if is_owner_user %}
                     <div class="clear-fix" id="shareable-container">
                         {#   Shareable flag    #}

--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -164,7 +164,7 @@
                     {% endif %}
                 </div>
 
-                {% if is_owner_user and cm.resource_type == "NetcdfResource" and not cm.raccess.public%}
+                {% if is_owner_user and cm.resource_type == "NetcdfResource" and not cm.raccess.public %}
                     <div class="pull-left label-public">Note that making the resource public may take a little extra time to update
                             Hyrax server in order to provide OPeNDAP service for this resource. </div>
                 {% endif %}


### PR DESCRIPTION
This resolves on-demand netCDF resource update feed to Hyrax server when private netCDF resources are made public so that links of data services provided by Hyrax server on resource landing page are instantaneously valid and available once the netCDF resource is made public. The cron job that runs the update script every midnight will still be scheduled to clean up synlinked netCDF resources as needed for cases when a public netCDF resource is made private or deleted. I have tested it out in my local development environment and made sure it all works as expected. @pkdash @gantian127 Could you give a quick code review and see if you can give a +1?