### PR TITLE
1069 fail test after base refactor

### DIFF
--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -284,16 +284,19 @@ class ResourceCreate(generics.CreateAPIView):
         Hack to work around the following issue in django-rest-framework:
 
         https://github.com/tomchristie/django-rest-framework/issues/3951
-        
+
         :param request:
         :param args:
         :param kwargs:
         :return:
         """
         if not isinstance(request, Request):
+            # Don't deep copy the file data as it may contain an open file handle
+            old_file_data = copy.copy(request.FILES)
             old_post_data = copy.deepcopy(request.POST)
             request = super(ResourceCreate, self).initialize_request(request, *args, **kwargs)
             request.POST.update(old_post_data)
+            request.FILES.update(old_file_data)
         return request
 
     def get_serializer_class(self):
@@ -529,6 +532,26 @@ class ResourceFileCRUD(APIView):
     ValidationError: return json format: {'parameter-1':['error message-1'], 'parameter-2': ['error message-2'], .. }
     """
     allowed_methods = ('GET', 'POST', 'PUT', 'DELETE')
+
+    def initialize_request(self, request, *args, **kwargs):
+        """
+        Hack to work around the following issue in django-rest-framework:
+
+        https://github.com/tomchristie/django-rest-framework/issues/3951
+
+        :param request:
+        :param args:
+        :param kwargs:
+        :return:
+        """
+        if not isinstance(request, Request):
+            # Don't deep copy the file data as it may contain an open file handle
+            old_file_data = copy.copy(request.FILES)
+            old_post_data = copy.deepcopy(request.POST)
+            request = super(ResourceFileCRUD, self).initialize_request(request, *args, **kwargs)
+            request.POST.update(old_post_data)
+            request.FILES.update(old_file_data)
+        return request
 
     def get(self, request, pk, filename):
         view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)


### PR DESCRIPTION
This PR contains a work around for a bug in django-rest-framework that caused two failing unit tests, one in hs_core.tests.api.rest.test_resource_file and one in hs_core.tests.api.rest.test_create_resource.  See #1069 for more details.