### PR TITLE
[#1093] WebApp - describle how to use predefined terms

### DIFF
--- a/hs_core/templates/pages/metadata_terms.html
+++ b/hs_core/templates/pages/metadata_terms.html
@@ -1053,26 +1053,34 @@
     <p>
         A Web App resource is a shortcut (or reference) to an external web application that can work with HydroShare data resources. A Web App might be a simple webpage, a resource viewer, a data editor, or a complicated scientific model. Third-party web applications can easily access HydroShare data resources using the HydroShare REST API, and can be linked to specific HydroShare resource types and made discoverable within HydroShare by registering them as a Web App resource.
     </p>
-    <a name="RequestUrlBase"></a>
+    <a name="AppURL"></a>
         <ul >
-            <li><strong>Term: </strong>RequestUrlBase</li>
-            <li><strong>URI: </strong><a href="#RequestUrlBase">http://www.hydroshare.org/terms/RequestUrlBase</a></li>
-            <li><strong>Label: </strong>Request URL Base</li>
-            <li><strong>Description: </strong>URL of the external web app</li>
+            <li><strong>Term: </strong>AppURL</li>
+            <li><strong>URI: </strong><a href="#AppURL">http://www.hydroshare.org/terms/AppURL</a></li>
+            <li><strong>Label: </strong>App URL</li>
+            <li><strong>Description: </strong>In most cases, an app will have been programmed to expect certain parameters in its App URL which send the app important information, such as which HydroShare resource to retrieve and process. HydroShare provides predefined parameters to achieve this. These predefined parameters can be appended to your App URL. They will be dynamically replaced at run-time when a user launches your app from a resource landing page. This approach gives you greater flexibility when customizing App URL. <br>Currently, HydroShare supports the following parameters:
+            <ul>
+                <li> <strong>${HS_RES_ID}</strong>: Resource ID</li>
+                <li> <strong>${HS_RES_TYPE}</strong>: Resource Type</li>
+                <li> <strong>${HS_USR_NAME}</strong>: HydroShare username</li>
+            </ul>
+                An example:<br>
+ <strong>http://www.my-app-website.org/app_1/?res_id=${HS_RES_ID}</strong>.<br>HydroShare will replace ${HS_RES_ID} with the real resource id.
+            </li>
         </ul>
-    <a name="ToolResourceType"></a>
+    <a name="SupportedResourceType"></a>
         <ul >
-            <li><strong>Term: </strong>ToolResourceType</li>
-            <li><strong>URI: </strong><a href="#ToolResourceType">http://www.hydroshare.org/terms/ToolResourceType</a></li>
-            <li><strong>Label: </strong>Tool Resource Type</li>
+            <li><strong>Term: </strong>SupportedResourceType</li>
+            <li><strong>URI: </strong><a href="#SupportedResourceType">http://www.hydroshare.org/terms/SupportedResourceType</a></li>
+            <li><strong>Label: </strong>Supported Resource Type</li>
             <li><strong>Description: </strong>Names of applicable date resource type</li>
         </ul>
-    <a name="ToolVersion"></a>
+    <a name="WebAppVersion"></a>
         <ul >
-            <li><strong>Term: </strong>ToolVersion</li>
-            <li><strong>URI: </strong><a href="#ToolVersion">http://www.hydroshare.org/terms/ToolVersion</a></li>
-            <li><strong>Label: </strong>Tool Version</li>
-            <li><strong>Description: </strong>Web app Version</li>
+            <li><strong>Term: </strong>WebAppVersion</li>
+            <li><strong>URI: </strong><a href="#WebAppVersion">http://www.hydroshare.org/terms/WebAppVersion</a></li>
+            <li><strong>Label: </strong>Version</li>
+            <li><strong>Description: </strong>Web App Version</li>
         </ul>
 
     <h3>Script Resource Type Description</h3>

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -16,7 +16,7 @@ class UrlBaseFormHelper(BaseFormHelper):
         layout = Layout(
             Field('value', css_class=field_width)
         )
-        kwargs['element_name_label'] = 'App URL'
+        kwargs['element_name_label'] = "App URL <a href='/terms#AppURL' target='_blank'><font size='3'>Help</font></a>"
 
         super(UrlBaseFormHelper, self).__init__(allow_edit, res_short_id, element_id, element_name, layout,  *args, **kwargs)
 
@@ -25,7 +25,7 @@ class UrlBaseForm(ModelForm):
     def __init__(self, allow_edit=True, res_short_id=None, element_id=None, *args, **kwargs):
         super(UrlBaseForm, self).__init__(*args, **kwargs)
         self.helper = UrlBaseFormHelper(allow_edit, res_short_id, element_id, element_name='RequestUrlBase')
-        self.fields['value'].label = "<a href='/terms#AppURL' target='_blank'>Learn how to pass resource parameters in app url</a>"
+        self.fields['value'].label = ''
 
     class Meta:
         model = RequestUrlBase
@@ -128,7 +128,7 @@ class SupportedResTypesForm(ModelForm):
 
     def __init__(self, allow_edit=True, res_short_id=None, element_id=None, *args, **kwargs):
         super(SupportedResTypesForm, self).__init__(*args, **kwargs)
-        self.fields['supported_res_types'].label = "Choices: "
+        self.fields['supported_res_types'].label = "Choose Resource Types:"
         self.helper = SupportedResTypeFormHelper(allow_edit, res_short_id, element_id, element_name='SupportedResTypes')
         if self.instance:
             try:

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -25,6 +25,7 @@ class UrlBaseForm(ModelForm):
     def __init__(self, allow_edit=True, res_short_id=None, element_id=None, *args, **kwargs):
         super(UrlBaseForm, self).__init__(*args, **kwargs)
         self.helper = UrlBaseFormHelper(allow_edit, res_short_id, element_id, element_name='RequestUrlBase')
+        self.fields['value'].label = "<a href='/terms#AppURL' target='_blank'>Learn how to pass resource parameters in app url</a>"
 
     class Meta:
         model = RequestUrlBase
@@ -52,6 +53,7 @@ class VersionForm(ModelForm):
     def __init__(self, allow_edit=True, res_short_id=None, element_id=None, *args, **kwargs):
         super(VersionForm, self).__init__(*args, **kwargs)
         self.helper = VersionFormHelper(allow_edit, res_short_id, element_id, element_name='ToolVersion')
+        self.fields['value'].label = ""
 
     class Meta:
         model = ToolVersion
@@ -70,7 +72,7 @@ class ToolIconFormHelper(BaseFormHelper):
         layout = Layout(
                 Field('url', css_class=field_width)
         )
-        kwargs['element_name_label'] = 'Tool Icon'
+        kwargs['element_name_label'] = 'Icon URL'
         super(ToolIconFormHelper, self).__init__(allow_edit, res_short_id, element_id, element_name, layout,  *args, **kwargs)
 
 
@@ -78,7 +80,7 @@ class ToolIconForm(ModelForm):
     def __init__(self, allow_edit=True, res_short_id=None, element_id=None, *args, **kwargs):
         super(ToolIconForm, self).__init__(*args, **kwargs)
         self.helper = ToolIconFormHelper(allow_edit, res_short_id, element_id, element_name='ToolIcon')
-        self.fields['url'].label = "URL"
+        self.fields['url'].label = ""
 
     class Meta:
         model = ToolIcon


### PR DESCRIPTION
@Castronova 
We will address issue #1093 in two PRs. 

This PR is to address your first question"1) Parameters that can be in the URL value need to be specified somewhere on the App resource instance editing page. These are currently only available by digging through the source code."

We added a link above the App URL text box, this link redirects user to the "WebApp" section of the "Terms" page (www.hydroshare.org/terms) which describes what are "predefined terms" and how to use them.

![image](https://cloud.githubusercontent.com/assets/10070599/14187155/dca9bc2c-f73e-11e5-9abc-8dc6263ba04a.png)

![image](https://cloud.githubusercontent.com/assets/10070599/14187168/efb5556a-f73e-11e5-904a-46423406a335.png)