### PR TITLE
Sync resource title with metadata title

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -479,6 +479,8 @@ def create_resource(
             for keyword in keywords:
                 resource.metadata.create_element('subject', value=keyword)
 
+            resource.title = resource.metadata.title.value
+            resource.save()
         if create_bag:
             hs_bagit.create_bag(resource)
 

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -167,6 +167,8 @@ def resource_modified(resource, by_user=None, overwrite_bag=True):
     resource.last_changed_by = by_user
 
     resource.updated = now().isoformat()
+    # seems this is the best place to sync resource title with metadata title
+    resource.title = resource.metadata.title.value
     resource.save()
     if resource.metadata.dates.all().filter(type='modified'):
         res_modified_date = resource.metadata.dates.all().filter(type='modified')[0]


### PR DESCRIPTION
The title for the resource that the user edits on resource landing page or though metadata extraction is stored as metadata title element. This is different than the mezzanine Page title attribute which is used in the <title> tag of the resource landing page. This code change is to set the Page title based on the metadata title to ensure both these titles have the same value.