### PR TITLE
fixes [#1098] added quotes to the droplist option values

### DIFF
--- a/hs_model_program/forms.py
+++ b/hs_model_program/forms.py
@@ -19,7 +19,7 @@ class mp_form_helper(BaseFormHelper):
             name = short_url.split('/')[-1]
             file_data[name] = short_url
 
-        options = '\n'.join(['<option value=%s>%s</option>'%(value, key) for key, value in file_data.iteritems() ])
+        options = '\n'.join(['<option value="%s">%s</option>'%(value, key) for key, value in file_data.iteritems() ])
 
         multiselect_elements = ['modelSoftware', 'modelDocumentation', 'modelReleaseNotes', 'modelEngine']
         multiselect = {}


### PR DESCRIPTION
Fixes a bug where metadata for uploaded content is saved incorrectly due to space characters in the file path.