### PR TITLE
[#997] Removed async and defer attributes from google maps script call

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -864,7 +864,7 @@
 
     {% block extra_js %}
         <script type="text/javascript" src="{{ STATIC_URL }}js/coverageMap.js"></script>
-        <script async defer src="https://maps.googleapis.com/maps/api/js?libraries=drawing"></script>
+        <script src="https://maps.googleapis.com/maps/api/js?libraries=drawing"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}js/resourceLandingAjax.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}js/irods.js"></script>
         <script type="text/javascript">


### PR DESCRIPTION
This should fix the problem causing the map not to load correctly. After consulting with @jcaraballo17, we determined that loading the script asynchronously was causing the problem.