### PR TITLE
[#1122] hotfix for collection: publish btn shows up when contained res are not published

### DIFF
--- a/theme/templates/resource-landing-page/top-right-buttons.html
+++ b/theme/templates/resource-landing-page/top-right-buttons.html
@@ -34,7 +34,7 @@
                     <form class="inline pull-right" action="{{ cm.get_absolute_url }}" method="post">
                         {% csrf_token %}
                         {% if page.perms.delete and cm.can_be_public_or_discoverable %}
-                            {% if cm.resource_type|lower == "collectionresource" and not cm.are_all_contained_resources_published or cm.resource_type|lower != "collectionresource" %}
+                            {% if cm.resource_type|lower == "collectionresource" and cm.are_all_contained_resources_published or cm.resource_type|lower != "collectionresource" %}
                                  <a id="publish" data-toggle="modal" data-target="#submit-for-publication-dialog">
                                     <span data-toggle="tooltip" data-placement="auto" title="Publish this resource"
                                           class="glyphicon glyphicon-book icon-button btn-edit"></span>


### PR DESCRIPTION
just one line changed, removing the "not" in this logic statement.

@pkdash @hyi please review, thanks