### PR TITLE
fix google map utility libraries reference issue

### DIFF
--- a/hs_core/templates/search/search.html
+++ b/hs_core/templates/search/search.html
@@ -216,8 +216,8 @@
     <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.11/css/jquery.dataTables.min.css">
     <script type="text/javascript" src="//cdn.datatables.net/1.10.11/js/jquery.dataTables.min.js"></script>
     <script src="//maps.googleapis.com/maps/api/js?v=3" type="text/javascript"></script>
-    <script src="//google-maps-utility-library-v3.googlecode.com/svn/tags/keydragzoom/2.0.8/src/keydragzoom_packed.js" type="text/javascript"></script>
-    <script src="//googlemaps.github.io/js-marker-clusterer/src/markerclusterer.js" type="text/javascript"></script>
+    <script src="//cdn.rawgit.com/googlemaps/v3-utility-library/master/keydragzoom/src/keydragzoom.js" type="text/javascript"></script>
+    <script src="//cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer.js" type="text/javascript"></script>
     <script type="text/javascript">
         var minFloatingNumber = 0.0001;
         var map = null;
@@ -287,7 +287,9 @@
                 map.setZoom(2);
                 google.maps.event.removeListener(listener);
             });
-            var markerCluster = new MarkerClusterer(map, markers);
+            var markerCluster = new MarkerClusterer(map, markers, {
+                imagePath: 'https://cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/images/m'
+            });
         }
 
         var createPointResourceMarker = function (lat, lng, info_content, bounds, info_window, rectangle, markers) {


### PR DESCRIPTION
@mjstealey @mauriel133 Google has moved the `svn` utility libraries to `GitHub`. It seems we can only browse the libraries source code from `svn`, but cannot make reference to them as we had. Since the libraries can be changed/moved/removed from git/svn any time, I think it is good practice to include the libraries from the CDN server.