### PR TITLE
1207 refts allow to reference any wml url

### DIFF
--- a/ref_ts/templates/pages/create-ref-time-series.html
+++ b/ref_ts/templates/pages/create-ref-time-series.html
@@ -23,10 +23,9 @@
                         <select class="" name="url" id="url" style="overflow-y: scroll;"></select>
                     </div>
                     <div>
-                        <input type="button" value="Check URL" onclick="check_url(document.getElementById('input_url').value)"/>
+                        <input id="check-url-btn" type="button" value="Check URL" onclick="check_url(document.getElementById('input_url').value)"/>
                     </div>
                 </div>
-
             </div>
         </div>
 
@@ -89,14 +88,41 @@
 
 {% block extra_js %}
     <script type="text/javascript">
-        $(function() {
             var globurl = "";
 
             $(document).ready(function(){
+
+                $('#site').change(function(){
+                    var site = $('#site').val();
+                    if (site != "-1")
+                    {
+                        get_variables(site);
+                    }
+                });
+
+                $('#variable').change(function(){
+                    var variable = $('#variable').val();
+                    var site = $('#site').val();
+                    if  (site != "-1" && variable != "-1")
+                    {
+                        getVals('soap', site, variable);
+                    }
+                });
+
+                // prevent from unexpectedly submitting form when users press down "Enter" key
+                $('#create-form').on("keyup keypress", function(e) {
+                var code = e.keyCode || e.which;
+                    if (code  == 13) {
+                        e.preventDefault();
+                        return false;
+                    }
+                });
+
                 $('#site-div').hide();
                 $('#variable-div').hide();
                 $('#message-div').show();
                 $('#preview-div').hide();
+                $('#check-url-btn').prop('disabled', false);
                 get_his_central_urls();
             });
 
@@ -152,6 +178,7 @@
 
              // check the url users input
             function check_url(url){
+                $('#check-url-btn').prop('disabled', true);
                 globurl = url;
 
                 show_message(false);
@@ -159,7 +186,7 @@
                 $('#variable-div').hide();
                 $('#preview-div').hide();
                 $('#submit').addClass('disabled');
-
+                show_message(true, 'Checking URL...', 'Black');
                 if (url.toLowerCase().match(/wsdl$/))
                 { // SOAP
                     get_sites(url);
@@ -170,6 +197,8 @@
                         url: '/hsapi/_internal/verify-rest-url/',
                         data: {url: url},
                         success: function (data, xhr, status) {
+                            $('#check-url-btn').prop('disabled', false);
+                            show_message(false);
                             if (data["status"] == "success")
                             {
                                 getVals('rest');
@@ -180,12 +209,12 @@
                             }
                         },
                         error: function(){
+                            $('#check-url-btn').prop('disabled', false);
                             show_message(true, '<h3>URL did not verify. There may be a problem with the URL you entered</h3>', 'Red');
                         }
                     });
                 }
             } // function check_url(url)
-
 
             function removeOptions(selectbox){
                 for(var i=selectbox.options.length-1; i>=0; i--)
@@ -205,6 +234,7 @@
                     url:'/hsapi/_internal/search-sites/',
                     data: {url: url},
                     success: function(data, xhr, status){
+                        $('#check-url-btn').prop("disabled", false);
                         if(data["status"] == "success")
                         {
                             console.log("sites:" + data["sites"].length);
@@ -244,9 +274,11 @@
                         }
                     },
                     error: function(data, stuff){
+                        $('#check-url-btn').prop("disabled", false);
                         get_sites_failed();
                     }
                 });
+
             } // get_sites(url)
 
             function get_sites_failed()
@@ -273,6 +305,7 @@
                 $('#variable-div').hide();
                 $('#preview-div').hide();
                 $('#submit').addClass('disabled');
+                $('#check-url-btn').prop("disabled", true);
 
                 $.ajax({
                     type:"GET",
@@ -280,6 +313,7 @@
                     data: {url: url,
                         site: site_code},
                     success: function(data, xhr, status){
+                        $('#check-url-btn').prop("disabled", false);
                         if(data["status"] == "success")
                         {
                             console.log("var:" + data["variables"].length);
@@ -321,6 +355,7 @@
                         }
                     },
                     error: function(data, stuff) {
+                        $('#check-url-btn').prop("disabled", false);
                         get_variables_failed();
                     }
                 })
@@ -343,6 +378,7 @@
                 show_message(true, 'Retrieving Data...', "Black");
                 $('#submit').addClass('disabled');
                 $('#preview-div').hide();
+                $('#check-url-btn').prop("disabled", true);
 
                 var service_url = "";
                 var site = "";
@@ -371,6 +407,7 @@
                         site: site,
                         variable: variable},
                     success: function(data, xhr, status){
+                        $('#check-url-btn').prop("disabled", false);
                         if (data["status"] == "success")
                         {
                             $('.ui-autocomplete-input').prop("disabled", false);
@@ -389,6 +426,7 @@
                         }
                     },
                     error: function(data, stuff){
+                        $('#check-url-btn').prop("disabled", false);
                         getVals_failed();
                     }
                 });
@@ -403,31 +441,7 @@
                 $('#variable').prop("disabled", false);
             }
 
-            $('#site').change(function(){
-                var site = $('#site').val();
-                if (site != "-1")
-                {
-                    get_variables(site);
-                }
 
-            });
-
-            $('#variable').change(function(){
-                var variable = $('#variable').val();
-                var site = $('#site').val();
-                if  (site != "-1" && variable != "-1")
-                {
-                    getVals('soap', site, variable);
-                }
-            });
-
-            $('#create-form').on("keyup keypress", function(e) {
-                var code = e.keyCode || e.which;
-                if (code  == 13) {
-                    e.preventDefault();
-                    return false;
-                }
-            });
 
             $.widget( "custom.combobox", {
                 _create: function() {
@@ -547,7 +561,7 @@
                     this.element.show();
                 }
             });
-        });
+{#        });#}
 
         $(function() {
             $("#url").combobox();

--- a/ref_ts/templates/pages/create-ref-time-series.html
+++ b/ref_ts/templates/pages/create-ref-time-series.html
@@ -149,7 +149,6 @@
                             $('#his-loading')
                                     .html('HIS Central Servers available')
                                     .css('color', 'Green');
-                            console.log("urls:" + data["url_list"].length);
                             var select = document.getElementsByName('url')[0];
                             removeOptions(select);
                             for (var i=0; i < data["url_list"].length; i++)
@@ -237,7 +236,6 @@
                         $('#check-url-btn').prop("disabled", false);
                         if(data["status"] == "success")
                         {
-                            console.log("sites:" + data["sites"].length);
                             var select = document.getElementsByName('site')[0];
                             removeOptions(select);
                             if (data["sites"].length > 1)
@@ -316,7 +314,6 @@
                         $('#check-url-btn').prop("disabled", false);
                         if(data["status"] == "success")
                         {
-                            console.log("var:" + data["variables"].length);
                             show_message(false);
                             $('.ui-autocomplete-input').prop("disabled", false);
                             $('#site-div').show();
@@ -441,8 +438,6 @@
                 $('#variable').prop("disabled", false);
             }
 
-
-
             $.widget( "custom.combobox", {
                 _create: function() {
                     this.wrapper = $( "<span>" )
@@ -561,7 +556,6 @@
                     this.element.show();
                 }
             });
-{#        });#}
 
         $(function() {
             $("#url").combobox();

--- a/ref_ts/templates/pages/create-ref-time-series.html
+++ b/ref_ts/templates/pages/create-ref-time-series.html
@@ -32,19 +32,19 @@
 
         <div id="site-div" class="form-group cuahsi-his cuahsi-his-2">
             <label for="" class="col-sm-2 control-label">Site</label>
-            <div class="col-sm-9">
+            <div class="col-sm-10">
                 <select class="form-control" name="site" id="site"></select>
             </div>
         </div>
 
         <div id="variable-div" class="form-group cuahsi-his cuahsi-his-3">
             <label for="" class="col-sm-2 control-label">Variable</label>
-            <div class="col-sm-9">
+            <div class="col-sm-10">
                 <select class="form-control" name="variable" id="variable"></select>
             </div>
         </div>
 
-         <div class="col-sm-offset-2 col-sm-9" id="message-div">
+         <div class="col-sm-offset-2 col-sm-10" id="message-div">
             <h3 id="message">
                 {%  if resource_creation_error %}
                 {{ resource_creation_error }}
@@ -52,12 +52,12 @@
             </h3>
         </div>
 
-        <div class ="form-group" id ="preview-div" class="col-sm-offset-2 col-sm-9">
+        <div class ="form-group" id ="preview-div" class="col-sm-offset-2 col-sm-10">
             <div class="col-sm-offset-2" id="preview"></div>
         </div>
 
         <div class="form-group">
-            <div class="col-sm-offset-2 col-sm-9">
+            <div class="col-sm-offset-2 col-sm-10">
                 <button type="submit" id="submit" class="btn btn-primary btn-lg btn-block disabled">Add HIS Time Series</button>
             </div>
         </div>

--- a/ref_ts/templates/pages/create-ref-time-series.html
+++ b/ref_ts/templates/pages/create-ref-time-series.html
@@ -18,27 +18,33 @@
             <p id="his-loading" style="color:blue"><i>loading HIS Central services...</i></p>
             <div class="ui-widget">
                 <label for="" class="col-sm-2 control-label">URL</label>
-                <div class="col-sm-10">
-                    <select class="" name="url" id="url" size="10" style="overflow-y: scroll;"></select>
+                <div class="row">
+                    <div class="col-sm-8">
+                        <select class="" name="url" id="url" style="overflow-y: scroll;"></select>
+                    </div>
+                    <div>
+                        <input type="button" value="Check URL" onclick="check_url(document.getElementById('input_url').value)"/>
+                    </div>
                 </div>
+
             </div>
         </div>
 
         <div id="site-div" class="form-group cuahsi-his cuahsi-his-2">
             <label for="" class="col-sm-2 control-label">Site</label>
-            <div class="col-sm-10">
+            <div class="col-sm-9">
                 <select class="form-control" name="site" id="site"></select>
             </div>
         </div>
 
         <div id="variable-div" class="form-group cuahsi-his cuahsi-his-3">
             <label for="" class="col-sm-2 control-label">Variable</label>
-            <div class="col-sm-10">
+            <div class="col-sm-9">
                 <select class="form-control" name="variable" id="variable"></select>
             </div>
         </div>
 
-         <div class="col-sm-offset-2 col-sm-10" id="message-div">
+         <div class="col-sm-offset-2 col-sm-9" id="message-div">
             <h3 id="message">
                 {%  if resource_creation_error %}
                 {{ resource_creation_error }}
@@ -46,12 +52,12 @@
             </h3>
         </div>
 
-        <div class ="form-group" id ="preview-div" class="col-sm-offset-2 col-sm-10">
+        <div class ="form-group" id ="preview-div" class="col-sm-offset-2 col-sm-9">
             <div class="col-sm-offset-2" id="preview"></div>
         </div>
 
         <div class="form-group">
-            <div class="col-sm-offset-2 col-sm-10">
+            <div class="col-sm-offset-2 col-sm-9">
                 <button type="submit" id="submit" class="btn btn-primary btn-lg btn-block disabled">Add HIS Time Series</button>
             </div>
         </div>
@@ -441,7 +447,8 @@
                     this.input = $( "<input>" )
                             .appendTo( this.wrapper )
                             .val( value )
-                            .attr( "title", "" )
+                            .attr( "title", "")
+                            .attr("id", "input_url")
                             .addClass( "" )
                             .autocomplete({
                                 delay: 0,

--- a/ref_ts/ts_utils.py
+++ b/ref_ts/ts_utils.py
@@ -457,7 +457,7 @@ def QueryHydroServerGetParsedWML(service_url, soap_or_rest, site_code=None, vari
             client = connect_wsdl_url(service_url)
             response = client.service.GetValues(site_code, variable_code, start_date, end_date, auth_token)
         elif soap_or_rest == 'rest':
-            r = requests.get(service_url)
+            r = requests.get(service_url, verify=False)
             if r.status_code != 200:
                 raise Exception("Query REST endpoint failed")
             response = r.text.encode('utf-8')

--- a/ref_ts/views.py
+++ b/ref_ts/views.py
@@ -161,7 +161,7 @@ def verify_rest_url(request):
         if f.is_valid():
             params = f.cleaned_data
             url = params['url']
-            ts = requests.get(url)
+            ts = requests.get(url, verify=False)
             ts_xml = etree.XML(ts.text.encode('utf-8'))
             if ts.status_code == 200 and 'timeseriesresponse' in ts_xml.tag.lower():
                 return json_or_jsonp(request, {"status": "success"})


### PR DESCRIPTION
We found the existing RefTS code already has the ability to accept any urls that can return wml content. The failing on some urls was because those urls are served via HTTPS.  The Requests module we are using by default blocks all https connections if no certificate file are provided. 
The changes we made to the backend are very simply. We simply set "verify=False" to let Requests lib ignore verifying ssl certificate, so it will accept both http urls and https urls. 

But we are not sure will this simply change leave any serious security issues?thanks @hyi @pkdash @mjstealey 

The other changes are all UI improvements, 
@jsadler2 can you please review the frontend? thanks


  