### PR TITLE
[#1283] add django-heartbeat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mjstealey/hs_docker_base:1.7.0
 MAINTAINER Michael J. Stealey <stealey@renci.org>
 
 ### Begin - HydroShare Development Image Additions ###
-
+RUN pip install django-heartbeat
 ### End - HydroShare Development Image Additions ###
 
 USER root

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -266,6 +266,7 @@ INSTALLED_APPS = (
     "django_irods",
     "theme",
     "theme.blog_mods",
+    "heartbeat",
     "mezzanine.boot",
     "mezzanine.conf",
     "mezzanine.core",

--- a/hydroshare/urls.py
+++ b/hydroshare/urls.py
@@ -81,6 +81,13 @@ if settings.DEBUG is False:   #if DEBUG is True it will be served automatically
   url(r'^static/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.STATIC_ROOT}),
 )
 
+if 'heartbeat' in settings.INSTALLED_APPS:
+  from heartbeat.urls import urlpatterns as heartbeat_urls
+
+  urlpatterns += [
+    url(r'^heartbeat/', include(heartbeat_urls))
+  ]
+
 urlpatterns += patterns('',
 
     # We don't want to presume how your homepage works, so here are a


### PR DESCRIPTION
Implement simple heartbeat monitor for deployed sites.
Reference: [https://github.com/pbs/django-heartbeat](https://github.com/pbs/django-heartbeat)

**Jenkins**
Follow on job would be configured in Jenkins to poll the status of the /heartbeat/ results every 5 mins.
- Attempt a restart on failure
- Email admin team on failure and on successful restart