### PR TITLE
1274 test user cascade delete

### DIFF
--- a/hs_access_control/models.py
+++ b/hs_access_control/models.py
@@ -2281,7 +2281,7 @@ class GroupMembershipRequest(models.Model):
     request_from = models.ForeignKey(User, related_name='ru2gmrequest')
 
     # when user is requesting to join a group this will be blank
-    # when a group owner sending invitation, this field will have a value
+    # when a group owner is sending an invitation, this field will represent the inviting user
     invitation_to = models.ForeignKey(User, null=True, blank=True, related_name='iu2gmrequest')
     group_to_join = models.ForeignKey(Group, related_name='g2gmrequest')
     date_requested = models.DateTimeField(editable=False, auto_now_add=True)

--- a/hs_access_control/tests/test_user_delete.py
+++ b/hs_access_control/tests/test_user_delete.py
@@ -101,7 +101,11 @@ class T12UserDelete(MockIRODSTestCaseMixin, TestCase):
         self.assertEqual(GroupAccess.objects.filter(id=agid).count(), 1)
         self.assertEqual(Group.objects.filter(id=ogid).count(), 1)
 
-        # these two tests will fail for an unknown reason
+        # the following tests will fail, because the resource field
+        # "creator" is a foreign key to User with on_delete=models.CASCADE
+        # and null=False. Thus removing the creator of a resource will
+        # remove the resource record (and orphan many files in the process).
+
         # print('resource access count is ', ResourceAccess.objects.filter(id=arid).count())
         # print('resource count is ', BaseResource.objects.filter(id=orid).count())
         # self.assertEqual(ResourceAccess.objects.filter(id=arid).count(), 1)

--- a/hs_access_control/tests/test_user_delete.py
+++ b/hs_access_control/tests/test_user_delete.py
@@ -2,7 +2,8 @@
 from django.test import TestCase
 from django.contrib.auth.models import Group
 
-from hs_access_control.models import UserAccess
+from hs_access_control.models import UserAccess, GroupAccess, ResourceAccess, \
+     UserGroupPrivilege, UserResourcePrivilege, GroupMembershipRequest
 
 from hs_core import hydroshare
 from hs_core.testing import MockIRODSTestCaseMixin
@@ -33,12 +34,63 @@ class T12UserDelete(MockIRODSTestCaseMixin, TestCase):
             groups=[]
         )
 
+        self.scratching = hydroshare.create_resource(
+            resource_type='GenericResource',
+            owner=self.cat,
+            title='all about sofas as scratching posts',
+            metadata=[]
+        )
+
+        self.felines = self.cat.uaccess.create_group(
+            title='felines',
+            description="We are the felines"
+        )
+
+        self.dog = hydroshare.create_account(
+            'dog@gmail.com',
+            username='dog',
+            first_name='a little arfer',
+            last_name='last_name_dog',
+            superuser=False,
+            groups=[]
+        )
+
+        self.arfers = self.dog.uaccess.create_group(
+            title='arfers',
+            description='animals that bark'
+        )
+
+        self.cat.uaccess.create_group_membership_request(self.arfers)
+
     def test_00_cascade(self):
         "Deleting a user cascade-deletes its access control"
+        # This tests that deleting a user cleans up its access control.
+        # Note that deleting the sole owner of a resource or group
+        # leaves it orphaned. This is not prevented.
         cat = self.cat
-        caccess = cat.uaccess
-        id = caccess.id
 
-        self.assertEqual(UserAccess.objects.filter(id=id).count(), 1)
+        # get the id's of all objects that should be deleted.
+        uid = cat.uaccess.id
+        rid = self.scratching.raccess.id
+        gid = self.felines.gaccess.id
+        gpid = UserGroupPrivilege.objects.get(user=cat).id
+        rpid = UserResourcePrivilege.objects.get(user=cat).id
+        mpid = GroupMembershipRequest.objects.get(request_from=cat).id
+
+        # all objects exist before the delete
+        self.assertEqual(UserAccess.objects.filter(id=uid).count(), 1)
+        self.assertEqual(ResourceAccess.objects.filter(id=rid).count(), 1)
+        self.assertEqual(GroupAccess.objects.filter(id=gid).count(), 1)
+        self.assertEqual(UserGroupPrivilege.objects.filter(id=gpid).count(), 1)
+        self.assertEqual(UserResourcePrivilege.objects.filter(id=rpid).count(), 1)
+        self.assertEqual(GroupMembershipRequest.objects.filter(id=mpid).count(), 1)
+
         cat.delete()
-        self.assertEqual(UserAccess.objects.filter(id=id).count(), 0)
+
+        # objects tied to the user are deleted, other objects continue to exist
+        self.assertEqual(UserAccess.objects.filter(id=uid).count(), 0)
+        self.assertEqual(ResourceAccess.objects.filter(id=rid).count(), 1)
+        self.assertEqual(GroupAccess.objects.filter(id=gid).count(), 1)
+        self.assertEqual(UserGroupPrivilege.objects.filter(id=gpid).count(), 0)
+        self.assertEqual(UserResourcePrivilege.objects.filter(id=rpid).count(), 0)
+        self.assertEqual(GroupMembershipRequest.objects.filter(id=mpid).count(), 0)

--- a/hs_access_control/tests/test_user_delete.py
+++ b/hs_access_control/tests/test_user_delete.py
@@ -101,7 +101,7 @@ class T12UserDelete(MockIRODSTestCaseMixin, TestCase):
         self.assertEqual(GroupAccess.objects.filter(id=agid).count(), 1)
         self.assertEqual(Group.objects.filter(id=ogid).count(), 1)
 
-        # these two tests will fail for an unknown reason 
+        # these two tests will fail for an unknown reason
         # print('resource access count is ', ResourceAccess.objects.filter(id=arid).count())
         # print('resource count is ', BaseResource.objects.filter(id=orid).count())
         # self.assertEqual(ResourceAccess.objects.filter(id=arid).count(), 1)

--- a/hs_access_control/tests/test_user_delete.py
+++ b/hs_access_control/tests/test_user_delete.py
@@ -1,19 +1,12 @@
 
-import unittest
-from django.http import Http404
 from django.test import TestCase
-from django.utils import timezone
-# from django.core.exceptions import PermissionDenied
-from django.contrib.auth.models import User, Group
-from pprint import pprint
+from django.contrib.auth.models import Group
 
-from hs_access_control.models import UserAccess, GroupAccess, ResourceAccess
+from hs_access_control.models import UserAccess
 
 from hs_core import hydroshare
-from hs_core.models import GenericResource, BaseResource
 from hs_core.testing import MockIRODSTestCaseMixin
-
-from hs_access_control.tests.utilities import *
+from hs_access_control.tests.utilities import global_reset
 
 
 class T12UserDelete(MockIRODSTestCaseMixin, TestCase):
@@ -43,11 +36,9 @@ class T12UserDelete(MockIRODSTestCaseMixin, TestCase):
     def test_00_cascade(self):
         "Deleting a user cascade-deletes its access control"
         cat = self.cat
-        caccess = cat.uaccess 
-	id = caccess.id
+        caccess = cat.uaccess
+        id = caccess.id
 
-        self.assertEqual(UserAccess.objects.filter(id=id).count(), 1) 
+        self.assertEqual(UserAccess.objects.filter(id=id).count(), 1)
         cat.delete()
-        self.assertEqual(UserAccess.objects.filter(id=id).count(), 0) 
-
-
+        self.assertEqual(UserAccess.objects.filter(id=id).count(), 0)

--- a/hs_access_control/tests/test_user_delete.py
+++ b/hs_access_control/tests/test_user_delete.py
@@ -44,8 +44,10 @@ class T12UserDelete(MockIRODSTestCaseMixin, TestCase):
         "Deleting a user cascade-deletes its access control"
         cat = self.cat
         caccess = cat.uaccess 
+	id = caccess.id
 
+        self.assertEqual(UserAccess.objects.filter(id=id).count(), 1) 
         cat.delete()
-        self.assertEqual(UserAccess.objects.filter(id=caccess), []) 
+        self.assertEqual(UserAccess.objects.filter(id=id).count(), 0) 
 
 


### PR DESCRIPTION
@mjstealey Handles issue #1274. **Answer is yes, deleting a user deletes the access control information for that user.** 

User.delete() correctly cascades to deleting UserAccess records in access control. This test proves that. 

The fact that UserAccess deletion cascades to delete UserAccess records from Groups and Resources is tested elsewhere. 