### PR TITLE
clean up temp files for bag and files retrieved from federation zone

### DIFF
--- a/hs_app_netCDF/receivers.py
+++ b/hs_app_netCDF/receivers.py
@@ -1,6 +1,7 @@
 import re
 import os
 import StringIO
+import shutil
 
 import netCDF4
 
@@ -155,6 +156,9 @@ def netcdf_pre_create_resource(sender, **kwargs):
         else:
             validate_files_dict['are_files_valid'] = False
             validate_files_dict['message'] = 'Please check if the uploaded file is in valid NetCDF format.'
+
+        if fed_res_fnames and in_file_name:
+            shutil.rmtree(os.path.dirname(in_file_name))
 
 
 # # receiver used to create netcdf header text after user click on "create resource"
@@ -382,6 +386,9 @@ def netcdf_pre_add_files_to_resource(sender, **kwargs):
         else:
             validate_files_dict['are_files_valid'] = False
             validate_files_dict['message'] = 'Please check if the uploaded file is in valid NetCDF format.'
+
+        if fed_res_fnames and in_file_name:
+            shutil.rmtree(os.path.dirname(in_file_name))
 
 # @receiver(post_add_files_to_resource, sender=NetcdfResource)
 # def netcdf_post_add_files_to_resource(sender, **kwargs):

--- a/hs_app_timeseries/receivers.py
+++ b/hs_app_timeseries/receivers.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import shutil
 
 from django.core.exceptions import ValidationError
 from django.dispatch import receiver
@@ -77,7 +78,8 @@ def post_add_files_to_resource_handler(sender, **kwargs):
                 if extract_metadata:
                     validate_err_message += " (Metadata was not extracted)"
                 validate_files_dict['message'] = validate_err_message
-
+        if res_file.fed_resource_file_name_or_path and fl_obj_name:
+            shutil.rmtree(os.path.dirname(fl_obj_name))
 
 @receiver(post_create_resource, sender=TimeSeriesResource)
 def post_create_resource_handler(sender, **kwargs):
@@ -102,6 +104,8 @@ def post_create_resource_handler(sender, **kwargs):
                 validate_files_dict['are_files_valid'] = False
                 validate_files_dict['message'] = validate_err_message + " (Metadata was not extracted)"
 
+        if res_file.fed_resource_file_name_or_path and fl_obj_name:
+            shutil.rmtree(os.path.dirname(fl_obj_name))
 
 @receiver(pre_metadata_element_create, sender=TimeSeriesResource)
 def metadata_element_pre_create_handler(sender, **kwargs):

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -211,8 +211,7 @@ def create_bag_files(resource, fed_zone_home_path=''):
 
     istorage.saveFile(from_file_name, to_file_name, False)
 
-    shutil.rmtree(bagit_path)
-
+    shutil.rmtree(dest_prefix)
     return istorage
 
 

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -7,7 +7,7 @@ import tempfile
 import logging
 import shutil
 import string
-import arrow
+from uuid import uuid4
 import errno
 
 from django.apps import apps
@@ -219,7 +219,7 @@ def get_fed_zone_files(irods_fnames):
     irods_storage = IrodsStorage('federated')
     for ifname in ifnames:
         fname = os.path.basename(ifname.rstrip(os.sep))
-        tmpdir = os.path.join(settings.TEMP_FILE_DIR, arrow.utcnow().format("YYYY.MM.DD.HH.mm.ss"))
+        tmpdir = os.path.join(settings.TEMP_FILE_DIR, uuid4().hex)
         tmpfile = os.path.join(tmpdir, fname)
         try:
             os.makedirs(tmpdir)

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -7,6 +7,8 @@ import tempfile
 import logging
 import shutil
 import string
+import arrow
+import errno
 
 from django.apps import apps
 from django.http import Http404
@@ -217,7 +219,16 @@ def get_fed_zone_files(irods_fnames):
     irods_storage = IrodsStorage('federated')
     for ifname in ifnames:
         fname = os.path.basename(ifname.rstrip(os.sep))
-        tmpfile = os.path.join(settings.TEMP_FILE_DIR, fname)
+        tmpdir = os.path.join(settings.TEMP_FILE_DIR, arrow.utcnow().format("YYYY.MM.DD.HH.mm.ss"))
+        tmpfile = os.path.join(tmpdir, fname)
+        try:
+            os.makedirs(tmpdir)
+        except OSError as ex:
+            if ex.errno == errno.EEXIST:
+                shutil.rmtree(tmpdir)
+                os.makedirs(tmpdir)
+            else:
+                raise Exception(ex.message)
         irods_storage.getFile(ifname, tmpfile)
         ret_file_list.append(tmpfile)
     return ret_file_list

--- a/hs_geo_raster_resource/receivers.py
+++ b/hs_geo_raster_resource/receivers.py
@@ -172,13 +172,17 @@ def raster_pre_create_resource_trigger(sender, **kwargs):
         error_info, vrt_file_path, temp_dir = raster_file_validation(files)
     elif fed_res_fnames:
         ref_tmpfiles = utils.get_fed_zone_files(fed_res_fnames)
+        fed_tmpfile_name = ref_tmpfiles[0]
         # raster file validation
         error_info, vrt_file_path, temp_dir = raster_file_validation(files, ref_tmp_file_names=ref_tmpfiles)
         ext = os.path.splitext(fed_res_fnames[0])[1]
         if ext == '.zip':
             # clear up the original zip file so that it will not be added into the resource
             fed_res_path.append(utils.get_federated_zone_home_path(fed_res_fnames[0]))
+            # remove the temp zip file retrieved from federated zone
+            shutil.rmtree(os.path.dirname(fed_tmpfile_name))
             del fed_res_fnames[0]
+
         file_selected = True
 
     if file_selected:
@@ -210,7 +214,9 @@ def raster_pre_create_resource_trigger(sender, **kwargs):
         # remove temp vrt file
         if os.path.isdir(temp_dir):
             shutil.rmtree(temp_dir)
-
+        # remove temp file retrieved from federated zone for metadata extraction
+        if fed_res_fnames and fed_tmpfile_name:
+            shutil.rmtree(os.path.dirname(fed_tmpfile_name))
     else:
         # initialize required raster metadata to be place holders to be edited later by users
         cell_info = OrderedDict([
@@ -261,10 +267,13 @@ def raster_pre_add_files_to_resource_trigger(sender, **kwargs):
         error_info, vrt_file_path, temp_dir = raster_file_validation(files)
     elif fed_res_fnames:
         ref_tmpfiles = utils.get_fed_zone_files(fed_res_fnames)
+        fed_tmpfile_name = ref_tmpfiles[0]
         # raster file validation
         error_info, vrt_file_path, temp_dir = raster_file_validation(files, ref_tmp_file_names=ref_tmpfiles)
         ext = os.path.splitext(fed_res_fnames[0])[1]
         if ext == '.zip':
+            # remove the temp zip file retrieved from federated zone
+            shutil.rmtree(os.path.dirname(fed_tmpfile_name))
             # clear up the original zip file so that it will not be added into the resource
             del fed_res_fnames[0]
         file_selected = True
@@ -316,7 +325,9 @@ def raster_pre_add_files_to_resource_trigger(sender, **kwargs):
         # remove temp dir
         if os.path.isdir(temp_dir):
             shutil.rmtree(temp_dir)
-
+        # remove the temp file retrieved from federated zone for metadata extraction
+        if fed_res_fnames and fed_tmpfile_name:
+            shutil.rmtree(os.path.dirname(fed_tmpfile_name))
 
 @receiver(pre_delete_file_from_resource, sender=RasterResource)
 def raster_pre_delete_file_from_resource_trigger(sender, **kwargs):


### PR DESCRIPTION
This PR fixed the issue of temp files or empty directories lingering around in /tmp directory as @mjstealey @pkdash and I found in the beta pre-deploy session together. Now /tmp/hydroshare directory will be cleaned up every time as well as all files retrieved from a federated zone for metadata extraction. Have tested all scenarios and made sure no temp files lingering around after resource is created or after a file is added to the resource. I will have to work on iRODS environment session JSON temp file clean up after I return from my vacation, but want to get this fix in first before I leave for vacation since files retrieve from a federated zone may be very big which will cause us disk space issues. This PR also fixed potential name clash issue. @pkdash Can you do a code review when you get a chance? @zhiyuli It'd be great if you can take a look at this PR as well especially for feature resource type to make sure what I did looks good to you although I did test all workflows and everything works as expected.  