### PR TITLE
REST API metadata support for resource creation

### DIFF
--- a/hs_core/forms.py
+++ b/hs_core/forms.py
@@ -827,6 +827,13 @@ class IdentifierForm(ModelForm):
         # fields that will be displayed are specified here - but not necessarily in the same order
         fields = ['name', 'url']
 
+    def clean(self):
+        data = self.cleaned_data
+        if data['name'].lower() == 'hydroshareidentifier':
+            raise forms.ValidationError("Identifier name attribute can't have a value "
+                                        "of '{}'.".format(data['name']))
+        return data
+
 
 class FormatFormSetHelper(FormHelper):
     def __init__(self, *args, **kwargs):

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -568,8 +568,8 @@ def prepare_resource_default_metadata(resource, metadata, res_title):
         metadata.append({'rights': {'statement': statement, 'url': url}})
 
     metadata.append({'identifier': {'name': 'hydroShareIdentifier',
-                                    'url': '{0}/resource{1}{2}'.format(current_site_url(), '/',
-                                                                       resource.short_id)}})
+                                    'url': '{0}/resource/{1}'.format(current_site_url(),
+                                                                     resource.short_id)}})
 
     # remove if there exists the 'type' element as system generates this element
     # remove if there exists 'format' elements - since format elements are system generated based

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -454,6 +454,8 @@ def resource_pre_create_actions(resource_type, resource_title, page_redirect_url
                                 files=(), fed_res_file_names='', metadata=None,
                                 requesting_user=None, **kwargs):
     from.resource import check_resource_type
+    from hs_core.views.utils import validate_metadata
+
     if not resource_title:
         resource_title = 'Untitled resource'
     else:
@@ -469,6 +471,9 @@ def resource_pre_create_actions(resource_type, resource_title, page_redirect_url
 
     if not metadata:
         metadata = []
+    else:
+        validate_metadata(metadata, resource_type)
+
     page_url_dict = {}
     # this is needed since raster and feature resource types allows to upload a zip file,
     # then replace zip file with exploded files. If the zip file is loaded from hydroshare

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -895,7 +895,6 @@ class Coverage(AbstractMetaDataElement):
         data for the coverage value attribute must be provided as a dictionary
         """
 
-        # TODO: validate coordinate values
         cov = Coverage.objects.get(id=element_id)
 
         changing_coverage_type = False

--- a/hs_core/receivers.py
+++ b/hs_core/receivers.py
@@ -34,9 +34,14 @@ def metadata_element_pre_create_handler(sender, **kwargs):
         element_form = FundingAgencyValidationForm(request.POST)
     elif element_name == 'coverage':
         if 'type' in request.POST:
-            element_form = CoverageSpatialForm(data=request.POST)
+            if request.POST['type'].lower() == 'point' or  request.POST['type'].lower() == 'box':
+                element_form = CoverageSpatialForm(data=request.POST)
+            else:
+                element_form = CoverageTemporalForm(data=request.POST)
         else:
             element_form = CoverageTemporalForm(data=request.POST)
+    else:
+        raise Exception("Invalid metadata element name:{}".format(element_name))
 
     if element_form.is_valid():
         return {'is_valid': True, 'element_data_dict': element_form.cleaned_data}

--- a/hs_core/receivers.py
+++ b/hs_core/receivers.py
@@ -1,20 +1,24 @@
 
-## Note: this module has been imported in the models.py in order to receive signals
-## se the end of the models.py for the import of this module
+# Note: this module has been imported in the models.py in order to receive signals
+# se the end of the models.py for the import of this module
 
 from django.dispatch import receiver
 from hs_core.signals import pre_metadata_element_create, pre_metadata_element_update
-from hs_core.models import BaseResource
-from forms import *
+from hs_core.models import GenericResource
+from forms import SubjectsForm, AbstractValidationForm, CreatorValidationForm, \
+    ContributorValidationForm, RelationValidationForm, SourceValidationForm, RightsValidationForm, \
+    LanguageValidationForm, ValidDateValidationForm, FundingAgencyValidationForm, \
+    CoverageSpatialForm, CoverageTemporalForm, IdentifierForm, TitleValidationForm
+
 
 # This handler is executed only when a metadata element is added as part of editing a resource
 @receiver(pre_metadata_element_create, sender=GenericResource)
 def metadata_element_pre_create_handler(sender, **kwargs):
     element_name = kwargs['element_name']
     request = kwargs['request']
-    if element_name == "subject":   #keywords
+    if element_name == "subject":   # keywords
         element_form = SubjectsForm(data=request.POST)
-    elif element_name == "description":   #abstract
+    elif element_name == "description":   # abstract
         element_form = AbstractValidationForm(request.POST)
     elif element_name == "creator":
         element_form = CreatorValidationForm(request.POST)
@@ -34,7 +38,7 @@ def metadata_element_pre_create_handler(sender, **kwargs):
         element_form = FundingAgencyValidationForm(request.POST)
     elif element_name == 'coverage':
         if 'type' in request.POST:
-            if request.POST['type'].lower() == 'point' or  request.POST['type'].lower() == 'box':
+            if request.POST['type'].lower() == 'point' or request.POST['type'].lower() == 'box':
                 element_form = CoverageSpatialForm(data=request.POST)
             else:
                 element_form = CoverageTemporalForm(data=request.POST)
@@ -50,11 +54,11 @@ def metadata_element_pre_create_handler(sender, **kwargs):
     else:
         return {'is_valid': False, 'element_data_dict': None}
 
+
 # This handler is executed only when a metadata element is added as part of editing a resource
 @receiver(pre_metadata_element_update, sender=GenericResource)
 def metadata_element_pre_update_handler(sender, **kwargs):
     element_name = kwargs['element_name'].lower()
-    element_id = kwargs['element_id']
     request = kwargs['request']
     repeatable_elements = {'creator': CreatorValidationForm,
                            'contributor': ContributorValidationForm,
@@ -64,14 +68,14 @@ def metadata_element_pre_update_handler(sender, **kwargs):
 
     if element_name == 'title':
         element_form = TitleValidationForm(request.POST)
-    elif element_name == "description":   #abstract
+    elif element_name == "description":   # abstract
         element_form = AbstractValidationForm(request.POST)
     elif element_name == "fundingagency":
         element_form = FundingAgencyValidationForm(request.POST)
     elif element_name in repeatable_elements:
-        # since element_name is a repeatable element (e.g creator) and data for the element is displayed on the
-        # landing page using formset, the data coming from a single element form in the request for update
-        # needs to be parsed to match with element field names
+        # since element_name is a repeatable element (e.g creator) and data for the element
+        # is displayed on the landing page using formset, the data coming from a single element
+        # form in the request for update needs to be parsed to match with element field names
         element_validation_form = repeatable_elements[element_name]
         form_data = {}
         for field_name in element_validation_form().fields:

--- a/hs_core/receivers.py
+++ b/hs_core/receivers.py
@@ -40,6 +40,8 @@ def metadata_element_pre_create_handler(sender, **kwargs):
                 element_form = CoverageTemporalForm(data=request.POST)
         else:
             element_form = CoverageTemporalForm(data=request.POST)
+    elif element_name == 'identifier':
+        element_form = IdentifierForm(data=request.POST)
     else:
         raise Exception("Invalid metadata element name:{}".format(element_name))
 
@@ -100,6 +102,10 @@ def metadata_element_pre_update_handler(sender, **kwargs):
             element_form = CoverageSpatialForm(data=request.POST)
         else:
             element_form = CoverageTemporalForm(data=request.POST)
+    elif element_name == 'identifier':
+        element_form = IdentifierForm(data=request.POST)
+    else:
+        raise Exception("Invalid metadata element name:{}".format(element_name))
 
     if element_form.is_valid():
         return {'is_valid': True, 'element_data_dict': element_form.cleaned_data}

--- a/hs_core/tests/api/rest/test_create_resource.py
+++ b/hs_core/tests/api/rest/test_create_resource.py
@@ -95,9 +95,9 @@ class TestCreateResource(HSRESTTestCase):
 
         # fundingagency
         agency_name = 'NSF'
-        award_title="Cyber Infrastructure"
-        award_number="NSF-101-20-6789"
-        agency_url="http://www.nsf.gov"
+        award_title = "Cyber Infrastructure"
+        award_number = "NSF-101-20-6789"
+        agency_url = "http://www.nsf.gov"
         metadata.append({'fundingagency': {'agency_name': agency_name, 'award_title': award_title,
                                            'award_number': award_number, 'agency_url': agency_url}})
         params = {'resource_type': rtype,
@@ -296,7 +296,6 @@ class TestCreateResource(HSRESTTestCase):
         params = self._get_params(rtype, title, metadata)
         self._test_not_allowed_element(params)
 
-
     def _get_params(self, rtype, title, metadata):
         params = {'resource_type': rtype,
                   'title': title,
@@ -310,4 +309,3 @@ class TestCreateResource(HSRESTTestCase):
         rest_url = '/hsapi/resource/'
         response = self.client.post(rest_url, params)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-

--- a/hs_core/tests/api/rest/test_create_resource.py
+++ b/hs_core/tests/api/rest/test_create_resource.py
@@ -1,4 +1,5 @@
 import json
+from dateutil import parser
 
 from rest_framework import status
 
@@ -114,6 +115,11 @@ class TestCreateResource(HSRESTTestCase):
         resource = get_resource_by_shortkey(res_id)
         self.assertEqual(resource.metadata.coverages.all().count(), 1)
         self.assertEqual(resource.metadata.coverages.filter(type='period').count(), 1)
+        coverage = resource.metadata.coverages.all().first()
+        self.assertEqual(parser.parse(coverage.value['start']).date(),
+                         parser.parse('01/01/2000').date())
+        self.assertEqual(parser.parse(coverage.value['end']).date(),
+                         parser.parse('12/12/2010').date())
         self.assertEqual(resource.metadata.rights.statement, statement)
         self.assertEqual(resource.metadata.rights.url, url)
         self.assertEqual(resource.metadata.language.code, 'fre')

--- a/hs_core/tests/api/rest/test_create_resource.py
+++ b/hs_core/tests/api/rest/test_create_resource.py
@@ -171,7 +171,7 @@ class TestCreateResource(HSRESTTestCase):
 
         originalcoverage
         variable
-        
+
         """
         rtype = 'NetcdfResource'
         title = 'My Test resource'
@@ -230,3 +230,84 @@ class TestCreateResource(HSRESTTestCase):
         self.assertEqual(variable.method, var_method)
 
         self.resources_to_delete.append(res_id)
+
+    def test_create_resource_not_allowed_valid_metadata_elements(self):
+        """
+        This is to test that the following core valid metadata elements can't be passed using the
+        'metadata' parameter
+
+        title
+        description (abstract)
+        subject (keyword)
+        format
+        date
+        publisher
+        type
+
+        :return:
+        """
+
+        rtype = 'GenericResource'
+        title = 'My Test resource'
+        # test title
+        metadata = []
+        metadata.append({'title': {'value': "This is a generic resource"}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+        # test description
+        metadata = []
+        metadata.append({'description': {'abstract': "This is a great resource"}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+        # test subject
+        metadata = []
+        metadata.append({'subject': {'value': "sample"}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+        # test format
+        metadata = []
+        metadata.append({'format': {'value': 'text/csv'}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+        # test date
+        metadata = []
+        metadata.append({'date': {'type': 'created', 'start_date': '01/01/2016'}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+        metadata = []
+        metadata.append({'date': {'type': 'modified', 'start_date': '01/01/2016'}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+        # test publisher
+        metadata = []
+        metadata.append({'publisher': {'name': 'USGS', 'url': 'http://usgs.gov'}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+        # test type
+        metadata = []
+        metadata.append({'type': {'url': "http://hydroshare.org/generic"}})
+        params = self._get_params(rtype, title, metadata)
+        self._test_not_allowed_element(params)
+
+
+    def _get_params(self, rtype, title, metadata):
+        params = {'resource_type': rtype,
+                  'title': title,
+                  'metadata': json.dumps(metadata),
+                  'file': ('cea.tif',
+                           open('hs_core/tests/data/cea.tif'),
+                           'image/tiff')}
+        return params
+
+    def _test_not_allowed_element(self, params):
+        rest_url = '/hsapi/resource/'
+        response = self.client.post(rest_url, params)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+

--- a/hs_core/tests/api/rest/test_create_resource.py
+++ b/hs_core/tests/api/rest/test_create_resource.py
@@ -2,6 +2,7 @@ import json
 
 from rest_framework import status
 
+from hs_core.hydroshare.utils import get_resource_by_shortkey
 from .base import HSRESTTestCase
 
 
@@ -35,4 +36,131 @@ class TestCreateResource(HSRESTTestCase):
         response = self.getResourceBag(res_id)
         self.assertEqual(response['Content-Type'], 'application/zip')
         self.assertTrue(int(response['Content-Length']) > 0)
+
+    def test_resource_create_with_core_metadata(self):
+        """
+        The followings are the core metadata elements that can be passed as part of the
+        'metadata' parameter when creating a resource:
+
+        coverage
+        creator
+        contributor
+        source,
+        relation,
+        identifier,
+        fundingagency
+
+        """
+        rtype = 'GenericResource'
+        title = 'My Test resource'
+        metadata = []
+        metadata.append({'coverage': {'type': 'period', 'value': {'start': '01/01/2000',
+                                                                  'end': '12/12/2010'}}})
+        statement = 'This resource is shared under the Creative Commons Attribution CC BY.'
+        url = 'http://creativecommons.org/licenses/by/4.0/'
+        metadata.append({'rights': {'statement': statement, 'url': url}})
+        metadata.append({'language': {'code': 'fre'}})
+
+        # contributor
+        con_name = 'Mike Sundar'
+        con_org = "USU"
+        con_email = 'mike.sundar@usu.edu'
+        con_address = "11 River Drive, Logan UT-84321, USA"
+        con_phone = '435-567-0989'
+        con_homepage = 'http://usu.edu/homepage/001'
+        metadata.append({'contributor': {'name': con_name,
+                                         'organization': con_org, 'email': con_email,
+                                         'address': con_address, 'phone': con_phone,
+                                         'homepage': con_homepage}})
+
+        # creator
+        cr_name = 'John Smith'
+        cr_org = "USU"
+        cr_email = 'jsmith@gmail.com'
+        cr_address = "101 Clarson Ave, Provo UT-84321, USA"
+        cr_phone = '801-567=9090'
+        cr_homepage = 'http://byu.edu/homepage/002'
+        metadata.append({'creator': {'name': cr_name, 'organization': cr_org,
+                                     'email': cr_email, 'address': cr_address,
+                                     'phone': cr_phone, 'homepage': cr_homepage}})
+
+        # relation
+        metadata.append({'relation': {'type': 'isPartOf',
+                                      'value': 'http://hydroshare.org/resource/001'}})
+        # source
+        metadata.append({'source': {'derived_from': 'http://hydroshare.org/resource/0001'}})
+
+        # identifier
+        metadata.append({'identifier': {'name': 'someIdentifier', 'url': 'http://some.org/001'}})
+
+        # fundingagency
+        agency_name = 'NSF'
+        award_title="Cyber Infrastructure"
+        award_number="NSF-101-20-6789"
+        agency_url="http://www.nsf.gov"
+        metadata.append({'fundingagency': {'agency_name': agency_name, 'award_title': award_title,
+                                           'award_number': award_number, 'agency_url': agency_url}})
+        params = {'resource_type': rtype,
+                  'title': title,
+                  'metadata': json.dumps(metadata),
+                  'file': ('cea.tif',
+                           open('hs_core/tests/data/cea.tif'),
+                           'image/tiff')}
+        rest_url = '/hsapi/resource/'
+        response = self.client.post(rest_url, params)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        content = json.loads(response.content)
+        res_id = content['resource_id']
+        resource = get_resource_by_shortkey(res_id)
+        self.assertEqual(resource.metadata.coverages.all().count(), 1)
+        self.assertEqual(resource.metadata.coverages.filter(type='period').count(), 1)
+        self.assertEqual(resource.metadata.rights.statement, statement)
+        self.assertEqual(resource.metadata.rights.url, url)
+        self.assertEqual(resource.metadata.language.code, 'fre')
+
+        # there should be 1 contributor
+        self.assertEqual(resource.metadata.contributors.all().count(), 1)
+        contributor = resource.metadata.contributors.all().first()
+        self.assertEqual(contributor.name, con_name)
+        self.assertEqual(contributor.organization, con_org)
+        self.assertEqual(contributor.email, con_email)
+        self.assertEqual(contributor.address, con_address)
+        self.assertEqual(contributor.phone, con_phone)
+        self.assertEqual(contributor.homepage, con_homepage)
+
+        # there should be 2 creators
+        self.assertEqual(resource.metadata.creators.all().count(), 2)
+        creator = resource.metadata.creators.filter(name=cr_name).first()
+        self.assertEqual(creator.name, cr_name)
+        self.assertEqual(creator.organization, cr_org)
+        self.assertEqual(creator.email, cr_email)
+        self.assertEqual(creator.address, cr_address)
+        self.assertEqual(creator.phone, cr_phone)
+        self.assertEqual(creator.homepage, cr_homepage)
+
+        # there should be 1 relation element
+        self.assertEqual(resource.metadata.relations.all().count(), 1)
+        relation = resource.metadata.relations.all().first()
+        self.assertEqual(relation.type, 'isPartOf')
+        self.assertEqual(relation.value, 'http://hydroshare.org/resource/001')
+
+        # there should be 1 source element
+        self.assertEqual(resource.metadata.sources.all().count(), 1)
+        source = resource.metadata.sources.all().first()
+        self.assertEqual(source.derived_from, 'http://hydroshare.org/resource/0001')
+
+        # there should be 2 identifiers
+        self.assertEqual(resource.metadata.identifiers.all().count(), 2)
+        identifier = resource.metadata.identifiers.filter(name='someIdentifier').first()
+        self.assertEqual(identifier.url, 'http://some.org/001')
+
+        # there should be 1 fundingagency
+        self.assertEqual(resource.metadata.funding_agencies.all().count(), 1)
+        agency = resource.metadata.funding_agencies.all().first()
+        self.assertEqual(agency.agency_name, agency_name)
+        self.assertEqual(agency.award_title, award_title)
+        self.assertEqual(agency.award_number, award_number)
+        self.assertEqual(agency.agency_url, agency_url)
+
+        self.resources_to_delete.append(res_id)
 

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -301,6 +301,13 @@ class ResourceCreate(generics.CreateAPIView):
     permission for the resource
     :param  view_groups: (optional) list of comma separated group names that should have view
     permission for the resource
+    :param  metadata: (optional) data for any valid metadata element including resource specific
+    metadata elements can be passed as json string:
+    example (passing data for the 'Coverage' element):
+    [{'coverage':{'type': 'period', 'start': '01/01/2000', 'end': '12/12/2010'}}, ...]
+    Note: the parameter 'metadata' can't be used for passing data for the following core metadata
+    elements:
+    Title, Description (abstract), Subject (keyword), Date, Publisher, Type, Format
     :return: id and type of the resource created
     :rtype: json string of the format: {'resource-id':id, 'resource_type': resource type}
     :raises:

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -841,7 +841,7 @@ def _validate_metadata(metadata_list):
     """
 
     err_message = "Metadata validation failed. Metadata element '{}' was found in value passed " \
-                  "for parameter 'metadata. Though it's a valid element it can't be passed " \
+                  "for parameter 'metadata'. Though it's a valid element it can't be passed " \
                   "as part of 'metadata' parameter."
     for element in metadata_list:
         # here k is the name of the element

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -17,7 +17,8 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import generics
 from rest_framework.request import Request
-from rest_framework.exceptions import *
+from rest_framework.exceptions import ValidationError, NotAuthenticated, PermissionDenied, NotFound
+from rest_framework import status
 
 from hs_core import hydroshare
 from hs_core.models import AbstractResource
@@ -27,7 +28,8 @@ from hs_core.views.utils import ACTION_TO_AUTHORIZE
 from hs_core.views import serializers
 from hs_core.views import pagination
 from hs_core.hydroshare.utils import get_file_storage, resource_modified
-from hs_core.serialization import GenericResourceMeta, HsDeserializationDependencyException, HsDeserializationException
+from hs_core.serialization import GenericResourceMeta, HsDeserializationDependencyException, \
+    HsDeserializationException
 from hs_core.hydroshare.hs_bagit import create_bag_files
 
 
@@ -57,6 +59,7 @@ class ResourceToListItemMixin(object):
                                                           resource_url=resource_url)
         return resource_list_item
 
+
 class ResourceFileToListItemMixin(object):
     def resourceFileToListItem(self, f):
         url = hydroshare.utils.current_site_url() + f.resource_file.url
@@ -79,7 +82,8 @@ class ResourceTypes(generics.ListAPIView):
     REST URL: hsapi/resourceTypes
     HTTP method: GET
 
-    example return JSON format for GET /hsapi/resourceTypes (note response will consist of only one page):
+    example return JSON format for GET /hsapi/resourceTypes (note response will consist of only
+    one page):
 
     [
         {
@@ -117,7 +121,8 @@ class ResourceTypes(generics.ListAPIView):
         return self.list(request)
 
     def get_queryset(self):
-        return [serializers.ResourceType(resource_type=rtype.__name__) for rtype in get_resource_types()]
+        return [serializers.ResourceType(resource_type=rtype.__name__) for rtype in
+                get_resource_types()]
 
     def get_serializer_class(self):
         return serializers.ResourceTypesSerializer
@@ -128,8 +133,8 @@ class ResourceList(ResourceToListItemMixin, generics.ListAPIView):
     Get a list of resources based on the following filter query parameters
 
     For an anonymous user, all public resources will be listed.
-    For any authenticated user with no other query parameters provided in the request, all resources that are viewable
-    by the user will be listed.
+    For any authenticated user with no other query parameters provided in the request, all
+    resources that are viewable by the user will be listed.
 
     REST URL: hsapi/resourceList/{query parameters}
     HTTP method: GET
@@ -145,10 +150,12 @@ class ResourceList(ResourceToListItemMixin, generics.ListAPIView):
     :param  types: (optional) - to get a list of resources of the specified resource types
     :param  from_date: (optional) - to get a list of resources created on or after this date
     :param  to_date: (optional) - to get a list of resources created on or before this date
-    :param  edit_permission: (optional) - to get a list of resources for which the authorised user has edit permission
+    :param  edit_permission: (optional) - to get a list of resources for which the authorised user
+    has edit permission
     :rtype:  json string
-    :return:  a paginated list of resources with data for resource id, title, resource type, creator, public,
-    date created, date last updated, resource bag url path, and science metadata url path
+    :return:  a paginated list of resources with data for resource id, title, resource type,
+    creator, public, date created, date last updated, resource bag url path, and science
+    metadata url path
 
     example return JSON format for GET /hsapi/resourceList:
 
@@ -156,17 +163,21 @@ class ResourceList(ResourceToListItemMixin, generics.ListAPIView):
             "next": link to next page
             "previous": link to previous page
             "results":[
-                    {"resource_type": resource type, "resource_title": resource title, "resource_id": resource id,
+                    {"resource_type": resource type, "resource_title": resource title,
+                    "resource_id": resource id,
                     "creator": creator name, "date_created": date resource created,
                     "date_last_updated": date resource last updated, "public": true or false,
-                    "discoverable": true or false, "shareable": true or false, "immutable": true or false,
+                    "discoverable": true or false, "shareable": true or false,
+                    "immutable": true or false,
                     "published": true or false, "bag_url": link to bag file,
                     "science_metadata_url": link to science metadata,
                     "resource_url": link to resource landing HTML page},
-                    {"resource_type": resource type, "resource_title": resource title, "resource_id": resource id,
+                    {"resource_type": resource type, "resource_title": resource title,
+                    "resource_id": resource id,
                     "creator": creator name, "date_created": date resource created,
                     "date_last_updated": date resource last updated, "public": true or false,
-                    "discoverable": true or false, "shareable": true or false, "immutable": true or false,
+                    "discoverable": true or false, "shareable": true or false,
+                    "immutable": true or false,
                     "published": true or false, "bag_url": link to bag file,
                     "science_metadata_url": link to science metadata,
                     "resource_url": link to resource landing HTML page},
@@ -181,7 +192,8 @@ class ResourceList(ResourceToListItemMixin, generics.ListAPIView):
 
     # needed for list of resources
     def get_queryset(self):
-        resource_list_request_validator = serializers.ResourceListRequestValidator(data=self.request.query_params)
+        resource_list_request_validator = serializers.ResourceListRequestValidator(
+            data=self.request.query_params)
         if not resource_list_request_validator.is_valid():
             raise ValidationError(detail=resource_list_request_validator.errors)
 
@@ -228,11 +240,14 @@ class ResourceReadUpdateDelete(ResourceToListItemMixin, generics.RetrieveUpdateD
 
     :raises:
     NotFound: return JSON format: {'detail': 'No resource was found for resource id':pk}
-    PermissionDenied: return JSON format: {'detail': 'You do not have permission to perform this action.'}
-    ValidationError: return JSON format: {parameter-1': ['error message-1'], 'parameter-2': ['error message-2'], .. }
+    PermissionDenied: return JSON format: {'detail': 'You do not have permission to perform
+    this action.'}
+    ValidationError: return JSON format: {parameter-1': ['error message-1'], 'parameter-2':
+    ['error message-2'], .. }
 
     :raises:
-    ValidationError: return json format: {'parameter-1':['error message-1'], 'parameter-2': ['error message-2'], .. }
+    ValidationError: return json format: {'parameter-1':['error message-1'], 'parameter-2':
+    ['error message-2'], .. }
     """
     pagination_class = PageNumberPagination
 
@@ -254,8 +269,8 @@ class ResourceReadUpdateDelete(ResourceToListItemMixin, generics.RetrieveUpdateD
         # only resource owners are allowed to delete
         view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.DELETE_RESOURCE)
         hydroshare.delete_resource(pk)
-        # spec says we need return the id of the resource that got deleted - otherwise would have used status code 204
-        # and not 200
+        # spec says we need return the id of the resource that got deleted - otherwise would
+        # have used status code 204 and not 200
         return Response(data={'resource_id': pk}, status=status.HTTP_200_OK)
 
     def get_serializer_class(self):
@@ -278,15 +293,21 @@ class ResourceCreate(generics.CreateAPIView):
     :type   view_groups: str
     :param  resource_type: resource type name
     :param  title: (optional) title of the resource (default value: 'Untitled resource')
-    :param  edit_users: (optional) list of comma separated usernames that should have edit permission for the resource
-    :param  edit_groups: (optional) list of comma separated group names that should have edit permission for the resource
-    :param  view_users: (optional) list of comma separated usernames that should have view permission for the resource
-    :param  view_groups: (optional) list of comma separated group names that should have view permission for the resource
+    :param  edit_users: (optional) list of comma separated usernames that should have edit
+    permission for the resource
+    :param  edit_groups: (optional) list of comma separated group names that should have edit
+    permission for the resource
+    :param  view_users: (optional) list of comma separated usernames that should have view
+    permission for the resource
+    :param  view_groups: (optional) list of comma separated group names that should have view
+    permission for the resource
     :return: id and type of the resource created
     :rtype: json string of the format: {'resource-id':id, 'resource_type': resource type}
     :raises:
-    NotAuthenticated: return json format: {'detail': 'Authentication credentials were not provided.'}
-    ValidationError: return json format: {parameter-1':['error message-1'], 'parameter-2': ['error message-2'], .. }
+    NotAuthenticated: return json format: {'detail': 'Authentication credentials were not
+    provided.'}
+    ValidationError: return json format: {parameter-1':['error message-1'], 'parameter-2':
+    ['error message-2'], .. }
     """
     def initialize_request(self, request, *args, **kwargs):
         """
@@ -319,7 +340,8 @@ class ResourceCreate(generics.CreateAPIView):
         if not request.user.is_authenticated():
             raise NotAuthenticated()
 
-        resource_create_request_validator = serializers.ResourceCreateRequestValidator(data=request.data)
+        resource_create_request_validator = serializers.ResourceCreateRequestValidator(
+            data=request.data)
         if not resource_create_request_validator.is_valid():
             raise ValidationError(detail=resource_create_request_validator.errors)
 
@@ -334,10 +356,13 @@ class ResourceCreate(generics.CreateAPIView):
         num_files = len(request.FILES)
         if num_files > 0:
             if num_files > 1:
-                raise ValidationError(detail={'file': 'Multiple file upload is not allowed on resource creation. Add additional files after the resource is created.'})
+                raise ValidationError(detail={'file': 'Multiple file upload is not allowed on '
+                                                      'resource creation. Add additional files '
+                                                      'after the resource is created.'})
             # Place files into format expected by hydroshare.utils.resource_pre_create_actions and
-            # hydroshare.create_resource, i.e. a tuple of django.core.files.uploadedfile.TemporaryUploadedFile objects.
-            files = [request.FILES['file'],]
+            # hydroshare.create_resource, i.e. a tuple of
+            # django.core.files.uploadedfile.TemporaryUploadedFile objects.
+            files = [request.FILES['file'], ]
         else:
             files = []
 
@@ -389,7 +414,8 @@ class SystemMetadataRetrieve(ResourceToListItemMixin, APIView):
     :rtype: str
     :raises:
     NotFound: return JSON format: {'detail': 'No resource was found for resource id:pk'}
-    PermissionDenied: return JSON format: {'detail': 'You do not have permission to perform this action.'}
+    PermissionDenied: return JSON format: {'detail': 'You do not have permission to
+    perform this action.'}
 
     example return JSON format for GET hsapi/sysmeta/<RESOURCE_ID>:
 
@@ -468,7 +494,8 @@ class ScienceMetadataRetrieveUpdate(APIView):
     :rtype: str
     :raises:
     NotFound: return json format: {'detail': 'No resource was found for resource id:pk'}
-    PermissionDenied: return json format: {'detail': 'You do not have permission to perform this action.'}
+    PermissionDenied: return json format: {'detail': 'You do not have permission to perform
+    this action.'}
 
     REST URL: hsapi/scimeta/{pk}
     HTTP method: PUT
@@ -481,8 +508,10 @@ class ScienceMetadataRetrieveUpdate(APIView):
     :rtype: json of the format: {'resource_id':pk}
     :raises:
     NotFound: return json format: {'detail': 'No resource was found for resource id':pk}
-    PermissionDenied: return json format: {'detail': 'You do not have permission to perform this action.'}
-    ValidationError: return json format: {parameter-1': ['error message-1'], 'parameter-2': ['error message-2'], .. }
+    PermissionDenied: return json format: {'detail': 'You do not have permission to perform
+    this action.'}
+    ValidationError: return json format: {parameter-1': ['error message-1'],
+    'parameter-2': ['error message-2'], .. }
     """
     ACCEPT_FORMATS = ('application/xml', 'application/rdf+xml')
 
@@ -505,23 +534,25 @@ class ScienceMetadataRetrieveUpdate(APIView):
 
         files = request.FILES.values()
         if len(files) == 0:
-            error_msg = {'file': 'No resourcemetadata.xml file was found to update resource metadata.'}
+            error_msg = {'file': 'No resourcemetadata.xml file was found to update resource '
+                                 'metadata.'}
             raise ValidationError(detail=error_msg)
         elif len(files) > 1:
-            error_msg = {'file': ('More than one file was found. Only one file, named resourcemetadata.xml, '
+            error_msg = {'file': ('More than one file was found. Only one file, named '
+                                  'resourcemetadata.xml, '
                                   'can be used to update resource metadata.')}
             raise ValidationError(detail=error_msg)
 
         scimeta = files[0]
         if scimeta.content_type not in self.ACCEPT_FORMATS:
             error_msg = {'file': ("Uploaded file has content type {t}, "
-                                  "but only these types are accepted: {e}.").format(t=scimeta.content_type,
-                                                                                    e=",".join(self.ACCEPT_FORMATS))}
+                                  "but only these types are accepted: {e}.").format(
+                t=scimeta.content_type, e=",".join(self.ACCEPT_FORMATS))}
             raise ValidationError(detail=error_msg)
         expect = 'resourcemetadata.xml'
         if scimeta.name != expect:
-            error_msg = {'file': "Uploaded file has name {n}, but expected {e}.".format(n=scimeta.name,
-                                                                                        e=expect)}
+            error_msg = {'file': "Uploaded file has name {n}, but expected {e}.".format(
+                n=scimeta.name, e=expect)}
             raise ValidationError(detail=error_msg)
 
         # Temp directory to store resourcemetadata.xml
@@ -613,8 +644,10 @@ class ResourceFileCRUD(APIView):
 
     :raises:
     NotFound: return json format: {'detail': 'No resource was found for resource id':pk}
-    PermissionDenied: return json format: {'detail': 'You do not have permission to perform this action.'}
-    ValidationError: return json format: {'parameter-1':['error message-1'], 'parameter-2': ['error message-2'], .. }
+    PermissionDenied: return json format: {'detail': 'You do not have permission to perform
+    this action.'}
+    ValidationError: return json format: {'parameter-1':['error message-1'],
+    'parameter-2': ['error message-2'], .. }
     """
     allowed_methods = ('GET', 'POST', 'PUT', 'DELETE')
 
@@ -643,8 +676,8 @@ class ResourceFileCRUD(APIView):
         try:
             f = hydroshare.get_resource_file(pk, filename)
         except ObjectDoesNotExist:
-            err_msg = 'File with file name {file_name} does not exist for resource with resource id ' \
-                      '{res_id}'.format(file_name=filename, res_id=pk)
+            err_msg = 'File with file name {file_name} does not exist for resource with ' \
+                      'resource id {res_id}'.format(file_name=filename, res_id=pk)
             raise NotFound(detail=err_msg)
 
         # redirects to django_irods/views.download function
@@ -657,30 +690,36 @@ class ResourceFileCRUD(APIView):
         :param pk: Primary key of the resource (i.e. resource short ID)
         :return:
         """
-        resource, _, _ = view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
+        resource, _, _ = view_utils.authorize(request, pk,
+                                              needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
         resource_files = request.FILES.values()
         if len(resource_files) == 0:
             error_msg = {'file': 'No file was found to add to the resource.'}
             raise ValidationError(detail=error_msg)
         elif len(resource_files) > 1:
-            error_msg = {'file': 'More than one file was found. Only one file can be added at a time.'}
+            error_msg = {'file': 'More than one file was found. Only one file can be '
+                                 'added at a time.'}
             raise ValidationError(detail=error_msg)
 
         # TODO: I know there has been some discussion when to validate a file
         # I agree that we should not validate and extract metadata as part of the file add api
-        # Once we have a decision, I will change this implementation accordingly. In that case we have
-        # to implement additional rest endpoints for file validation and extraction.
+        # Once we have a decision, I will change this implementation accordingly. In that case
+        # we have to implement additional rest endpoints for file validation and extraction.
         try:
-            hydroshare.utils.resource_file_add_pre_process(resource=resource, files=[resource_files[0]],
+            hydroshare.utils.resource_file_add_pre_process(resource=resource,
+                                                           files=[resource_files[0]],
                                                            user=request.user, extract_metadata=True)
 
-        except (hydroshare.utils.ResourceFileSizeException, hydroshare.utils.ResourceFileValidationException, Exception) as ex:
+        except (hydroshare.utils.ResourceFileSizeException,
+                hydroshare.utils.ResourceFileValidationException, Exception) as ex:
             error_msg = {'file': 'Adding file to resource failed. %s' % ex.message}
             raise ValidationError(detail=error_msg)
 
         try:
-           res_file_objects = hydroshare.utils.resource_file_add_process(resource=resource, files=[resource_files[0]],
-                                                                         user=request.user, extract_metadata=True)
+            res_file_objects = hydroshare.utils.resource_file_add_process(resource=resource,
+                                                                          files=[resource_files[0]],
+                                                                          user=request.user,
+                                                                          extract_metadata=True)
 
         except (hydroshare.utils.ResourceFileValidationException, Exception) as ex:
             error_msg = {'file': 'Adding file to resource failed. %s' % ex.message}
@@ -693,7 +732,8 @@ class ResourceFileCRUD(APIView):
         return Response(data=response_data, status=status.HTTP_201_CREATED)
 
     def delete(self, request, pk, filename):
-        resource, _, user = view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
+        resource, _, user = view_utils.authorize(
+            request, pk, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
         try:
             hydroshare.delete_resource_file(pk, filename, user)
         except ObjectDoesNotExist as ex:    # matching file not found
@@ -705,7 +745,8 @@ class ResourceFileCRUD(APIView):
         return Response(data=response_data, status=status.HTTP_200_OK)
 
     def put(self, request, pk, filename):
-        # TODO: Currently we do not have this action for the front end. Will implement in the next iteration
+        # TODO: Currently we do not have this action for the front end. Will implement
+        # in the next iteration
         # Implement only after we have a decision when to validate a file
         raise NotImplementedError()
 
@@ -729,12 +770,15 @@ class ResourceFileList(ResourceFileToListItemMixin, generics.ListAPIView):
         "previous": null,
         "results": [
             {
-                "url": "http://mill24.cep.unc.edu/django_irods/download/bd88d2a152894134928c587d38cf0272/data/contents/mytest_resource/text_file.txt",
+                "url": "http://mill24.cep.unc.edu/django_irods/
+                download/bd88d2a152894134928c587d38cf0272/data/contents/
+                mytest_resource/text_file.txt",
                 "size": 21,
                 "content_type": "text/plain"
             },
             {
-                "url": "http://mill24.cep.unc.edu/django_irods/download/bd88d2a152894134928c587d38cf0272/data/contents/mytest_resource/a_directory/cea.tif",
+                "url": "http://mill24.cep.unc.edu/django_irods/download/
+                bd88d2a152894134928c587d38cf0272/data/contents/mytest_resource/a_directory/cea.tif",
                 "size": 270993,
                 "content_type": "image/tiff"
             }
@@ -743,7 +787,8 @@ class ResourceFileList(ResourceFileToListItemMixin, generics.ListAPIView):
 
     :raises:
     NotFound: return json format: {'detail': 'No resource was found for resource id':pk}
-    PermissionDenied: return json format: {'detail': 'You do not have permission to perform this action.'}
+    PermissionDenied: return json format: {'detail': 'You do not have permission to perform
+    this action.'}
     """
     allowed_methods = ('GET',)
 

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -10,12 +10,14 @@ from .utils import validate_json, validate_user_name,  validate_group_name
 
 RESOURCE_TYPES = [rtype.__name__ for rtype in utils.get_resource_types()]
 
+
 class StringListField(serializers.ListField):
     child = serializers.CharField()
 
+
 class ResourceUpdateRequestValidator(serializers.Serializer):
     title = serializers.CharField(required=False)
-    #metadata = serializers.CharField(validators=[validate_json], required=False)
+    metadata = serializers.CharField(validators=[validate_json], required=False)
     edit_users = serializers.CharField(required=False)
     edit_groups = serializers.CharField(required=False)
     view_users = serializers.CharField(required=False)

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -61,7 +61,8 @@ class ResourceCreateRequestValidator(ResourceUpdateRequestValidator):
 
 
 class ResourceTypesSerializer(serializers.Serializer):
-    resource_type = serializers.CharField(max_length=100, required=True, validators=[lambda x: x in RESOURCE_TYPES])
+    resource_type = serializers.CharField(max_length=100, required=True,
+                                          validators=[lambda x: x in RESOURCE_TYPES])
 
 
 class ResourceListRequestValidator(serializers.Serializer):
@@ -137,4 +138,3 @@ class UserAuthenticateRequestValidator(serializers.Serializer):
 
 class AccessRulesRequestValidator(serializers.Serializer):
     public = serializers.BooleanField(default=False)
-

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -188,7 +188,11 @@ def validate_group_name(group_name):
 def validate_metadata(metadata, resource_type):
     """
     Validate metadata including validation of resource type specific metadata.
-    If validation fails, ValidationError exception is raised
+    If validation fails, ValidationError exception is raised.
+
+    Note: This validation does not check if a specific element is repeatable or not. If an element
+    is not repeatable and the metadata list contains more than one dict for the same element type,
+    then exception will be raised when that element is created the 2nd time.
 
     :param metadata: a list of dicts where each dict defines data for a specific metadata
     element.

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -13,9 +13,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile
 from django.utils.http import int_to_base36
-from django.conf import settings
 
-from rest_framework.exceptions import *
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 
 from mezzanine.utils.email import subject_template, default_token_generator, send_mail_template
 from mezzanine.utils.urls import next_url
@@ -42,8 +41,8 @@ ActionToAuthorize = namedtuple('ActionToAuthorize',
 ACTION_TO_AUTHORIZE = ActionToAuthorize(0, 1, 2, 3, 4, 5)
 
 
-# Since an SessionException will be raised for all irods-related operations from django_irods module,
-# there is no need to raise iRODS SessionException from within this function
+# Since an SessionException will be raised for all irods-related operations from django_irods
+# module, there is no need to raise iRODS SessionException from within this function
 def upload_from_irods(username, password, host, port, zone, irods_fnames, res_files):
     """
     use iget to transfer selected data object from irods zone to local as a NamedTemporaryFile
@@ -57,10 +56,12 @@ def upload_from_irods(username, password, host, port, zone, irods_fnames, res_fi
     :raises SessionException(proc.returncode, stdout, stderr) defined in django_irods/icommands.py
             to capture iRODS exceptions raised from iRODS icommand subprocess run triggered from
             any method calls from IrodsStorage() if an error or exception ever occurs
-    :return: None, but the downloaded file from the iRODS will be appended to res_files list for uploading
+    :return: None, but the downloaded file from the iRODS will be appended to res_files list for
+    uploading
     """
     irods_storage = IrodsStorage()
-    irods_storage.set_user_session(username=username, password=password, host=host, port=port, zone=zone)
+    irods_storage.set_user_session(username=username, password=password, host=host, port=port,
+                                   zone=zone)
     ifnames = string.split(irods_fnames, ',')
     for ifname in ifnames:
         size = irods_storage.size(ifname)
@@ -109,31 +110,40 @@ def run_ssh_command(host, uname, pwd, exec_cmd):
 # when private netCDF resources are made public so that all links of data services
 # provided by Hyrax service are instantaneously available on demand
 def run_script_to_update_hyrax_input_files():
-    run_ssh_command(host=settings.HYRAX_SSH_HOST, uname=settings.HYRAX_SSH_PROXY_USER, pwd=settings.HYRAX_SSH_PROXY_USER_PWD, exec_cmd=settings.HYRAX_SCRIPT_RUN_COMMAND)
+    run_ssh_command(host=settings.HYRAX_SSH_HOST, uname=settings.HYRAX_SSH_PROXY_USER,
+                    pwd=settings.HYRAX_SSH_PROXY_USER_PWD,
+                    exec_cmd=settings.HYRAX_SCRIPT_RUN_COMMAND)
 
 
-def authorize(request, res_id, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE, raises_exception=True):
+def authorize(request, res_id, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE,
+              raises_exception=True):
     """
-    This function checks if a user has authorization for resource related actions as outlined below. This
-    function doesn't check authorization for user sharing resource with another user.
+    This function checks if a user has authorization for resource related actions as outlined
+    below. This function doesn't check authorization for user sharing resource with another user.
 
     How this function should be called for different actions on a resource by a specific user?
     1. User wants to view a resource (both metadata and content files) which includes
        downloading resource bag or resource content files:
-       authorize(request, res_id=id_of_resource, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
+       authorize(request, res_id=id_of_resource,
+       needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
     2. User wants to view resource metadata only:
-       authorize(request, res_id=id_of_resource, needed_permission=ACTION_TO_AUTHORIZE.VIEW_METADATA)
+       authorize(request, res_id=id_of_resource,
+       needed_permission=ACTION_TO_AUTHORIZE.VIEW_METADATA)
     3. User wants to edit a resource which includes:
        a. edit metadata
        b. add file to resource
        c. delete a file from the resource
-       authorize(request, res_id=id_of_resource, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
+       authorize(request, res_id=id_of_resource,
+       needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
     4. User wants to set resource flag (public, published, shareable etc):
-       authorize(request, res_id=id_of_resource, needed_permission=ACTION_TO_AUTHORIZE.SET_RESOURCE_FLAG)
+       authorize(request, res_id=id_of_resource,
+       needed_permission=ACTION_TO_AUTHORIZE.SET_RESOURCE_FLAG)
     5. User wants to delete a resource:
-       authorize(request, res_id=id_of_resource, needed_permission=ACTION_TO_AUTHORIZE.DELETE_RESOURCE)
+       authorize(request, res_id=id_of_resource,
+       needed_permission=ACTION_TO_AUTHORIZE.DELETE_RESOURCE)
     6. User wants to create new version of a resource:
-       authorize(request, res_id=id_of_resource, needed_permission=ACTION_TO_AUTHORIZE.CREATE_RESOURCE_VERSION)
+       authorize(request, res_id=id_of_resource,
+       needed_permission=ACTION_TO_AUTHORIZE.CREATE_RESOURCE_VERSION)
 
     Note: resource 'shareable' status has no effect on authorization
     """
@@ -169,6 +179,7 @@ def authorize(request, res_id, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOUR
     else:
         return res, authorized, user
 
+
 def validate_json(js):
     try:
         json.loads(js)
@@ -179,6 +190,7 @@ def validate_json(js):
 def validate_user_name(user_name):
     if not User.objects.filter(username=user_name).exists():
         raise ValidationError(detail='No user found for user name:%s' % user_name)
+
 
 def validate_group_name(group_name):
     if not Group.objects.filter(name=group_name).exists():
@@ -235,10 +247,14 @@ def validate_metadata(metadata, resource_type):
                 if hasattr(element_class(), attribute_name):
                     if callable(getattr(element_class(), attribute_name)):
                         element_attribute_names_valid = False
-                        validation_errors['metadata'].append("Invalid attribute name:%s found for metadata element name:%s." % (attribute_name, k))
+                        validation_errors['metadata'].append(
+                            "Invalid attribute name:%s found for metadata element name:%s."
+                            % (attribute_name, k))
                 else:
                     element_attribute_names_valid = False
-                    validation_errors['metadata'].append("Invalid attribute name:%s found for metadata element name:%s." % (attribute_name, k))
+                    validation_errors['metadata'].append(
+                        "Invalid attribute name:%s found for metadata element name:%s."
+                        % (attribute_name, k))
 
             if element_attribute_names_valid:
                 if is_core_element:
@@ -266,7 +282,7 @@ def validate_metadata(metadata, resource_type):
 
 
 class MetadataElementRequest(object):
-    def __init__(self,element_name, **element_data_dict):
+    def __init__(self, element_name, **element_data_dict):
         if element_name.lower() == 'coverage' or element_name.lower() == 'originalcoverage':
             if 'value' in element_data_dict:
                 element_data_dict = element_data_dict['value']
@@ -281,20 +297,24 @@ def create_form(formclass, request):
 
     return params
 
+
 def get_my_resources_list(request):
     user = request.user
     # get a list of resources with effective OWNER privilege
     owned_resources = user.uaccess.get_resources_with_explicit_access(PrivilegeCodes.OWNER)
     # remove obsoleted resources from the owned_resources
-    owned_resources = owned_resources.exclude(object_id__in=Relation.objects.filter(type='isReplacedBy').values('object_id'))
+    owned_resources = owned_resources.exclude(object_id__in=Relation.objects.filter(
+        type='isReplacedBy').values('object_id'))
     # get a list of resources with effective CHANGE privilege
     editable_resources = user.uaccess.get_resources_with_explicit_access(PrivilegeCodes.CHANGE)
     # remove obsoleted resources from the editable_resources
-    editable_resources = editable_resources.exclude(object_id__in=Relation.objects.filter(type='isReplacedBy').values('object_id'))
+    editable_resources = editable_resources.exclude(object_id__in=Relation.objects.filter(
+        type='isReplacedBy').values('object_id'))
     # get a list of resources with effective VIEW privilege
     viewable_resources = user.uaccess.get_resources_with_explicit_access(PrivilegeCodes.VIEW)
     # remove obsoleted resources from the viewable_resources
-    viewable_resources = viewable_resources.exclude(object_id__in=Relation.objects.filter(type='isReplacedBy').values('object_id'))
+    viewable_resources = viewable_resources.exclude(object_id__in=Relation.objects.filter(
+        type='isReplacedBy').values('object_id'))
 
     owned_resources = list(owned_resources)
     editable_resources = list(editable_resources)
@@ -319,8 +339,10 @@ def get_my_resources_list(request):
         if res in labeled_resources:
             res.labels = res.rlabels.get_labels(user)
 
-    resource_collection = (owned_resources + editable_resources + viewable_resources + discovered_resources)
+    resource_collection = (owned_resources + editable_resources + viewable_resources +
+                           discovered_resources)
     return resource_collection
+
 
 def send_action_to_take_email(request, user, action_type, **kwargs):
     """
@@ -332,11 +354,12 @@ def send_action_to_take_email(request, user, action_type, **kwargs):
     to use. Additional context variable needed in the email template can be
     passed using the kwargs
 
-    for action_type == 'group_membership', an instance of GroupMembershipRequest and instance of Group are expected to
+    for action_type == 'group_membership', an instance of GroupMembershipRequest and
+    instance of Group are expected to
     be passed into this function
     """
     email_to = kwargs.get('group_owner', user)
-    context = {'request': request, 'user':user}
+    context = {'request': request, 'user': user}
     if action_type == 'group_membership':
         membership_request = kwargs['membership_request']
         action_url = reverse(action_type, kwargs={

--- a/setup.cfg
+++ b/setup.cfg
@@ -173,7 +173,6 @@ exclude=
   hs_core/tests/api/native/test_users.py,
   hs_core/tests/api/native/test_utils.py,
   hs_core/tests/api/rest/base.py,
-  hs_core/tests/api/rest/test_create_resource.py,
   hs_core/tests/api/rest/test_resource_file.py,
   hs_core/tests/api/rest/test_resource_list.py,
   hs_core/tests/api/rest/test_resource_meta.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -191,7 +191,6 @@ exclude=
   hs_core/views/__init__.py,
   hs_core/views/pagination.py,
   hs_core/views/resource_api.py,
-  hs_core/views/resource_rest_api.py,
   hs_core/views/serializers.py,
   hs_core/views/user_rest_api.py,
   hs_core/views/utils.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,7 +130,6 @@ exclude=
   hs_core/hydroshare/resource.py,
   hs_core/hydroshare/social.py,
   hs_core/hydroshare/users.py,
-  hs_core/hydroshare/utils.py,
   hs_core/languages_iso.py,
   hs_core/management/commands/create_site.py,
   hs_core/metadata_terms_urls.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -192,7 +192,6 @@ exclude=
   hs_core/views/pagination.py,
   hs_core/views/resource_api.py,
   hs_core/views/user_rest_api.py,
-  hs_core/views/utils.py,
   hs_geographic_feature_resource/forms.py,
   hs_geographic_feature_resource/models.py,
   hs_geographic_feature_resource/page_processors.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -135,7 +135,6 @@ exclude=
   hs_core/metadata_terms_urls.py,
   hs_core/models.py,
   hs_core/page_processors.py,
-  hs_core/receivers.py,
   hs_core/resourcemap_urls.py,
   hs_core/search_indexes.py,
   hs_core/serialization.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -191,7 +191,6 @@ exclude=
   hs_core/views/__init__.py,
   hs_core/views/pagination.py,
   hs_core/views/resource_api.py,
-  hs_core/views/serializers.py,
   hs_core/views/user_rest_api.py,
   hs_core/views/utils.py,
   hs_geographic_feature_resource/forms.py,


### PR DESCRIPTION
Using the new ```metadata``` parameter, resource creation REST API endpoint can now be passed data for any number of valid metadata elements supported by the specified resource type in json format. 

