### PR TITLE
[#1330] hot fix: access management for feature res in view mode

### DIFF
--- a/hs_geographic_feature_resource/templates/pages/geographicfeatureresource.html
+++ b/hs_geographic_feature_resource/templates/pages/geographicfeatureresource.html
@@ -129,7 +129,10 @@
 
         $(document).ready(function () {
 
-            $('.label-file-name').each(function () {
+            var edit_mode = "{{edit_mode}}";
+            if (edit_mode.toLowerCase() == "true")
+            {
+                $('.label-file-name').each(function () {
                         var filename = $(this).text().trim().toLowerCase();
                         var extension = filename.substring(filename.length - 4, filename.length);
                         if (extension == ".shp" || extension == ".shx" || extension == ".dbf") {
@@ -143,7 +146,9 @@
                             $("#" + tag_id2).children().find("div[class='modal-body']").html(del_msg_prj);
                         } // else
                     } // function
-            ); //each
+                ); //each
+            }
+
         })
     </script>
 


### PR DESCRIPTION
this hotfix addressed #1330 
bug reason: a javascript logic written specifically for feature res type in Edit mode got executed in View mode and failed, causing a “Butterfly Effect” which somehow affected the auto-complete functionality in the access management popup.
