### PR TITLE
1238 rest api and ref time series

### DIFF
--- a/ref_ts/page_processors.py
+++ b/ref_ts/page_processors.py
@@ -13,10 +13,7 @@ def landing_page(request, page):
     context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource,
                                                extended_metadata_layout=None, request=request)
     extended_metadata_exists = False
-    if content_model.metadata.sites.all().first() or \
-            content_model.metadata.variables.all().first() or \
-            content_model.metadata.methods.all().first() or \
-            content_model.metadata.quality_levels.all().first():
+    if content_model.metadata.referenceURLs.all().first():
         extended_metadata_exists = True
 
     context['extended_metadata_exists'] = extended_metadata_exists

--- a/ref_ts/receivers.py
+++ b/ref_ts/receivers.py
@@ -1,49 +1,56 @@
+import logging
 from django.dispatch import receiver
 from hs_core.signals import pre_create_resource
 from ref_ts.models import RefTimeSeriesResource
 from . import ts_utils
 
+logger = logging.getLogger(__name__)
+
 # redirect to render custom create-resource template
 @receiver(pre_create_resource, sender=RefTimeSeriesResource)
 def ref_time_series_describe_resource_trigger(sender, **kwargs):
-    page_url_dict = kwargs['page_url_dict']
     url_key = kwargs['url_key']
-    page_url_dict[url_key] = "pages/create-ref-time-series.html"
-    validate_files_dict = kwargs['validate_files']
-    metadata = kwargs['metadata']
-    try:
-        reference_url_dict = None
-        site_dict = None
-        variable_dict = None
-        for metadata_dict in metadata:
-            if metadata_dict.has_key("referenceurl"):
-                reference_url_dict = metadata_dict["referenceurl"]
-            elif metadata_dict.has_key("site"):
-                site_dict = metadata_dict["site"]
-            elif metadata_dict.has_key("variable"):
-                variable_dict = metadata_dict["variable"]
-        if reference_url_dict:
-            ref_url = reference_url_dict["value"]
-            ref_type = reference_url_dict["type"]
-            site_code = None
-            variable_code = None
-            if site_dict:
-                site_code = site_dict["code"]
-            if variable_dict:
-                variable_code = variable_dict["code"]
-            ts_dict = ts_utils.QueryHydroServerGetParsedWML(service_url=ref_url,
-                                                            soap_or_rest=ref_type,
-                                                            site_code=site_code,
-                                                            variable_code=variable_code)
-            del metadata[:]
-            ts_utils.prepare_metadata_list(metadata=metadata,
-                                           ts_dict=ts_dict,
-                                           url=ref_url,
-                                           reference_type=ref_type)
-        else:
-            raise Exception("Missing parameter 'referenceurl' in request")
+    if url_key is not None:
+        # the call is from UI
+        page_url_dict = kwargs['page_url_dict']
+        page_url_dict[url_key] = "pages/create-ref-time-series.html"
+    else:
+        # the call is from rest api
+        metadata = kwargs['metadata']
+        try:
+            reference_url_dict = None
+            site_dict = None
+            variable_dict = None
+            for metadata_dict in metadata:
+                if "referenceurl" in metadata_dict:
+                    reference_url_dict = metadata_dict["referenceurl"]
+                elif "site" in metadata_dict:
+                    site_dict = metadata_dict["site"]
+                elif "variable" in metadata_dict:
+                    variable_dict = metadata_dict["variable"]
+            if reference_url_dict:
+                ref_url = reference_url_dict["value"]
+                ref_type = reference_url_dict["type"]
+                site_code = None
+                variable_code = None
+                if site_dict:
+                    site_code = site_dict["code"]
+                if variable_dict:
+                    variable_code = variable_dict["code"]
+                if ref_type == "soap" and (site_code is None or variable_code is None):
+                    raise Exception("site_code and variable_code should be provided with soap url")
+                ts_dict = ts_utils.QueryHydroServerGetParsedWML(service_url=ref_url,
+                                                                soap_or_rest=ref_type,
+                                                                site_code=site_code,
+                                                                variable_code=variable_code)
+                del metadata[:]
+                ts_utils.prepare_metadata_list(metadata=metadata,
+                                               ts_dict=ts_dict,
+                                               url=ref_url,
+                                               reference_type=ref_type)
+            else:
+                raise Exception("Missing parameter 'referenceurl' in request")
 
-    except Exception as ex:
-        validate_files_dict['are_files_valid'] = False
-        validate_files_dict['message'] = ex.message
-        kwargs['files'].append(None)
+        except Exception as ex:
+            logger.exception("Failed to create refts res from rest api: " + ex.message)
+            raise ex

--- a/ref_ts/receivers.py
+++ b/ref_ts/receivers.py
@@ -1,4 +1,3 @@
-
 from django.dispatch import receiver
 from hs_core.signals import pre_create_resource
 from ref_ts.models import RefTimeSeriesResource
@@ -13,35 +12,37 @@ def ref_time_series_describe_resource_trigger(sender, **kwargs):
     validate_files_dict = kwargs['validate_files']
     metadata = kwargs['metadata']
     try:
-        if len(metadata) > 0:
-            reference_url_dict = None
-            site_dict = None
-            variable_dict = None
-            for metadata_dict in metadata:
-                if metadata_dict.has_key("referenceurl"):
-                    reference_url_dict = metadata_dict["referenceurl"]
-                elif metadata_dict.has_key("site"):
-                    site_dict = metadata_dict["site"]
-                elif metadata_dict.has_key("variable"):
-                    variable_dict = metadata_dict["variable"]
-            if reference_url_dict:
-                ref_url = reference_url_dict["value"]
-                ref_type = reference_url_dict["type"]
-                site_code = None
-                variable_code = None
-                if site_dict:
-                    site_code = site_dict["code"]
-                if variable_dict:
-                    variable_code = variable_dict["code"]
-                ts_dict = ts_utils.QueryHydroServerGetParsedWML(service_url=ref_url,
-                                                                soap_or_rest=ref_type,
-                                                                site_code=site_code,
-                                                                variable_code=variable_code)
-                del metadata[:]
-                ts_utils.prepare_metadata_list(metadata=metadata,
-                                               ts_dict=ts_dict,
-                                               url=ref_url,
-                                               reference_type=ref_type)
+        reference_url_dict = None
+        site_dict = None
+        variable_dict = None
+        for metadata_dict in metadata:
+            if metadata_dict.has_key("referenceurl"):
+                reference_url_dict = metadata_dict["referenceurl"]
+            elif metadata_dict.has_key("site"):
+                site_dict = metadata_dict["site"]
+            elif metadata_dict.has_key("variable"):
+                variable_dict = metadata_dict["variable"]
+        if reference_url_dict:
+            ref_url = reference_url_dict["value"]
+            ref_type = reference_url_dict["type"]
+            site_code = None
+            variable_code = None
+            if site_dict:
+                site_code = site_dict["code"]
+            if variable_dict:
+                variable_code = variable_dict["code"]
+            ts_dict = ts_utils.QueryHydroServerGetParsedWML(service_url=ref_url,
+                                                            soap_or_rest=ref_type,
+                                                            site_code=site_code,
+                                                            variable_code=variable_code)
+            del metadata[:]
+            ts_utils.prepare_metadata_list(metadata=metadata,
+                                           ts_dict=ts_dict,
+                                           url=ref_url,
+                                           reference_type=ref_type)
+        else:
+            raise Exception("Missing parameter 'referenceurl' in request")
+
     except Exception as ex:
         validate_files_dict['are_files_valid'] = False
         validate_files_dict['message'] = ex.message

--- a/ref_ts/receivers.py
+++ b/ref_ts/receivers.py
@@ -60,6 +60,6 @@ def ref_time_series_describe_resource_trigger(sender, **kwargs):
             else:
                 raise Exception("Missing parameter 'referenceurl' in request")
 
-        except BaseException as ex:
+        except Exception as ex:
             logger.exception("Failed to create refts res from rest api: " + ex.message)
             raise ex

--- a/ref_ts/receivers.py
+++ b/ref_ts/receivers.py
@@ -2,6 +2,7 @@
 from django.dispatch import receiver
 from hs_core.signals import pre_create_resource
 from ref_ts.models import RefTimeSeriesResource
+from . import ts_utils
 
 # redirect to render custom create-resource template
 @receiver(pre_create_resource, sender=RefTimeSeriesResource)
@@ -9,4 +10,39 @@ def ref_time_series_describe_resource_trigger(sender, **kwargs):
     page_url_dict = kwargs['page_url_dict']
     url_key = kwargs['url_key']
     page_url_dict[url_key] = "pages/create-ref-time-series.html"
-
+    validate_files_dict = kwargs['validate_files']
+    metadata = kwargs['metadata']
+    try:
+        if len(metadata) > 0:
+            reference_url_dict = None
+            site_dict = None
+            variable_dict = None
+            for metadata_dict in metadata:
+                if metadata_dict.has_key("referenceurl"):
+                    reference_url_dict = metadata_dict["referenceurl"]
+                elif metadata_dict.has_key("site"):
+                    site_dict = metadata_dict["site"]
+                elif metadata_dict.has_key("variable"):
+                    variable_dict = metadata_dict["variable"]
+            if reference_url_dict:
+                ref_url = reference_url_dict["value"]
+                ref_type = reference_url_dict["type"]
+                site_code = None
+                variable_code = None
+                if site_dict:
+                    site_code = site_dict["code"]
+                if variable_dict:
+                    variable_code = variable_dict["code"]
+                ts_dict = ts_utils.QueryHydroServerGetParsedWML(service_url=ref_url,
+                                                                soap_or_rest=ref_type,
+                                                                site_code=site_code,
+                                                                variable_code=variable_code)
+                del metadata[:]
+                ts_utils.prepare_metadata_list(metadata=metadata,
+                                               ts_dict=ts_dict,
+                                               url=ref_url,
+                                               reference_type=ref_type)
+    except Exception as ex:
+        validate_files_dict['are_files_valid'] = False
+        validate_files_dict['message'] = ex.message
+        kwargs['files'].append(None)

--- a/ref_ts/views.py
+++ b/ref_ts/views.py
@@ -201,7 +201,8 @@ def create_ref_time_series(request, *args, **kwargs):
 
             request.session['just_created'] = True
             return HttpResponseRedirect(res.get_absolute_url())
-
+        else:
+            raise Exception("Parameters validation error")
     except Exception as ex:
         logger.exception("create_ref_time_series: %s" % (ex.message))
         context = {'resource_creation_error': "Error: failed to create resource." }

--- a/ref_ts/views.py
+++ b/ref_ts/views.py
@@ -114,7 +114,7 @@ def time_series_from_service(request):
             noDataValue = ts['noDataValue']
 
             tempdir = tempfile.mkdtemp()
-            ts_utils.create_vis_2(path=tempdir, site_name=site, data=data, xlabel='Date',
+            ts_utils.create_vis_2(path=tempdir, data=data, xlabel='Date',
                                 variable_name=variable_name, units=units, noDataValue=noDataValue,
                                 predefined_name=PREVIEW_NAME)
             tempdir_last_six_chars = tempdir[-6:]

--- a/ref_ts/views.py
+++ b/ref_ts/views.py
@@ -23,7 +23,6 @@ from .forms import ReferencedSitesForm, ReferencedVariablesForm, GetTSValuesForm
 
 PREVIEW_NAME = "preview.png"
 HIS_CENTRAL_URL = 'http://hiscentral.cuahsi.org/webservices/hiscentral.asmx/GetWaterOneFlowServiceInfo'
-BLANK_FIELD_STRING = ""
 
 logger = logging.getLogger("django")
 
@@ -186,45 +185,10 @@ def create_ref_time_series(request, *args, **kwargs):
         frm = CreateRefTimeSeriesForm(request.POST)
         if frm.is_valid():
             metadata = []
-            if ts_dict["longitude"] is not None and ts_dict["latitude"] is not None:
-                coverage_point = {"Coverage": {"type": "point",
-                                      "value": {"east": ts_dict["longitude"],
-                                                "north": ts_dict["latitude"],
-                                                "units": "WGS 84 EPSG:4326"}
-                                     }
-                                 }
-                metadata.append(coverage_point)
-
-            if ts_dict["start_date"] is not None and ts_dict["end_date"] is not None:
-                coverage_period ={"Coverage": {"type": "period",
-                                      "value": {"start": ts_dict["start_date"],
-                                                "end": ts_dict["end_date"]}
-                                     }
-                        }
-                metadata.append(coverage_period)
-
-            metadata += [{"ReferenceURL": {"value": url, "type": reference_type}},
-                        {"Site": {"name": ts_dict['site_name'] if ts_dict['site_name'] is not None else BLANK_FIELD_STRING,
-                                  "code": ts_dict['site_code'] if ts_dict['site_code'] is not None else BLANK_FIELD_STRING,
-                                  "net_work": ts_dict['net_work'] if ts_dict['net_work'] is not None else BLANK_FIELD_STRING,
-                                  "latitude": ts_dict['latitude'],
-                                  "longitude": ts_dict['longitude']
-                                  }
-                        },
-                        {"Variable": {"name": ts_dict['variable_name'] if ts_dict['variable_name'] is not None else BLANK_FIELD_STRING,
-                                      "code": ts_dict['variable_code'] if ts_dict['variable_code'] is not None else BLANK_FIELD_STRING
-                                      }
-                        },
-                        {"DataSource": {"code": ts_dict['source_code'] if ts_dict['source_code'] is not None else BLANK_FIELD_STRING}},
-                        {"Method": {"code": ts_dict['method_code'] if ts_dict['method_code'] is not None else BLANK_FIELD_STRING,
-                                    "description": ts_dict['method_description'] if ts_dict['method_description'] is not None else BLANK_FIELD_STRING
-                                   }
-                        },
-                        {"QualityControlLevel": {
-                            "code": ts_dict['quality_control_level_code'] if ts_dict['quality_control_level_code'] is not None else BLANK_FIELD_STRING,
-                            "definition": ts_dict['quality_control_level_definition'] if ts_dict['quality_control_level_definition'] is not None else BLANK_FIELD_STRING
-                                                 }
-                        }]
+            ts_utils.prepare_metadata_list(metadata=metadata,
+                                           ts_dict=ts_dict,
+                                           url=url,
+                                           reference_type=reference_type)
 
             res = hydroshare.create_resource(
                 resource_type='RefTimeSeriesResource',


### PR DESCRIPTION
This pr works with @pkdash 's latest updates to rest api and its python client, allowing users to programmatically create a RefTS resource.

An example:
ref_url = "https://appsdev.hydroshare.org/apps/snow-inspector/waterml/?start=2016-01-30&end=2016-05-09&lat=44.957390&lon=-119.965527"

rtype = 'RefTimeSeriesResource'
title = 'My Test RefTimeSeriesResource 1'
metadata = []
ref_type = "rest"
metadata.append({"referenceurl": {"value": ref_url, "type": ref_type}})

res_id = hs.createResource(
                            rtype,
                            title,
                            resource_file=None,
                            keywords=["kw1", "kw2"],
                            abstract="my abstract",
                            metadata=json.dumps(metadata))
