### PR TITLE
Download refts bag via rest api

### DIFF
--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -256,7 +256,8 @@ class ResourceReadUpdateDelete(ResourceToListItemMixin, generics.RetrieveUpdateD
     def get(self, request, pk):
         """ Get resource in zipped BagIt format
         """
-        res, _, _ = view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
+        res, _, _ = view_utils.authorize(request, pk,
+                                         needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
         site_url = hydroshare.utils.current_site_url()
         if res.resource_type.lower() == "reftimeseriesresource":
             # if res is RefTimeSeriesResource

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -256,8 +256,7 @@ class ResourceReadUpdateDelete(ResourceToListItemMixin, generics.RetrieveUpdateD
     def get(self, request, pk):
         """ Get resource in zipped BagIt format
         """
-        view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
-        res = hydroshare.utils.get_resource_by_shortkey(pk, or_404=False)
+        res, _, _ = view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
         site_url = hydroshare.utils.current_site_url()
         if res.resource_type.lower() == "reftimeseriesresource":
             # if res is RefTimeSeriesResource

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -258,10 +258,13 @@ class ResourceReadUpdateDelete(ResourceToListItemMixin, generics.RetrieveUpdateD
         """
         view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
         res = hydroshare.utils.get_resource_by_shortkey(pk, or_404=False)
+        site_url = hydroshare.utils.current_site_url()
         if res.resource_type.lower() == "reftimeseriesresource":
-            bag_url = hydroshare.utils.current_site_url() + reverse('ref_ts.views.download_refts_resource_files', kwargs={'shortkey': pk})
+            # if res is RefTimeSeriesResource
+            bag_url = site_url + reverse('ref_ts.views.download_refts_resource_files',
+                                         kwargs={'shortkey': pk})
         else:
-            bag_url = hydroshare.utils.current_site_url() + AbstractResource.bag_url(pk)
+            bag_url = site_url + AbstractResource.bag_url(pk)
         return HttpResponseRedirect(bag_url)
 
     def put(self, request, pk):

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -257,8 +257,11 @@ class ResourceReadUpdateDelete(ResourceToListItemMixin, generics.RetrieveUpdateD
         """ Get resource in zipped BagIt format
         """
         view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
-
-        bag_url = hydroshare.utils.current_site_url() + AbstractResource.bag_url(pk)
+        res = hydroshare.utils.get_resource_by_shortkey(pk, or_404=False)
+        if res.resource_type.lower() == "reftimeseriesresource":
+            bag_url = hydroshare.utils.current_site_url() + reverse('ref_ts.views.download_refts_resource_files', kwargs={'shortkey': pk})
+        else:
+            bag_url = hydroshare.utils.current_site_url() + AbstractResource.bag_url(pk)
         return HttpResponseRedirect(bag_url)
 
     def put(self, request, pk):


### PR DESCRIPTION
@pkdash 
I am not sure this is the best way to do it, but based on my testing it works. Also, the hs_restclient does not need to change anything.

hs_restclient users can download a refts bag in the same way as other res types

refts_res_id = "719034bf610b40cc97fea7033c5d7fd3"
hs.getResource(refts_res_id, destination="/tmp", unzip=True)