### PR TITLE
Brought in defusedxml, and replaced all references to xml.sax with it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER Michael J. Stealey <stealey@renci.org>
 
 ### Begin - HydroShare Development Image Additions ###
 
+RUN pip install defusedxml==0.4.1
+
 ### End - HydroShare Development Image Additions ###
 
 USER root

--- a/hs_app_netCDF/serialization.py
+++ b/hs_app_netCDF/serialization.py
@@ -1,4 +1,4 @@
-import xml.sax
+import defusedxml.sax
 
 import rdflib
 
@@ -33,7 +33,7 @@ class NetcdfResourceMeta(GenericResourceMeta):
         # Also parse using SAX so that we can capture certain metadata elements
         # in the same order in which they appear in the RDF+XML serialization.
         SAX_parse_results = NetcdfResourceSAXHandler()
-        xml.sax.parse(self.rmeta_path, SAX_parse_results)
+        defusedxml.sax.parse(self.rmeta_path, SAX_parse_results)
 
         hsterms = rdflib.namespace.Namespace('http://hydroshare.org/terms/')
 
@@ -216,9 +216,9 @@ class NetcdfResourceMeta(GenericResourceMeta):
             return unicode(str(self))
 
 
-class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
+class NetcdfResourceSAXHandler(defusedxml.sax.ContentHandler):
     def __init__(self):
-        xml.sax.ContentHandler.__init__(self)
+        defusedxml.sax.ContentHandler.__init__(self)
 
         # Content
         self.variables = []
@@ -246,62 +246,62 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
             if len(self.variables) < 1:
                 msg = "Error: haven't yet encountered variables, "
                 msg += "yet trying to store variable name."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._var_name.append(content)
 
         elif self._get_var_shape:
             if len(self.variables) < 1:
                 msg = "Error: haven't yet encountered variables, "
                 msg += "yet trying to store variable shape."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._var_shape.append(content)
 
         elif self._get_var_long_name:
             if len(self.variables) < 1:
                 msg = "Error: haven't yet encountered variables, "
                 msg += "yet trying to store variable long name."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._var_long_name.append(content)
 
         elif self._get_var_missing_val:
             if len(self.variables) < 1:
                 msg = "Error: haven't yet encountered variables, "
                 msg += "yet trying to store variable missing value."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._var_missing_val.append(content)
 
         elif self._get_var_type:
             if len(self.variables) < 1:
                 msg = "Error: haven't yet encountered variables, "
                 msg += "yet trying to store variable type."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._var_type.append(content)
 
         elif self._get_var_comment:
             if len(self.variables) < 1:
                 msg = "Error: haven't yet encountered variables, "
                 msg += "yet trying to store variable comment."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._var_comment.append(content)
 
         elif self._get_var_unit:
             if len(self.variables) < 1:
                 msg = "Error: haven't yet encountered variables, "
                 msg += "yet trying to store variable unit."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._var_unit.append(content)
 
     def startElement(self, name, attrs):
         if name == 'hsterms:netcdfVariable':
             if self._get_var:
-                raise xml.sax.SAXException("Error: nested hsterms:netcdfVariable elements.")
+                raise defusedxml.sax.SAXException("Error: nested hsterms:netcdfVariable elements.")
             self._get_var = True
 
         elif name == 'rdf:Description':
             if self._get_var:
                 if self._get_var_details:
                     msg = "Error: nested rdf:Description elements within hsterms:netcdfVariable element."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 # Create new variable
                 self.variables.append(NetcdfResourceMeta.Variable())
                 self._get_var_details = True
@@ -309,49 +309,49 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
         elif name == 'hsterms:name':
             if self._get_var_details:
                 if self._get_var_name:
-                    raise xml.sax.SAXException("Error: nested hsterms:name elements within hsterms:netcdfVariable.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:name elements within hsterms:netcdfVariable.")
                 self._get_var_name = True
                 self._var_name = []
 
         elif name == 'hsterms:shape':
             if self._get_var_details:
                 if self._get_var_shape:
-                    raise xml.sax.SAXException("Error: nested hsterms:shape elements within hsterms:netcdfVariable.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:shape elements within hsterms:netcdfVariable.")
                 self._get_var_shape = True
                 self._var_shape = []
 
         elif name == 'hsterms:longName':
             if self._get_var_details:
                 if self._get_var_long_name:
-                    raise xml.sax.SAXException("Error: nested hsterms:longName elements within hsterms:netcdfVariable.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:longName elements within hsterms:netcdfVariable.")
                 self._get_var_long_name = True
                 self._var_long_name = []
 
         elif name == 'hsterms:missingValue':
             if self._get_var_details:
                 if self._get_var_missing_val:
-                    raise xml.sax.SAXException("Error: nested hsterms:missingValue elements within hsterms:netcdfVariable.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:missingValue elements within hsterms:netcdfVariable.")
                 self._get_var_missing_val = True
                 self._var_missing_val = []
 
         elif name == 'hsterms:type':
             if self._get_var_details:
                 if self._get_var_type:
-                    raise xml.sax.SAXException("Error: nested hsterms:type elements within hsterms:netcdfVariable.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:type elements within hsterms:netcdfVariable.")
                 self._get_var_type = True
                 self._var_type = []
 
         elif name == 'hsterms:comment':
             if self._get_var_details:
                 if self._get_var_comment:
-                    raise xml.sax.SAXException("Error: nested hsterms:comment elements within hsterms:netcdfVariable.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:comment elements within hsterms:netcdfVariable.")
                 self._get_var_comment = True
                 self._var_comment = []
 
         elif name == 'hsterms:unit':
             if self._get_var_details:
                 if self._get_var_unit:
-                    raise xml.sax.SAXException("Error: nested hsterms:unit elements within hsterms:netcdfVariable.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:unit elements within hsterms:netcdfVariable.")
                 self._get_var_unit = True
                 self._var_unit = []
 
@@ -359,7 +359,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
         if name == 'hsterms:netcdfVariable':
             if not self._get_var:
                 msg = "Error: close hsterms:netcdfVariable tag without corresponding open tag."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._get_var = False
 
         elif name == 'rdf:Description':
@@ -367,7 +367,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_details:
                     msg = "Error: close rdf:Description tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self._get_var_details = False
 
         elif name == 'hsterms:name':
@@ -375,7 +375,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_name:
                     msg = "Error: close hsterms:name tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.variables[-1].name = "".join(self._var_name)
                 self._var_name = None
                 self._get_var_name = False
@@ -385,7 +385,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_shape:
                     msg = "Error: close hsterms:shape tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.variables[-1].shape = "".join(self._var_shape)
                 self._var_shape = None
                 self._get_var_shape = False
@@ -395,7 +395,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_long_name:
                     msg = "Error: close hsterms:longName tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.variables[-1].longName = "".join(self._var_long_name)
                 self._var_long_name = None
                 self._get_var_long_name = False
@@ -405,7 +405,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_missing_val:
                     msg = "Error: close hsterms:missingValue tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.variables[-1].missingValue = "".join(self._var_missing_val)
                 self._var_missing_val = None
                 self._get_var_missing_val = False
@@ -415,7 +415,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_type:
                     msg = "Error: close hsterms:type tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.variables[-1].type = "".join(self._var_type)
                 self._var_type = None
                 self._get_var_type = False
@@ -425,7 +425,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_comment:
                     msg = "Error: close hsterms:comment tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.variables[-1].comment = "".join(self._var_comment)
                 self._var_comment = None
                 self._get_var_comment = False
@@ -435,7 +435,7 @@ class NetcdfResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_var_unit:
                     msg = "Error: close hsterms:unit tag without corresponding open tag "
                     msg += "within hsterms:netcdfVariable."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.variables[-1].unit = "".join(self._var_unit)
                 self._var_unit = None
                 self._get_var_unit = False

--- a/hs_core/serialization.py
+++ b/hs_core/serialization.py
@@ -1,6 +1,6 @@
 import os
 import heapq
-import xml.sax
+import defusedxml.sax
 import urlparse
 import logging
 
@@ -444,7 +444,7 @@ class GenericResourceMeta(object):
         # Also parse using SAX so that we can capture certain metadata elements
         # in the same order in which they appear in the RDF+XML serialization.
         SAX_parse_results = GenericResourceSAXHandler()
-        xml.sax.parse(self.rmeta_path, SAX_parse_results)
+        defusedxml.sax.parse(self.rmeta_path, SAX_parse_results)
 
         hsterms = rdflib.namespace.Namespace('http://hydroshare.org/terms/')
 
@@ -1246,9 +1246,9 @@ class GenericResourceMeta(object):
         pass
 
 
-class GenericResourceSAXHandler(xml.sax.ContentHandler):
+class GenericResourceSAXHandler(defusedxml.sax.ContentHandler):
     def __init__(self):
-        xml.sax.ContentHandler.__init__(self)
+        defusedxml.sax.ContentHandler.__init__(self)
 
         # Content
         self.subjects = []
@@ -1276,47 +1276,47 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
             if len(self.contributors) < 1:
                 msg = "Error: haven't yet encountered contributor, "
                 msg += "yet trying to store contributor name."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._contributor_name.append(content)
 
         elif self._get_contributor_organization:
             if len(self.contributors) < 1:
                 msg = "Error: haven't yet encountered contributor, "
                 msg += "yet trying to store contributor organization."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._contributor_organization.append(content)
 
         elif self._get_contributor_email:
             if len(self.contributors) < 1:
                 msg = "Error: haven't yet encountered contributor, "
                 msg += "yet trying to store contributor email."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._contributor_email.append(content)
 
         elif self._get_contributor_address:
             if len(self.contributors) < 1:
                 msg = "Error: haven't yet encountered contributor, "
                 msg += "yet trying to store contributor address."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._contributor_address.append(content)
 
     def startElement(self, name, attrs):
         if name == 'dc:subject':
             if self._get_subject:
-                raise xml.sax.SAXException("Error: nested dc:subject elements.")
+                raise defusedxml.sax.SAXException("Error: nested dc:subject elements.")
             self._get_subject = True
             self._subject = []
 
         elif name == 'dc:contributor':
             if self._get_contributor:
-                raise xml.sax.SAXException("Error: nested dc:contributor elements.")
+                raise defusedxml.sax.SAXException("Error: nested dc:contributor elements.")
             self._get_contributor = True
 
         elif name == 'rdf:Description':
             if self._get_contributor:
                 if self._get_contributor_details:
                     msg = "Error: nested rdf:Description elements within dc:contributor element."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 # Create new contributor
                 contributor = GenericResourceMeta.ResourceContributor()
                 if attrs.has_key('rdf:about'):
@@ -1327,28 +1327,28 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
         elif name == 'hsterms:name':
             if self._get_contributor_details:
                 if self._get_contributor_name:
-                    raise xml.sax.SAXException("Error: nested hsterms:name elements within dc:contributor.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:name elements within dc:contributor.")
                 self._get_contributor_name = True
                 self._contributor_name = []
 
         elif name == 'hsterms:organization':
             if self._get_contributor_details:
                 if self._get_contributor_organization:
-                    raise xml.sax.SAXException("Error: nested hsterms:organization elements within dc:contributor.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:organization elements within dc:contributor.")
                 self._get_contributor_organization = True
                 self._contributor_organization = []
 
         elif name == 'hsterms:email':
             if self._get_contributor_details:
                 if self._get_contributor_email:
-                    raise xml.sax.SAXException("Error: nested hsterms:email elements within dc:contributor.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:email elements within dc:contributor.")
                 self._get_contributor_email = True
                 self._contributor_email = []
 
         elif name == 'hsterms:address':
             if self._get_contributor_details:
                 if self._get_contributor_address:
-                    raise xml.sax.SAXException("Error: nested hsterms:address elements within dc:contributor.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:address elements within dc:contributor.")
                 self._get_contributor_address = True
                 self._contributor_address = []
 
@@ -1356,7 +1356,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
             if self._get_contributor_details:
                 if not attrs.has_key('rdf:resource'):
                     msg = "Error: hsterms:phone within dc:contributor element has no phone number."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 phone_raw = str(attrs.getValue('rdf:resource')).split(':')
                 if len(phone_raw) > 1:
                     self.contributors[-1].phone = phone_raw[1]
@@ -1367,7 +1367,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
         if name == 'dc:subject':
             if not self._get_subject:
                 msg = "Error: close dc:subject tag without corresponding open tag."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self.subjects.append("".join(self._subject))
             self._subject = None
             self._get_subject = False
@@ -1375,7 +1375,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
         elif name == 'dc:contributor':
             if not self._get_contributor:
                 msg = "Error: close dc:contributor tag without corresponding open tag."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._get_contributor = False
 
         elif name == 'rdf:Description':
@@ -1383,7 +1383,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_contributor_details:
                     msg = "Error: close rdf:Description tag without corresponding open tag "
                     msg += "within dc:contributor."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self._get_contributor_details = False
 
         elif name == 'hsterms:name':
@@ -1391,7 +1391,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_contributor_name:
                     msg = "Error: close hsterms:name tag without corresponding open tag "
                     msg += "within dc:contributor."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.contributors[-1].name = "".join(self._contributor_name)
                 self._contributor_name = None
                 self._get_contributor_name = False
@@ -1401,7 +1401,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_contributor_organization:
                     msg = "Error: close hsterms:organization tag without corresponding open tag "
                     msg += "within dc:contributor."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.contributors[-1].organization = "".join(self._contributor_organization)
                 self._contributor_organization = None
                 self._get_contributor_organization = False
@@ -1411,7 +1411,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_contributor_email:
                     msg = "Error: close hsterms:email tag without corresponding open tag "
                     msg += "within dc:contributor."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.contributors[-1].email = "".join(self._contributor_email)
                 self._contributor_email = None
                 self._get_contributor_email = False
@@ -1421,7 +1421,7 @@ class GenericResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_contributor_address:
                     msg = "Error: close hsterms:address tag without corresponding open tag "
                     msg += "within dc:contributor."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.contributors[-1].address = "".join(self._contributor_address)
                 self._contributor_address = None
                 self._get_contributor_address = False

--- a/hs_core/tests/serialization/test_resourcemeta_sax_parsing.py
+++ b/hs_core/tests/serialization/test_resourcemeta_sax_parsing.py
@@ -1,6 +1,6 @@
 # run with: python manage.py test hs_core.tests.serialization.test_resourcemeta_sax_parsing
 import unittest
-import xml.sax
+import defusedxml.sax
 
 from hs_core.serialization import GenericResourceSAXHandler
 from hs_geo_raster_resource.serialization import RasterResourceSAXHandler
@@ -48,7 +48,7 @@ class TestGenericResourceMetaSax(unittest.TestCase):
 
     def test_sax_parsing(self):
         handler = GenericResourceSAXHandler()
-        xml.sax.parseString(self.parse_sample, handler)
+        defusedxml.sax.parseString(self.parse_sample, handler)
 
         self.assertTrue(len(handler.subjects) == 4)
         self.assertEqual(handler.subjects[0], 'HydroShare')
@@ -115,7 +115,7 @@ class TestRasterResourceMetaSax(unittest.TestCase):
 
     def test_sax_parsing(self):
         handler = RasterResourceSAXHandler()
-        xml.sax.parseString(self.parse_sample, handler)
+        defusedxml.sax.parseString(self.parse_sample, handler)
 
         self.assertTrue(len(handler.band_info) == 3)
         self.assertEqual(handler.band_info[0].name, 'Band_1')
@@ -186,7 +186,7 @@ class TestNetcdfResourceMetaSax(unittest.TestCase):
 
     def test_sax_parsing(self):
         handler = NetcdfResourceSAXHandler()
-        xml.sax.parseString(self.parse_sample, handler)
+        defusedxml.sax.parseString(self.parse_sample, handler)
 
         self.assertTrue(len(handler.variables) == 3)
         self.assertEqual(handler.variables[0].name, 'ACLWDNB')

--- a/hs_geo_raster_resource/serialization.py
+++ b/hs_geo_raster_resource/serialization.py
@@ -1,4 +1,4 @@
-import xml.sax
+import defusedxml.sax
 
 import rdflib
 
@@ -28,7 +28,7 @@ class RasterResourceMeta(GenericResourceMeta):
         # Also parse using SAX so that we can capture certain metadata elements
         # in the same order in which they appear in the RDF+XML serialization.
         SAX_parse_results = RasterResourceSAXHandler()
-        xml.sax.parse(self.rmeta_path, SAX_parse_results)
+        defusedxml.sax.parse(self.rmeta_path, SAX_parse_results)
 
         hsterms = rdflib.namespace.Namespace('http://hydroshare.org/terms/')
 
@@ -273,9 +273,9 @@ class RasterResourceMeta(GenericResourceMeta):
                 elif key == 'projection':
                     self.projection = value
 
-class RasterResourceSAXHandler(xml.sax.ContentHandler):
+class RasterResourceSAXHandler(defusedxml.sax.ContentHandler):
     def __init__(self):
-        xml.sax.ContentHandler.__init__(self)
+        defusedxml.sax.ContentHandler.__init__(self)
 
         # Content
         self.band_info = []
@@ -299,48 +299,48 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
             if len(self.band_info) < 1:
                 msg = "Error: haven't yet encountered band information, "
                 msg += "yet trying to store band information name."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._bandinfo_name.append(content)
 
         elif self._get_bandinfo_var_name:
             if len(self.band_info) < 1:
                 msg = "Error: haven't yet encountered band information, "
                 msg += "yet trying to store band information variable name."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._bandinfo_var_name.append(content)
 
         elif self._get_bandinfo_var_unit:
             if len(self.band_info) < 1:
                 msg = "Error: haven't yet encountered band information, "
                 msg += "yet trying to store band information variable unit."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._bandinfo_var_unit.append(content)
 
         elif self._get_bandinfo_method:
             if len(self.band_info) < 1:
                 msg = "Error: haven't yet encountered band information, "
                 msg += "yet trying to store band information method."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._bandinfo_method.append(content)
 
         elif self._get_bandinfo_comment:
             if len(self.band_info) < 1:
                 msg = "Error: haven't yet encountered band information, "
                 msg += "yet trying to store band information comment."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._bandinfo_comment.append(content)
 
     def startElement(self, name, attrs):
         if name == 'hsterms:BandInformation':
             if self._get_bandinfo:
-                raise xml.sax.SAXException("Error: nested hsterms:BandInformation elements.")
+                raise defusedxml.sax.SAXException("Error: nested hsterms:BandInformation elements.")
             self._get_bandinfo = True
 
         elif name == 'rdf:Description':
             if self._get_bandinfo:
                 if self._get_bandinfo_details:
                     msg = "Error: nested rdf:Description elements within hsterms:BandInformation element."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 # Create new band info
                 self.band_info.append(RasterResourceMeta.BandInformation())
                 self._get_bandinfo_details = True
@@ -348,35 +348,35 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
         elif name == 'hsterms:name':
             if self._get_bandinfo_details:
                 if self._get_bandinfo_name:
-                    raise xml.sax.SAXException("Error: nested hsterms:name elements within hsterms:BandInformation.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:name elements within hsterms:BandInformation.")
                 self._get_bandinfo_name = True
                 self._bandinfo_name = []
 
         elif name == 'hsterms:variableName':
             if self._get_bandinfo_details:
                 if self._get_bandinfo_var_name:
-                    raise xml.sax.SAXException("Error: nested hsterms:variableName elements within hsterms:BandInformation.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:variableName elements within hsterms:BandInformation.")
                 self._get_bandinfo_var_name = True
                 self._bandinfo_var_name = []
 
         elif name == 'hsterms:variableUnit':
             if self._get_bandinfo_details:
                 if self._get_bandinfo_var_unit:
-                    raise xml.sax.SAXException("Error: nested hsterms:variableUnit elements within hsterms:BandInformation.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:variableUnit elements within hsterms:BandInformation.")
                 self._get_bandinfo_var_unit = True
                 self._bandinfo_var_unit = []
 
         elif name == 'hsterms:method':
             if self._get_bandinfo_details:
                 if self._get_bandinfo_method:
-                    raise xml.sax.SAXException("Error: nested hsterms:method elements within hsterms:BandInformation.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:method elements within hsterms:BandInformation.")
                 self._get_bandinfo_method = True
                 self._bandinfo_method = []
 
         elif name == 'hsterms:comment':
             if self._get_bandinfo_details:
                 if self._get_bandinfo_comment:
-                    raise xml.sax.SAXException("Error: nested hsterms:comment elements within hsterms:BandInformation.")
+                    raise defusedxml.sax.SAXException("Error: nested hsterms:comment elements within hsterms:BandInformation.")
                 self._get_bandinfo_comment = True
                 self._bandinfo_comment = []
 
@@ -384,7 +384,7 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
         if name == 'hsterms:BandInformation':
             if not self._get_bandinfo:
                 msg = "Error: close hsterms:BandInformation tag without corresponding open tag."
-                raise xml.sax.SAXException(msg)
+                raise defusedxml.sax.SAXException(msg)
             self._get_bandinfo = False
 
         elif name == 'rdf:Description':
@@ -392,7 +392,7 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_bandinfo_details:
                     msg = "Error: close rdf:Description tag without corresponding open tag "
                     msg += "within hsterms:BandInformation."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self._get_bandinfo_details = False
 
         elif name == 'hsterms:name':
@@ -400,7 +400,7 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_bandinfo_name:
                     msg = "Error: close hsterms:name tag without corresponding open tag "
                     msg += "within hsterms:BandInformation."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.band_info[-1].name = "".join(self._bandinfo_name)
                 self._bandinfo_name = None
                 self._get_bandinfo_name = False
@@ -410,7 +410,7 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_bandinfo_var_name:
                     msg = "Error: close hsterms:variableName tag without corresponding open tag "
                     msg += "within hsterms:BandInformation."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.band_info[-1].variableName = "".join(self._bandinfo_var_name)
                 self._bandinfo_var_name = None
                 self._get_bandinfo_var_name = False
@@ -420,7 +420,7 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_bandinfo_var_unit:
                     msg = "Error: close hsterms:variableUnit tag without corresponding open tag "
                     msg += "within hsterms:BandInformation."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.band_info[-1].variableUnit = "".join(self._bandinfo_var_unit)
                 self._bandinfo_var_unit = None
                 self._get_bandinfo_var_unit = False
@@ -430,7 +430,7 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_bandinfo_method:
                     msg = "Error: close hsterms:method tag without corresponding open tag "
                     msg += "within hsterms:BandInformation."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.band_info[-1].method = "".join(self._bandinfo_method)
                 self._bandinfo_method = None
                 self._get_bandinfo_method = False
@@ -440,7 +440,7 @@ class RasterResourceSAXHandler(xml.sax.ContentHandler):
                 if not self._get_bandinfo_comment:
                     msg = "Error: close hsterms:comment tag without corresponding open tag "
                     msg += "within hsterms:BandInformation."
-                    raise xml.sax.SAXException(msg)
+                    raise defusedxml.sax.SAXException(msg)
                 self.band_info[-1].comment = "".join(self._bandinfo_comment)
                 self._bandinfo_comment = None
                 self._get_bandinfo_comment = False

--- a/ref_ts/ts_utils.py
+++ b/ref_ts/ts_utils.py
@@ -6,7 +6,7 @@ from dateutil import parser
 from lxml import etree
 from suds.transport import TransportError
 from suds.client import Client
-from xml.sax._exceptions import SAXParseException
+from defusedxml.sax._exceptions import SAXParseException
 import matplotlib.pyplot as plt
 
 from hs_core import hydroshare


### PR DESCRIPTION
This should stop the problem we've been having with downloading DTDs
causing timeouts, plus it mitigates or prevents a variety of other
vulnerabilities that XML parsing exposes.