### PR TITLE
1365 webapp changes for netcdf res

### DIFF
--- a/hs_access_control/models.py
+++ b/hs_access_control/models.py
@@ -2716,3 +2716,15 @@ class ResourceAccess(models.Model):
             return PrivilegeCodes.VIEW
         else:
             return user_priv
+
+    @property
+    def sharing_status(self):
+
+        if self.published:
+            return "published"
+        elif self.public:
+            return "public"
+        elif self.discoverable:
+            return "discoverable"
+        else:
+            return "private"

--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -156,6 +156,19 @@ class NetcdfResource(BaseResource):
         # can have only 1 file
         return False
 
+    # add resource-specific HS terms
+    def get_hs_term_dict(self):
+        # get existing hs_term_dict from base class
+        hs_term_dict = super(NetcdfResource, self).get_hs_term_dict()
+        # add new terms for NetCDF res
+        hs_term_dict["HS_NETCDF_FILE_NAME"] = ""
+        for res_file in self.files.all():
+            fn = res_file.resource_file.name
+            if fn.lower().endswith('.nc'):
+                hs_term_dict["HS_NETCDF_FILE_NAME"] = fn[fn.rfind('/')+1:]
+                break
+        return hs_term_dict
+
     class Meta:
         verbose_name = 'Multidimensional (NetCDF)'
         proxy = True

--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -163,9 +163,9 @@ class NetcdfResource(BaseResource):
         # add new terms for NetCDF res
         hs_term_dict["HS_NETCDF_FILE_NAME"] = ""
         for res_file in self.files.all():
-            f_name, f_ext = get_resource_file_name_and_extension(res_file)
+            f_fullname, f_ext = get_resource_file_name_and_extension(res_file)
             if f_ext.lower() == '.nc':
-                hs_term_dict["HS_NETCDF_FILE_NAME"] = f_name + f_ext
+                hs_term_dict["HS_NETCDF_FILE_NAME"] = f_fullname
                 break
         return hs_term_dict
 

--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -10,7 +10,7 @@ from mezzanine.pages.page_processors import processor_for
 
 from hs_core.models import BaseResource, ResourceManager
 from hs_core.models import resource_processor, CoreMetaData, AbstractMetaDataElement
-
+from hs_core.hydroshare.utils import get_resource_file_name_and_extension
 
 # Define original spatial coverage metadata info
 class OriginalCoverage(AbstractMetaDataElement):
@@ -163,9 +163,9 @@ class NetcdfResource(BaseResource):
         # add new terms for NetCDF res
         hs_term_dict["HS_NETCDF_FILE_NAME"] = ""
         for res_file in self.files.all():
-            fn = res_file.resource_file.name
-            if fn.lower().endswith('.nc'):
-                hs_term_dict["HS_NETCDF_FILE_NAME"] = fn[fn.rfind('/')+1:]
+            f_name, f_ext = get_resource_file_name_and_extension(res_file)
+            if f_ext.lower() == '.nc':
+                hs_term_dict["HS_NETCDF_FILE_NAME"] = f_name + f_ext
                 break
         return hs_term_dict
 

--- a/hs_app_netCDF/receivers.py
+++ b/hs_app_netCDF/receivers.py
@@ -199,7 +199,7 @@ def netcdf_pre_create_resource(sender, **kwargs):
 def netcdf_pre_delete_file_from_resource(sender, **kwargs):
     nc_res = kwargs['resource']
     del_file = kwargs['file']
-    del_file_ext = utils.get_resource_file_extension(del_file)
+    del_file_ext = utils.get_resource_file_name_and_extension(del_file)[1]
 
     # update resource modification info
     user = nc_res.creator
@@ -212,7 +212,7 @@ def netcdf_pre_delete_file_from_resource(sender, **kwargs):
     if del_file_ext in file_ext:
         del file_ext[del_file_ext]
         for f in ResourceFile.objects.filter(object_id=nc_res.id):
-            ext = utils.get_resource_file_extension(f)
+            ext = utils.get_resource_file_name_and_extension(f)[1]
             if ext in file_ext:
                 delete_resource_file_only(nc_res, f)
                 nc_res.metadata.formats.filter(value=file_ext[ext]).delete()

--- a/hs_app_timeseries/receivers.py
+++ b/hs_app_timeseries/receivers.py
@@ -46,7 +46,7 @@ def pre_delete_file_from_resource_handler(sender, **kwargs):
             element.save()
 
     # check if it is a sqlite file
-    fl_ext = utils.get_resource_file_extension(del_file)
+    fl_ext = utils.get_resource_file_name_and_extension(del_file)[1]
     if fl_ext == '.sqlite' and resource.metadata.is_dirty:
         TimeSeriesMetaData.objects.filter(id=resource.metadata.id).update(is_dirty=False)
         # metadata object is_dirty attribute for some reason can't be set using the following
@@ -99,7 +99,7 @@ def post_create_resource_handler(sender, **kwargs):
 def _process_uploaded_sqlite_file(user, resource, res_file, validate_files_dict,
                                   delete_existing_metadata=True):
     # check if it a sqlite file
-    fl_ext = utils.get_resource_file_extension(res_file)
+    fl_ext = utils.get_resource_file_name_and_extension(res_file)[1]
 
     if fl_ext == '.sqlite':
         # get the file from iRODS to a temp directory

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -322,6 +322,26 @@ def get_resource_file_extension(res_file):
     return fl_ext
 
 
+def get_resource_file_name_and_extension(res_file):
+    """
+    Gets the file extension of the specified resource file
+    :param res_file: an instance of ResourceFile for which file extension to be retrieved
+    :return: (file name, file extension)
+    """
+    f_fullname = None
+    if res_file.resource_file:
+        f_fullname = res_file.resource_file.name
+    elif res_file.fed_resource_file:
+        f_fullname = res_file.fed_resource_file.name
+    elif res_file.fed_resource_file_name_or_path:
+        f_fullname = res_file.fed_resource_file_name_or_path
+
+    f_fullname = f_fullname[f_fullname.rfind('/')+1:]
+    file_name, file_ext = os.path.splitext(f_fullname.lower())
+
+    return file_name, file_ext
+
+
 def delete_fed_zone_file(file_name_with_full_path):
     '''
     Args:

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -309,7 +309,7 @@ def get_resource_file_name_and_extension(res_file):
     """
     Gets the file name and extension of the specified resource file
     :param res_file: an instance of ResourceFile for which file extension to be retrieved
-    :return: (file name, file extension)
+    :return: (full filename, file extension) ex: "/my_path_to/ABC.nc" --> ("ABC.nc", ".nc")
     """
     f_fullname = None
     if res_file.resource_file:
@@ -320,9 +320,9 @@ def get_resource_file_name_and_extension(res_file):
         f_fullname = res_file.fed_resource_file_name_or_path
 
     f_fullname = os.path.basename(f_fullname)
-    file_name, file_ext = os.path.splitext(f_fullname)
+    _, file_ext = os.path.splitext(f_fullname)
 
-    return file_name, file_ext
+    return f_fullname, file_ext
 
 
 def delete_fed_zone_file(file_name_with_full_path):

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -305,26 +305,9 @@ def replace_resource_file_on_irods(new_file, original_resource_file):
     istorage.saveFile(new_file, destination_file, True)
 
 
-def get_resource_file_extension(res_file):
-    """
-    Gets the file extension of the specified resource file
-    :param res_file: an instance of ResourceFile for which file extension to be retrieved
-    :return: file extension
-    """
-    fl_ext = None
-    if res_file.resource_file:
-        fl_ext = os.path.splitext(res_file.resource_file.name)[1]
-    elif res_file.fed_resource_file:
-        fl_ext = os.path.splitext(res_file.fed_resource_file.name)[1]
-    elif res_file.fed_resource_file_name_or_path:
-        fl_ext = os.path.splitext(res_file.fed_resource_file_name_or_path)[1]
-
-    return fl_ext
-
-
 def get_resource_file_name_and_extension(res_file):
     """
-    Gets the file extension of the specified resource file
+    Gets the file name and extension of the specified resource file
     :param res_file: an instance of ResourceFile for which file extension to be retrieved
     :return: (file name, file extension)
     """
@@ -336,8 +319,8 @@ def get_resource_file_name_and_extension(res_file):
     elif res_file.fed_resource_file_name_or_path:
         f_fullname = res_file.fed_resource_file_name_or_path
 
-    f_fullname = f_fullname[f_fullname.rfind('/')+1:]
-    file_name, file_ext = os.path.splitext(f_fullname.lower())
+    f_fullname = os.path.basename(f_fullname)
+    file_name, file_ext = os.path.splitext(f_fullname)
 
     return file_name, file_ext
 

--- a/hs_core/page_processors.py
+++ b/hs_core/page_processors.py
@@ -66,7 +66,8 @@ def get_page_context(page, user, resource_edit=False, extended_metadata_layout=N
                 if tool_res_obj:
                     sharing_status_supported = False
 
-                    supported_sharing_status_obj = tool_res_obj.metadata.sharing_status.first()
+                    supported_sharing_status_obj = tool_res_obj.metadata.\
+                        supported_sharing_status.first()
                     if supported_sharing_status_obj is not None:
                         suppored_sharing_status_str = supported_sharing_status_obj.\
                                                       get_sharing_status_str()
@@ -75,12 +76,8 @@ def get_page_context(page, user, resource_edit=False, extended_metadata_layout=N
                             if suppored_sharing_status_str.lower().\
                                     find(res_sharing_status.lower()) != -1:
                                 sharing_status_supported = True
-                        else:
-                            #  webapp with an empty sharing status metadata does not support
-                            #  any sharing status
-                            pass
                     else:
-                        # webapp without sharing_status metadata
+                        # backward compatible: webapp without supported_sharing_status metadata
                         # is considered to support all sharing status
                         sharing_status_supported = True
 

--- a/hs_core/templates/pages/metadata_terms.html
+++ b/hs_core/templates/pages/metadata_terms.html
@@ -1333,6 +1333,7 @@
                 <li> <strong>${HS_RES_ID}</strong>: Resource ID</li>
                 <li> <strong>${HS_RES_TYPE}</strong>: Resource Type</li>
                 <li> <strong>${HS_USR_NAME}</strong>: HydroShare username</li>
+                <li> <strong>${HS_NETCDF_FILE_NAME}</strong>: Fullname of the '.nc' file in a NetCDF res</li>
             </ul>
                 An example:<br>
  <strong>http://www.my-app-website.org/app_1/?res_id=${HS_RES_ID}</strong>.<br>HydroShare will replace ${HS_RES_ID} with the real resource id.

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -16,7 +16,7 @@ class UrlBaseFormHelper(BaseFormHelper):
         layout = Layout(
             Field('value', css_class=field_width)
         )
-        kwargs['element_name_label'] = "App URL <a href='/terms#AppURL' target='_blank'><font size='3'>Help</font></a>"
+        kwargs['element_name_label'] = "App URL Pattern <a href='/terms#AppURL' target='_blank'><font size='3'>Help</font></a>"
 
         super(UrlBaseFormHelper, self).__init__(allow_edit, res_short_id, element_id, element_name, layout,  *args, **kwargs)
 

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -91,17 +91,30 @@ class ToolIconForm(ModelForm):
 class ToolIconValidationForm(forms.Form):
     url = forms.CharField(max_length=1024)
 
-parameters_choices = (
-    ('GenericResource', 'Generic Resource'),
-    ('RasterResource', 'Raster Resource'),
-    ('RefTimeSeriesResource', 'HIS Referenced Time Series Resource'),
-    ('TimeSeriesResource', 'Time Series Resource'),
-    ('NetcdfResource', 'NetCDF Resource'),
-    ('ModelProgramResource', 'Model Program Resource'),
-    ('ModelInstanceResource', 'Model Instance Resource'),
-    ('SWATModelInstanceResource', 'SWAT Model Instance Resource'),
-    ('GeographicFeatureResource', 'Geographic Feature Resource'),
-    ('ScriptResource', 'Script Resource')
+# SupportedResTypes_choices = (
+#     ('GenericResource', 'Generic Resource'),
+#     ('RasterResource', 'Raster Resource'),
+#     ('RefTimeSeriesResource', 'HIS Referenced Time Series Resource'),
+#     ('TimeSeriesResource', 'Time Series Resource'),
+#     ('NetcdfResource', 'NetCDF Resource'),
+#     ('ModelProgramResource', 'Model Program Resource'),
+#     ('ModelInstanceResource', 'Model Instance Resource'),
+#     ('SWATModelInstanceResource', 'SWAT Model Instance Resource'),
+#     ('GeographicFeatureResource', 'Geographic Feature Resource'),
+#     ('ScriptResource', 'Script Resource'),
+# )
+
+SupportedResTypes_choices = (
+    ('GenericResource', 'GenericResource'),
+    ('RasterResource', 'RasterResource'),
+    ('RefTimeSeriesResource', 'RefTimeSeriesResource'),
+    ('TimeSeriesResource', 'TimeSeriesResource'),
+    ('NetcdfResource', 'NetcdfResource'),
+    ('ModelProgramResource', 'ModelProgramResource'),
+    ('ModelInstanceResource', 'ModelInstanceResource'),
+    ('SWATModelInstanceResource', 'SWATModelInstanceResource'),
+    ('GeographicFeatureResource', 'GeographicFeatureResource'),
+    ('ScriptResource', 'ScriptResource'),
 )
 
 
@@ -122,7 +135,7 @@ class SupportedResTypeFormHelper(BaseFormHelper):
 
 
 class SupportedResTypesForm(ModelForm):
-    supported_res_types = forms.MultipleChoiceField(choices=parameters_choices,
+    supported_res_types = forms.MultipleChoiceField(choices=SupportedResTypes_choices,
                                                     widget=forms.CheckboxSelectMultiple(
                                                             attrs={'style': 'width:auto;margin-top:-5px'}))
 
@@ -134,21 +147,18 @@ class SupportedResTypesForm(ModelForm):
             try:
                 supported_res_types = self.instance.supported_res_types.all()
                 if len(supported_res_types) > 0:
-                    checked_item_list = []
-                    for parameter in supported_res_types:
-                        checked_item_list.append(parameter.description)
-
-                    self.fields['supported_res_types'].initial = checked_item_list
+                    self.initial['supported_res_types'] = \
+                        [parameter.description for parameter in supported_res_types]
                 else:
-                    self.fields['supported_res_types'].initial = []
+                    self.initial['supported_res_types'] = []
             except:
-                self.fields['supported_res_types'].initial = []
+                self.initial['supported_res_types'] = []
 
     class Meta:
         model = SupportedResTypes
-        fields = '__all__'
+        fields = ('supported_res_types',)
 
 
 class SupportedResTypesValidationForm(forms.Form):
-    supported_res_types = forms.MultipleChoiceField(choices=parameters_choices, required=False)
+    supported_res_types = forms.MultipleChoiceField(choices=SupportedResTypes_choices, required=False)
 

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -3,7 +3,7 @@ from django import forms
 
 from crispy_forms.layout import Layout, Field
 
-from models import RequestUrlBase, ToolVersion, SupportedResTypes, ToolIcon
+from models import RequestUrlBase, ToolVersion, SupportedResTypes, ToolIcon, SupportedSharingStatus
 from hs_core.forms import BaseFormHelper
 
 
@@ -91,30 +91,17 @@ class ToolIconForm(ModelForm):
 class ToolIconValidationForm(forms.Form):
     url = forms.CharField(max_length=1024)
 
-# SupportedResTypes_choices = (
-#     ('GenericResource', 'Generic Resource'),
-#     ('RasterResource', 'Raster Resource'),
-#     ('RefTimeSeriesResource', 'HIS Referenced Time Series Resource'),
-#     ('TimeSeriesResource', 'Time Series Resource'),
-#     ('NetcdfResource', 'NetCDF Resource'),
-#     ('ModelProgramResource', 'Model Program Resource'),
-#     ('ModelInstanceResource', 'Model Instance Resource'),
-#     ('SWATModelInstanceResource', 'SWAT Model Instance Resource'),
-#     ('GeographicFeatureResource', 'Geographic Feature Resource'),
-#     ('ScriptResource', 'Script Resource'),
-# )
-
 SupportedResTypes_choices = (
-    ('GenericResource', 'GenericResource'),
-    ('RasterResource', 'RasterResource'),
-    ('RefTimeSeriesResource', 'RefTimeSeriesResource'),
-    ('TimeSeriesResource', 'TimeSeriesResource'),
-    ('NetcdfResource', 'NetcdfResource'),
-    ('ModelProgramResource', 'ModelProgramResource'),
-    ('ModelInstanceResource', 'ModelInstanceResource'),
-    ('SWATModelInstanceResource', 'SWATModelInstanceResource'),
-    ('GeographicFeatureResource', 'GeographicFeatureResource'),
-    ('ScriptResource', 'ScriptResource'),
+    ('GenericResource', 'Generic Resource'),
+    ('RasterResource', 'Raster Resource'),
+    ('RefTimeSeriesResource', 'HIS Referenced Time Series Resource'),
+    ('TimeSeriesResource', 'Time Series Resource'),
+    ('NetcdfResource', 'NetCDF Resource'),
+    ('ModelProgramResource', 'Model Program Resource'),
+    ('ModelInstanceResource', 'Model Instance Resource'),
+    ('SWATModelInstanceResource', 'SWAT Model Instance Resource'),
+    ('GeographicFeatureResource', 'Geographic Feature Resource'),
+    ('ScriptResource', 'Script Resource'),
 )
 
 
@@ -147,6 +134,10 @@ class SupportedResTypesForm(ModelForm):
             try:
                 supported_res_types = self.instance.supported_res_types.all()
                 if len(supported_res_types) > 0:
+                    # NOTE: The following code works for SWAT res type but does not work here!!!
+                    # self.fields['supported_res_types'].initial =
+                    #   [parameter.description for parameter in supported_res_types]
+
                     self.initial['supported_res_types'] = \
                         [parameter.description for parameter in supported_res_types]
                 else:
@@ -162,3 +153,54 @@ class SupportedResTypesForm(ModelForm):
 class SupportedResTypesValidationForm(forms.Form):
     supported_res_types = forms.MultipleChoiceField(choices=SupportedResTypes_choices, required=False)
 
+
+SupportedSharingStatus_choices = (
+    ('Published', 'Published'),
+    ('Public', 'Public'),
+    ('Discoverable', 'Discoverable'),
+    ('Private', 'Private'),
+)
+
+
+class SupportedSharingStatusFormHelper(BaseFormHelper):
+    def __init__(self, allow_edit=True, res_short_id=None,
+                 element_id=None, element_name=None,  *args, **kwargs):
+
+        # the order in which the model fields are listed for
+        # the FieldSet is the order these fields will be displayed
+        layout = Layout(MetadataField('sharing_status'))
+        kwargs['element_name_label'] = 'Supported Resource Sharing Status'
+        super(SupportedSharingStatusFormHelper, self).\
+            __init__(allow_edit, res_short_id, element_id,
+                     element_name, layout,  *args, **kwargs)
+
+
+class SupportedSharingStatusForm(ModelForm):
+    sharing_status = forms.MultipleChoiceField(choices=SupportedSharingStatus_choices,
+                                               widget=forms.CheckboxSelectMultiple(
+                                                attrs={'style': 'width:auto;margin-top:-5px'}))
+
+    def __init__(self, allow_edit=True, res_short_id=None, element_id=None, *args, **kwargs):
+        super(SupportedSharingStatusForm, self).__init__(*args, **kwargs)
+        self.fields['sharing_status'].label = "Choose Sharing Status:"
+        self.helper = SupportedSharingStatusFormHelper(allow_edit, res_short_id, element_id,
+                                                       element_name='SupportedSharingStatus')
+        if self.instance:
+            try:
+                supported_sharing_status = self.instance.sharing_status.all()
+                if len(supported_sharing_status) > 0:
+                    self.initial['sharing_status'] = \
+                        [parameter.description for parameter in supported_sharing_status]
+                else:
+                    self.initial['sharing_status'] = []
+            except:
+                self.initial['sharing_status'] = []
+
+    class Meta:
+        model = SupportedSharingStatus
+        fields = ('sharing_status',)
+
+
+class SupportedSharingStatusValidationForm(forms.Form):
+    sharing_status = forms.MultipleChoiceField(choices=SupportedSharingStatus_choices,
+                                               required=False)

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -131,18 +131,15 @@ class SupportedResTypesForm(ModelForm):
         self.fields['supported_res_types'].label = "Choose Resource Types:"
         self.helper = SupportedResTypeFormHelper(allow_edit, res_short_id, element_id, element_name='SupportedResTypes')
         if self.instance:
-            try:
-                supported_res_types = self.instance.supported_res_types.all()
-                if len(supported_res_types) > 0:
-                    # NOTE: The following code works for SWAT res type but does not work here!!!
-                    # self.fields['supported_res_types'].initial =
-                    #   [parameter.description for parameter in supported_res_types]
+            supported_res_types = self.instance.supported_res_types.all()
+            if len(supported_res_types) > 0:
+                # NOTE: The following code works for SWAT res type but does not work here!!!
+                # self.fields['supported_res_types'].initial =
+                #   [parameter.description for parameter in supported_res_types]
 
-                    self.initial['supported_res_types'] = \
-                        [parameter.description for parameter in supported_res_types]
-                else:
-                    self.initial['supported_res_types'] = []
-            except:
+                self.initial['supported_res_types'] = \
+                    [parameter.description for parameter in supported_res_types]
+            else:
                 self.initial['supported_res_types'] = []
 
     class Meta:
@@ -186,14 +183,11 @@ class SupportedSharingStatusForm(ModelForm):
         self.helper = SupportedSharingStatusFormHelper(allow_edit, res_short_id, element_id,
                                                        element_name='SupportedSharingStatus')
         if self.instance:
-            try:
-                supported_sharing_status = self.instance.sharing_status.all()
-                if len(supported_sharing_status) > 0:
-                    self.initial['sharing_status'] = \
-                        [parameter.description for parameter in supported_sharing_status]
-                else:
-                    self.initial['sharing_status'] = []
-            except:
+            supported_sharing_status = self.instance.sharing_status.all()
+            if len(supported_sharing_status) > 0:
+                self.initial['sharing_status'] = \
+                    [parameter.description for parameter in supported_sharing_status]
+            else:
                 self.initial['sharing_status'] = []
 
     class Meta:

--- a/hs_tools_resource/migrations/0008_auto_20160729_1811.py
+++ b/hs_tools_resource/migrations/0008_auto_20160729_1811.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('hs_tools_resource', '0007_auto_20160122_2240'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SupportedSharingStatus',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('object_id', models.PositiveIntegerField()),
+                ('content_type', models.ForeignKey(related_name='hs_tools_resource_supportedsharingstatus_related', to='contenttypes.ContentType')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='SupportedSharingStatusChoices',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('description', models.CharField(max_length=128)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='supportedsharingstatus',
+            name='sharing_status',
+            field=models.ManyToManyField(to='hs_tools_resource.SupportedSharingStatusChoices', null=True, blank=True),
+        ),
+    ]

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -93,8 +93,6 @@ class SupportedResTypes(AbstractMetaDataElement):
                     else:
                         meta_instance.supported_res_types.create(description=res_type_str)
                 meta_instance.save()
-                # if meta_instance.supported_res_types.all().count() == 0:
-                #     meta_instance.delete()
             else:
                 raise ObjectDoesNotExist("No supported_res_types parameter was found in the **kwargs list")
         else:

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -78,25 +78,23 @@ class SupportedResTypes(AbstractMetaDataElement):
                     new_meta_instance.supported_res_types.create(description=res_type_str)
             return new_meta_instance
         else:
-            raise ObjectDoesNotExist("No supported_res_types parameter was found in the **kwargs list")
+            raise ValidationError("No supported_res_types parameter was found in the **kwargs list")
 
     @classmethod
     def update(cls, element_id, **kwargs):
         meta_instance = SupportedResTypes.objects.get(id=element_id)
-        if meta_instance:
-            if 'supported_res_types' in kwargs:
-                meta_instance.supported_res_types.clear()
-                for res_type_str in kwargs['supported_res_types']:
-                    qs = SupportedResTypeChoices.objects.filter(description__iexact=res_type_str)
-                    if qs.exists():
-                        meta_instance.supported_res_types.add(qs[0])
-                    else:
-                        meta_instance.supported_res_types.create(description=res_type_str)
-                meta_instance.save()
-            else:
-                raise ObjectDoesNotExist("No supported_res_types parameter was found in the **kwargs list")
+
+        if 'supported_res_types' in kwargs:
+            meta_instance.supported_res_types.clear()
+            for res_type_str in kwargs['supported_res_types']:
+                qs = SupportedResTypeChoices.objects.filter(description__iexact=res_type_str)
+                if qs.exists():
+                    meta_instance.supported_res_types.add(qs[0])
+                else:
+                    meta_instance.supported_res_types.create(description=res_type_str)
+            meta_instance.save()
         else:
-            raise ObjectDoesNotExist("No SupportedResTypes object was found with the provided id: %s" % kwargs['id'])
+            raise ValidationError("No supported_res_types parameter was found in the **kwargs list")
 
     @classmethod
     def remove(cls, element_id):
@@ -130,30 +128,25 @@ class SupportedSharingStatus(AbstractMetaDataElement):
                     new_meta_instance.sharing_status.create(description=sharing_status)
             return new_meta_instance
         else:
-            raise ObjectDoesNotExist("No sharing_status parameter was found in the **kwargs list")
+            raise ValidationError("No sharing_status parameter was found in the **kwargs list")
 
     @classmethod
     def update(cls, element_id, **kwargs):
         meta_instance = SupportedSharingStatus.objects.get(id=element_id)
-        if meta_instance:
-            if 'sharing_status' in kwargs:
-                meta_instance.sharing_status.clear()
-                for sharing_status in kwargs['sharing_status']:
-                    qs = SupportedSharingStatusChoices.objects.filter\
-                        (description__iexact=sharing_status)
-                    if qs.exists():
-                        meta_instance.sharing_status.add(qs[0])
-                    else:
-                        meta_instance.sharing_status.create(description=sharing_status)
-                meta_instance.save()
-                # if meta_instance.sharing_status.all().count() == 0:
-                #     meta_instance.delete()
-            else:
-                raise ObjectDoesNotExist("No sharing_status parameter "
-                                         "was found in the **kwargs list")
+        if 'sharing_status' in kwargs:
+            meta_instance.sharing_status.clear()
+            for sharing_status in kwargs['sharing_status']:
+                qs = SupportedSharingStatusChoices.objects.filter\
+                    (description__iexact=sharing_status)
+                if qs.exists():
+                    meta_instance.sharing_status.add(qs[0])
+                else:
+                    meta_instance.sharing_status.create(description=sharing_status)
+            meta_instance.save()
         else:
-            raise ObjectDoesNotExist("No SupportedSharingStatus object was "
-                                     "found with the provided id: %s" % kwargs['id'])
+            raise ValidationError("No sharing_status parameter "
+                                  "was found in the **kwargs list")
+
 
     @classmethod
     def remove(cls, element_id):

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -167,7 +167,7 @@ class ToolMetaData(CoreMetaData):
     versions = GenericRelation(ToolVersion)
     supported_res_types = GenericRelation(SupportedResTypes)
     tool_icon = GenericRelation(ToolIcon)
-    sharing_status = GenericRelation(SupportedSharingStatus)
+    supported_sharing_status = GenericRelation(SupportedSharingStatus)
 
     @classmethod
     def get_supported_element_names(cls):
@@ -196,8 +196,8 @@ class ToolMetaData(CoreMetaData):
         elif not self.supported_res_types.all().first().supported_res_types.count() > 0:
             missing_required_elements.append('Supported Resource Types')
 
-        if self.sharing_status.all().first():
-            if not self.sharing_status.all().first().sharing_status.count() > 0:
+        if self.supported_sharing_status.all().first():
+            if not self.supported_sharing_status.all().first().sharing_status.count() > 0:
                 missing_required_elements.append('Supported Sharing Status')
 
         return missing_required_elements
@@ -208,6 +208,6 @@ class ToolMetaData(CoreMetaData):
         self.versions.all().delete()
         self.supported_res_types.all().delete()
         self.tool_icon.all().delete()
-        self.sharing_status.all().delete()
+        self.supported_sharing_status.all().delete()
 
 import receivers # never delete this otherwise non of the receiver function will work

--- a/hs_tools_resource/page_processors.py
+++ b/hs_tools_resource/page_processors.py
@@ -4,7 +4,7 @@ from crispy_forms.layout import Layout, HTML
 from hs_core import page_processors
 from hs_core.views import add_generic_context
 
-from forms import UrlBaseForm, VersionForm, SupportedResTypesForm, ToolIconForm, parameters_choices
+from forms import UrlBaseForm, VersionForm, SupportedResTypesForm, ToolIconForm, SupportedResTypes_choices
 from models import ToolResource, RequestUrlBase
 
 
@@ -29,7 +29,7 @@ def landing_page(request, page):
             supported_res_types_str = content_model.metadata.supported_res_types.first().get_supported_res_types_str()
             supported_res_types_array = supported_res_types_str.split(',')
             for type_name in supported_res_types_array:
-                for display_name_tuple in parameters_choices:
+                for display_name_tuple in SupportedResTypes_choices:
                     if type_name.lower() == display_name_tuple[0].lower():
                         new_supported_res_types_array += [display_name_tuple[1]]
                         break
@@ -98,15 +98,15 @@ def landing_page(request, page):
         context['supported_res_types_form'] = supported_res_types_form
         context['tool_icon_form'] = tool_icon_form
 
-        if supported_res_types_obj:
-            supported_res_types = supported_res_types_obj.supported_res_types.all()
-            checked_res_str = ""
-            if len(supported_res_types) > 0:
-                for parameter in supported_res_types:
-                    checked_res_str += str(parameter.description)
-                    checked_res_str += ","
-
-            context['checked_res'] = checked_res_str
+        # if supported_res_types_obj:
+        #     supported_res_types = supported_res_types_obj.supported_res_types.all()
+        #     checked_res_str = ""
+        #     if len(supported_res_types) > 0:
+        #         for parameter in supported_res_types:
+        #             checked_res_str += str(parameter.description)
+        #             checked_res_str += ","
+        #
+        #     context['checked_res'] = checked_res_str
 
     hs_core_dublin_context = add_generic_context(request, page)
     context.update(hs_core_dublin_context)

--- a/hs_tools_resource/page_processors.py
+++ b/hs_tools_resource/page_processors.py
@@ -105,7 +105,6 @@ def landing_page(request, page):
                      '{% load crispy_forms_tags %} '
                      '{% crispy tool_icon_form %} '
                      '</div> '),
-                # HTML('<div id="checked_res_div" hidden="true">{{ checked_res }}</div>')
         )
 
         # get the context from hs_core
@@ -118,16 +117,6 @@ def landing_page(request, page):
         context['supported_res_types_form'] = supported_res_types_form
         context['tool_icon_form'] = tool_icon_form
         context['sharing_status_obj_form'] = sharing_status_obj_form
-
-        # if supported_res_types_obj:
-        #     supported_res_types = supported_res_types_obj.supported_res_types.all()
-        #     checked_res_str = ""
-        #     if len(supported_res_types) > 0:
-        #         for parameter in supported_res_types:
-        #             checked_res_str += str(parameter.description)
-        #             checked_res_str += ","
-        #
-        #     context['checked_res'] = checked_res_str
 
     hs_core_dublin_context = add_generic_context(request, page)
     context.update(hs_core_dublin_context)

--- a/hs_tools_resource/page_processors.py
+++ b/hs_tools_resource/page_processors.py
@@ -14,7 +14,7 @@ def landing_page(request, page):
     content_model = page.get_content_model()
     edit_resource = page_processors.check_resource_mode(request)
 
-    if content_model.metadata.sharing_status.first() is None:
+    if content_model.metadata.supported_sharing_status.first() is None:
         content_model.metadata.create_element('SupportedSharingStatus',
                                               sharing_status=
                                               ['Published', 'Public', 'Discoverable', 'Private'],)
@@ -41,9 +41,10 @@ def landing_page(request, page):
 
             context['supported_res_types'] = ", ".join(new_supported_res_types_array)
 
-        if content_model.metadata.sharing_status.first():
+        if content_model.metadata.supported_sharing_status.first() is not None:
             extended_metadata_exists = True
-            sharing_status_str = content_model.metadata.sharing_status.first().get_sharing_status_str()
+            sharing_status_str = content_model.metadata.supported_sharing_status.first()\
+                .get_sharing_status_str()
             context['supported_sharing_status'] = sharing_status_str
 
         if content_model.metadata.tool_icon.first():
@@ -72,7 +73,7 @@ def landing_page(request, page):
                                                          element_id=supported_res_types_obj.id
                                                          if supported_res_types_obj else None)
 
-        sharing_status_obj = content_model.metadata.sharing_status.first()
+        sharing_status_obj = content_model.metadata.supported_sharing_status.first()
         sharing_status_obj_form = SupportedSharingStatusForm(instance=sharing_status_obj,
                                                          res_short_id=content_model.short_id,
                                                          element_id=sharing_status_obj.id

--- a/hs_tools_resource/receivers.py
+++ b/hs_tools_resource/receivers.py
@@ -1,10 +1,19 @@
 from django.dispatch import receiver
 
-from hs_core.signals import pre_metadata_element_create, pre_metadata_element_update
+from hs_core.signals import pre_metadata_element_create, pre_metadata_element_update, \
+                            pre_create_resource
 
 from hs_tools_resource.models import ToolResource
-from hs_tools_resource.forms import SupportedResTypesValidationForm, UrlBaseForm, VersionForm, \
-                                    ToolIconForm, UrlBaseValidationForm
+from hs_tools_resource.forms import SupportedResTypesValidationForm,  VersionForm, \
+                                    ToolIconForm, UrlBaseValidationForm, \
+                                    SupportedSharingStatusValidationForm
+
+@receiver(pre_create_resource, sender=ToolResource)
+def webapp_pre_create_resource(sender, **kwargs):
+    metadata = kwargs['metadata']
+    all_sharing_status = {'SupportedSharingStatus': {'sharing_status':
+                          ["Published", "Public", "Discoverable", "Private"]}}
+    metadata.append(all_sharing_status)
 
 
 @receiver(pre_metadata_element_create, sender=ToolResource)
@@ -30,6 +39,10 @@ def validate_form(request, element_name):
         element_form = SupportedResTypesValidationForm(data=request.POST)
     elif element_name == 'toolicon':
         element_form = ToolIconForm(data=request.POST)
+    elif element_name == 'supportedsharingstatus':
+        element_form = SupportedSharingStatusValidationForm(data=request.POST)
+    else:
+        return {'is_valid': False, 'element_data_dict': None}
 
     if element_form.is_valid():
         return {'is_valid': True, 'element_data_dict': element_form.cleaned_data}

--- a/hs_tools_resource/static/js/toolresource.js
+++ b/hs_tools_resource/static/js/toolresource.js
@@ -1,10 +1,10 @@
 $(document).ready(function() {
-    var checked_res_str=$("#checked_res_div").text();
-    var checked_res_array=checked_res_str.split(",");
-    for (var i = 0; i < checked_res_array.length; i++) {
-        var checked_res_item=checked_res_array[i];
-        $("input[value='"+checked_res_item+"']").attr("checked","true");
-    }
+    //var checked_res_str=$("#checked_res_div").text();
+    //var checked_res_array=checked_res_str.split(",");
+    //for (var i = 0; i < checked_res_array.length; i++) {
+    //    var checked_res_item=checked_res_array[i];
+    //    $("input[value='"+checked_res_item+"']").attr("checked","true");
+    //}
     // Getter for icon_url input element
     var get_icon_input_element = function() {
         return $('#resourceSpecificTab #div_id_url');

--- a/hs_tools_resource/static/js/toolresource.js
+++ b/hs_tools_resource/static/js/toolresource.js
@@ -1,10 +1,5 @@
 $(document).ready(function() {
-    //var checked_res_str=$("#checked_res_div").text();
-    //var checked_res_array=checked_res_str.split(",");
-    //for (var i = 0; i < checked_res_array.length; i++) {
-    //    var checked_res_item=checked_res_array[i];
-    //    $("input[value='"+checked_res_item+"']").attr("checked","true");
-    //}
+
     // Getter for icon_url input element
     var get_icon_input_element = function() {
         return $('#resourceSpecificTab #div_id_url');

--- a/hs_tools_resource/templates/pages/toolresource.html
+++ b/hs_tools_resource/templates/pages/toolresource.html
@@ -40,6 +40,16 @@
                     {% endif %}
                 </div>
                 <div>
+                    {% if supported_sharing_status %}
+                        <h4><strong>Supported Resource Sharing Status:</strong></h4>
+                        <hr style="margin-top: 0px;margin-bottom: 2px">
+                        <div class="row">
+                            <div class="col-sm-8">{{ supported_sharing_status }}</div>
+                        </div>
+                        <hr style="border:0">
+                    {% endif %}
+                </div>
+                <div>
                     {% if tool_icon_url %}
                         <h4><strong>App Icon:</strong></h4>
                         <hr style="margin-top: 0px;margin-bottom: 2px">

--- a/hs_tools_resource/templates/pages/toolresource.html
+++ b/hs_tools_resource/templates/pages/toolresource.html
@@ -11,10 +11,10 @@
             <div class="col-md-12">
                 <div>
                     {% if url_base %}
-                        <h4><strong>App URL:</strong></h4>
+                        <h4><strong>App URL Pattern:</strong></h4>
                         <hr style="margin-top: 0px;margin-bottom: 2px">
                         <div class="row">
-                            <div class="col-sm-8"><a href='{{ url_base.value }}'>{{ url_base.value }}</a></div>
+                            <div class="col-sm-8">{{ url_base.value }}</div>
                         </div>
                         <hr style="border:0">
                     {%  endif %}


### PR DESCRIPTION
This PR is to address #1365:
1) a new url pattern term "HS_NETCDF_FILE_NAME" is added, which represents the full filename of the .nc file in a NetCDF res.

2) A new metadata term is added into WebApp called "SupportedSharingStatus", which is a new criteria to associate a webapp with certain res types in certain sharing status. Example: if a webapp supports NetCDF res type and its "SupportedSharingStatus" value is set to "Public", this webapp will only show up on Public NetCDF res landing page.  

3) some minor UI changes and bug fixes (see #1371 )

A live instance is deployed on https://riverdev.hydroshare.org/
