### PR TITLE
[#1350] Allow text formatting for text area inputs in group pages

### DIFF
--- a/hs_core/templates/pages/collaborate.html
+++ b/hs_core/templates/pages/collaborate.html
@@ -43,9 +43,9 @@
                             {% endif %}
                             <div class="group-caption">
                                 <h3 class="group-name"><a href="/group/{{ group.id }}">{{ group.name }}</a></h3>
-                                <small class="text-muted group-keywords">{{ group.gaccess.purpose }}</small>
+                                <small class="text-muted group-keywords">{{ group.gaccess.purpose|linebreaks }}</small>
 
-                                <p class="group-description">{{ group.gaccess.description }}</p>
+                                <p class="group-description">{{ group.gaccess.description|linebreaks }}</p>
 
                                 <div class="text-center group-thumbnail-footer">
                                     {% if group.gaccess.public %}

--- a/hs_core/templates/pages/my-resources.html
+++ b/hs_core/templates/pages/my-resources.html
@@ -128,7 +128,7 @@
 
                         <div id="toolbar-labels-dropdown" class="dropdown-menu" role="menu">
                             <div class="panel-body" role="form">
-                                <span>Label as:</span>
+                                <strong>Label as:</strong>
                                 <ul class="list-group list-labels">
                                     <li class="divider persist"></li>
                                     <li class="list-group-item persist" data-toggle="modal" data-target="#modalCreateLabel">
@@ -545,7 +545,7 @@
                                 </tr>
                                 {% endfor %}
                             {% else %}
-                                <tr class="no-labels-found"><td>No labels found.</td></tr>
+                                <tr class="no-items-found"><td>No labels found.</td></tr>
                             {% endif %}
                         </tbody>
                     </table>

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -2923,6 +2923,13 @@ h4.title {
     border-radius: 0;
 }
 
+.no-items-found {
+    font-style: italic;
+    font-size: 14px;
+    pointer-events: none;
+	border: 0;
+}
+
 .list-labels li:hover {
 	background:#DDD;
 }
@@ -2936,11 +2943,6 @@ h4.title {
 	margin-bottom: 0;
 }
 
-.no-labels-found {
-    font-style: italic;
-    font-size: 14px;
-    pointer-events: none;
-}
 
 #toolbar-labels-dropdown {
 	font-size: 14px;

--- a/theme/static/js/hs_resource_table.js
+++ b/theme/static/js/hs_resource_table.js
@@ -42,18 +42,15 @@ $(document).ready(function () {
         }
     });
 
-    // Disable default form submission when pressing enter
-    $(document).ready(function () {
-        $(window).keydown(function (event) {
-            if (event.keyCode == 13) {
-                event.preventDefault();
-                return false;
-            }
-        });
+    // Disable default form submission when pressing enter for textarea inputs
+    $(window).keydown(function (event) {
+        if (event.keyCode == 13 && event.target.tagName != "TEXTAREA") {
+            event.preventDefault();
+        }
     });
 
     // Autofocus input when modal appears
-    $("#modalCreateLabel").on('shown.bs.modal', function() {
+    $("#modalCreateLabel").on('shown.bs.modal', function () {
         $("#txtLabelName").focus();
     });
 
@@ -175,9 +172,9 @@ function label_ajax_submit() {
                 else if (formType == "delete-label") {
                     var deletedLabel = el.attr("data-label");
                     $("#table-user-labels td[data-label='" + deletedLabel + "']").parent().remove();
-                    if ($("#table-user-labels .user-label").length == 0 && $("#table-user-labels .no-labels-found").length == 0) {
+                    if ($("#table-user-labels .user-label").length == 0 && $("#table-user-labels .no-items-found").length == 0) {
                         $("#table-user-labels tbody").append(
-                                '<tr class="no-labels-found"><td>No labels found.</td></tr>'
+                                '<tr class="no-items-found"><td>No labels found.</td></tr>'
                         )
                     }
                     updateLabelLists();
@@ -343,11 +340,11 @@ function updateLabelLists() {
 
     if (labels.length == 0) {
         $("#user-labels-left").append(
-                '<h5><i>No labels found.</i></h5>'
+                '<i class="list-group-item no-items-found"><h5>No labels found.</h5></i>'
         );
 
         $("#toolbar-labels-dropdown ul").prepend(
-                '<li class="no-labels-found">No labels found.</li>'
+                 '<i class="no-items-found list-group-item"><h5>No labels found.</h5></i>'
         );
 
         $(".btn-inline-label").attr("data-toggle", "");
@@ -435,7 +432,7 @@ function createLabel () {
                     '</td>'+
                 '</tr>');
 
-        userLabelsTable.find(".no-labels-found").remove();
+        userLabelsTable.find(".no-items-found").remove();
 
         $(".btn-label-remove").click(label_ajax_submit);
         $("#modalCreateLabel").modal('hide');

--- a/theme/templates/pages/group.html
+++ b/theme/templates/pages/group.html
@@ -467,7 +467,7 @@
                                     <div class="panel-body">
                                         <div class="list-group">
                                             <ul class="list-group inputs-group">
-                                                <i class="list-group-item no-items-found"><i>No resources have been shared with this group yet.</i></i>
+                                                <i class="list-group-item no-items-found">No resources have been shared with this group yet.</i>
                                             </ul>
                                         </div>
 

--- a/theme/templates/pages/group.html
+++ b/theme/templates/pages/group.html
@@ -51,9 +51,9 @@
 
             <div class="col-sm-7">
                 <h2 class="group-title">{{ group.name }}</h2>
-                <h4 class="text-muted">{{ group.gaccess.purpose }}</h4>
+                <h4 class="text-muted">{{ group.gaccess.purpose|linebreaks }}</h4>
 
-                <p>{{ group.gaccess.description }}</p>
+                <p>{{ group.gaccess.description|linebreaks }}</p>
             </div>
 
 
@@ -467,7 +467,7 @@
                                     <div class="panel-body">
                                         <div class="list-group">
                                             <ul class="list-group inputs-group">
-                                                <h5><i>No resources have been shared with this group yet.</i></h5>
+                                                <i class="list-group-item no-items-found"><i>No resources have been shared with this group yet.</i></i>
                                             </ul>
                                         </div>
 


### PR DESCRIPTION
Also contains minor layout fixes for default 'no items found' labels.