### PR TITLE
supervisord for gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM mjstealey/hs_docker_base:1.7.4
 MAINTAINER Michael J. Stealey <stealey@renci.org>
 
 ### Begin - HydroShare Development Image Additions ###
-
+RUN apt-get update \
+    && apt-get install -y \
+    supervisor
+RUN pip install -U gunicorn==19.6.0 \
+    && pip install gevent==1.1.2
 ### End - HydroShare Development Image Additions ###
 
 USER root

--- a/gunicorn_start
+++ b/gunicorn_start
@@ -3,7 +3,7 @@
 # gunicorn_start
 # Author: Michael Stealey <michael.j.stealey@gmail.com>
 
-NAME="hydroshare"                                   # Name of the application
+NAME="hydroshare_app"                               # Name of the application
 DJANGODIR=/home/docker/hydroshare                   # Django project directory
 SOCKFILE=/var/run/gunicorn.sock                     # we will communicte using this unix socket
 USER=root                                           # the user to run as

--- a/hsctl
+++ b/hsctl
@@ -22,7 +22,7 @@ OTHER_DOCKER_CONTAINERS=(postgis rabbitmq redis solr)
 
 ### Pre-flight Variables ###
 DEV_SERVER='python manage.py runserver 0.0.0.0:8000'
-PROD_SERVER='source gunicorn_start'
+PROD_SERVER='/usr/bin/supervisord -n'
 
 display_usage() {
 	echo "*** HydroShare Control script ***"
@@ -164,11 +164,11 @@ preflight_hs() {
             echo "*** Not using SSL: USE_SSL = ${USE_SSL} ***"
         fi
         # use production server to run HydroShare
-        sed -i 's/'"${DEV_SERVER}"'/'"${PROD_SERVER}"'/g' ${HS_PATH}/init;
+        sed -i 's!'"${DEV_SERVER}"'!'"${PROD_SERVER}"'!g' ${HS_PATH}/init;
     else
         echo "*** Not using nginx: USE_NGINX = ${USE_NGINX} ***"
         # use development server to run HydroShare
-        sed -i 's/'"${PROD_SERVER}"'/'"${DEV_SERVER}"'/g' ${HS_PATH}/init;
+        sed -i 's!'"${PROD_SERVER}"'!'"${DEV_SERVER}"'!g' ${HS_PATH}/init;
         # enable SSH server for debugging purposes
         sed -i 's!'"# REMOVED SSH COMPONENT"'!'"/usr/sbin/sshd"'!g' ${HS_PATH}/init;
     fi

--- a/hydroshare.conf
+++ b/hydroshare.conf
@@ -1,0 +1,7 @@
+[program:hydroshare]
+command = /home/docker/hydroshare/gunicorn_start                      ; Command to start app
+user = root                                                           ; User to run as
+stdout_logfile = /home/docker/hydroshare/log/gunicorn_supervisor.log  ; Where to write log messages
+redirect_stderr = true                                                ; Save stderr in the same log
+autorestart=true                                                      ; Restart if main process is killed
+environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8                       ; Set UTF-8 as default encoding

--- a/init
+++ b/init
@@ -4,5 +4,6 @@
 # Specific to running in PyCharm on local machine (due to sshd)
 
 sleep 3s
+cp /home/docker/hydroshare/hydroshare.conf /etc/supervisor/conf.d/hydroshare.conf
 /usr/sbin/sshd
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Reference issue #1384 
- use supervisord to manage the running of gunicorn
- gets gunicorn_start off of process id 1 (previously killed container if PID 1 went down)
- workers get restarted even if master process is killed (should minimize the offline events we've observed recently)