### PR TITLE
[#1395] refts outputs excessively long log

### DIFF
--- a/ref_ts/tests/test_ref_ts.py
+++ b/ref_ts/tests/test_ref_ts.py
@@ -10,7 +10,7 @@ from hs_core import hydroshare
 class TestRefTS(TestCase):
 
     def setUp(self):
-        self.logger = logging.getLogger("django")
+        self.logger = logging.getLogger(__name__)
         self.api_client = Client()
 
         self.username = 'creator'

--- a/ref_ts/ts_utils.py
+++ b/ref_ts/ts_utils.py
@@ -13,7 +13,8 @@ from hs_core import hydroshare
 from owslib.waterml.wml11 import WaterML_1_1 as wml11
 from owslib.waterml.wml10 import WaterML_1_0 as wml10
 
-logger = logging.getLogger("django")
+logger = logging.getLogger(__name__)
+logging.getLogger('suds').setLevel(logging.INFO)
 BLANK_FIELD_STRING = ""
 
 def wmlParse(response, ver=11):

--- a/ref_ts/views.py
+++ b/ref_ts/views.py
@@ -25,7 +25,7 @@ from .forms import ReferencedSitesForm, ReferencedVariablesForm, GetTSValuesForm
 PREVIEW_NAME = "preview.png"
 HIS_CENTRAL_URL = 'http://hiscentral.cuahsi.org/webservices/hiscentral.asmx/GetWaterOneFlowServiceInfo'
 
-logger = logging.getLogger("django")
+logger = logging.getLogger(__name__)
 
 # query HIS central to get all available HydroServer urls
 def get_his_urls(request):


### PR DESCRIPTION
@mjstealey @pkdash 
We found the excessively long log was output by library "suds" -- a third party lib used in RefTS code.  Its default log level is "Debug". We explicitly raised it to "INFO" level. A quick test showed this change could fix it. 

We also changed all statements in RefTS code that initialize the logger to 
"logger = logging.getLogger(____name____)", as is recommended in doc  https://docs.python.org/2/library/logging.html#module-logging 