### PR TITLE
fixed refts bag download issue

### DIFF
--- a/ref_ts/views.py
+++ b/ref_ts/views.py
@@ -221,7 +221,7 @@ def download_refts_resource_files(request, shortkey, *args, **kwargs):
             return response
 
         path = "bags/" + str(shortkey) + ".zip"
-        response_irods = download_bag_from_irods(request, path)
+        response_irods = download_bag_from_irods(request, path, use_async=False)
 
         tempdir = tempfile.mkdtemp()
         bag_save_to_path = tempdir + "/" + str(shortkey) + ".zip"


### PR DESCRIPTION
@zhiyuli @pkdash Please review this PR in conjunction with django_irods PR https://github.com/hydroshare/django_irods/pull/13. I have tested it out locally and the sync bag download for ref_ts resource works as expected. However, I have issues in my local dev env to test async bag download for other resources. It appears there is an issue in local dev env with async celery task execution although it works fine on dev.hydroshare.org with the same code base. @mjstealey and I are trying to figure out this issue, but in the meantime, want to get this ref_ts bag download fix in.