### PR TITLE
fixed bagit compliance issues

### DIFF
--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -37,7 +37,8 @@ logger = logging.getLogger('django')
 @periodic_task(ignore_result=True, run_every=crontab(minute=0, hour=0))
 def check_doi_activation():
     msg_lst = []
-    # retrieve all published resources with failed metadata deposition with CrossRef if any and retry metadata deposition
+    # retrieve all published resources with failed metadata deposition with CrossRef if any and
+    # retry metadata deposition
     failed_resources = BaseResource.objects.filter(raccess__published=True, doi__contains='failure')
     for res in failed_resources:
         if res.metadata.dates.all().filter(type='published'):
@@ -46,26 +47,36 @@ def check_doi_activation():
             act_doi = get_activated_doi(res.doi)
             response = deposit_res_metadata_with_crossref(res)
             if response.status_code == status.HTTP_200_OK:
-                # retry of metadata deposition succeeds, change resource flag from failure to pending
+                # retry of metadata deposition succeeds, change resource flag from failure
+                # to pending
                 res.doi = get_resource_doi(act_doi, 'pending')
                 res.save()
             else:
                 # retry of metadata deposition failed again, notify admin
-                msg_lst.append("Metadata deposition with CrossRef for the published resource DOI {res_doi} "
-                               "failed again after retry with first metadata deposition requested since {pub_date}.".format(res_doi=act_doi, pub_date=pub_date))
+                msg_lst.append("Metadata deposition with CrossRef for the published resource "
+                               "DOI {res_doi} failed again after retry with first metadata "
+                               "deposition requested since {pub_date}.".format(res_doi=act_doi,
+                                                                               pub_date=pub_date))
                 logger.debug(response.content)
         else:
-           msg_lst.append("{res_id} does not have published date in its metadata.".format(res_id=res.short_id))
+            msg_lst.append("{res_id} does not have published date in its metadata.".format(
+                res_id=res.short_id))
 
-    pending_resources = BaseResource.objects.filter(raccess__published=True, doi__contains='pending')
+    pending_resources = BaseResource.objects.filter(raccess__published=True,
+                                                    doi__contains='pending')
     for res in pending_resources:
         if res.metadata.dates.all().filter(type='published'):
             pub_date = res.metadata.dates.all().filter(type='published')[0]
             pub_date = pub_date.start_date.strftime('%m/%d/%Y')
             act_doi = get_activated_doi(res.doi)
             main_url = get_crossref_url()
-            response = requests.get('{MAIN_URL}servlet/submissionDownload?usr={USERNAME}&pwd={PASSWORD}&doi_batch_id={DOI_BATCH_ID}&type={TYPE}'.format(
-                                MAIN_URL=main_url, USERNAME=settings.CROSSREF_LOGIN_ID, PASSWORD=settings.CROSSREF_LOGIN_PWD, DOI_BATCH_ID=res.short_id, TYPE='result'))
+            req_str = '{MAIN_URL}servlet/submissionDownload?usr={USERNAME}&pwd=' \
+                      '{PASSWORD}&doi_batch_id={DOI_BATCH_ID}&type={TYPE}'
+            response = requests.get(req_str.format(MAIN_URL=main_url,
+                                                   USERNAME=settings.CROSSREF_LOGIN_ID,
+                                                   PASSWORD=settings.CROSSREF_LOGIN_PWD,
+                                                   DOI_BATCH_ID=res.short_id,
+                                                   TYPE='result'))
             root = ElementTree.fromstring(response.content)
             rec_cnt_elem = root.find('.//record_count')
             success_cnt_elem = root.find('.//success_count')
@@ -78,16 +89,20 @@ def check_doi_activation():
                     res.save()
                     success = True
             if not success:
-                msg_lst.append("Published resource DOI {res_doi} is not yet activated with request data deposited since {pub_date}.".format(res_doi=act_doi, pub_date=pub_date))
+                msg_lst.append("Published resource DOI {res_doi} is not yet activated with request "
+                               "data deposited since {pub_date}.".format(res_doi=act_doi,
+                                                                         pub_date=pub_date))
                 logger.debug(response.content)
         else:
-           msg_lst.append("{res_id} does not have published date in its metadata.".format(res_id=res.short_id))
+            msg_lst.append("{res_id} does not have published date in its metadata.".format(
+                res_id=res.short_id))
 
     if msg_lst:
         email_msg = '\n'.join(msg_lst)
         subject = 'Notification of pending DOI deposition/activation of published resources'
         # send email for people monitoring and follow-up as needed
         send_mail(subject, email_msg, settings.DEFAULT_FROM_EMAIL, [settings.DEFAULT_SUPPORT_EMAIL])
+
 
 @shared_task
 def add_zip_file_contents_to_resource(pk, zip_file_path):
@@ -106,7 +121,8 @@ def add_zip_file_contents_to_resource(pk, zip_file_path):
         for i, f in enumerate(files):
             logger.debug("Adding file {0} to resource {1}".format(f.name, pk))
             utils.add_file_to_resource(resource, f)
-            resource.file_unpack_message = "Imported {0} of about {1} file(s) ...".format(i, num_files)
+            resource.file_unpack_message = "Imported {0} of about {1} file(s) ...".format(
+                i, num_files)
             resource.save()
 
         # Call success callback
@@ -137,9 +153,9 @@ def add_zip_file_contents_to_resource(pk, zip_file_path):
 @shared_task
 def create_bag_by_irods(resource_id, istorage=None):
     """
-    create a resource bag on iRODS side by running the bagit rule followed by ibun zipping operation.
-    This function runs as a celery task, invoked asynchronously so that it does not block the main
-    web thread when it creates bags for very large files which will take some time.
+    create a resource bag on iRODS side by running the bagit rule followed by ibun zipping
+    operation. This function runs as a celery task, invoked asynchronously so that it does not
+    block the main web thread when it creates bags for very large files which will take some time.
     :param
     resource_id: the resource uuid that is used to look for the resource to create the bag for.
     istorage: IrodsStorage object used to call irods bagit rule and zipping up operation
@@ -158,13 +174,18 @@ def create_bag_by_irods(resource_id, istorage=None):
         irods_bagit_input_path = os.path.join(res.resource_federation_path, resource_id)
         is_exist = istorage.exists(irods_bagit_input_path)
         bagit_input_path = "*BAGITDATA='{path}'".format(path=irods_bagit_input_path)
-        bagit_input_resource = "*DESTRESC='{def_res}'".format(def_res=settings.HS_IRODS_LOCAL_ZONE_DEF_RES)
+        bagit_input_resource = "*DESTRESC='{def_res}'".format(
+            def_res=settings.HS_IRODS_LOCAL_ZONE_DEF_RES)
         bag_full_name = os.path.join(res.resource_federation_path, bag_full_name)
         bagit_files = [
-                '{fed_path}/{res_id}/bagit.txt'.format(fed_path=res.resource_federation_path, res_id=resource_id),
-                '{fed_path}/{res_id}/manifest-md5.txt'.format(fed_path=res.resource_federation_path, res_id=resource_id),
-                '{fed_path}/{res_id}/tagmanifest-md5.txt'.format(fed_path=res.resource_federation_path, res_id=resource_id),
-                '{fed_path}/bags/{res_id}.zip'.format(fed_path=res.resource_federation_path, res_id=resource_id)
+                '{fed_path}/{res_id}/bagit.txt'.format(fed_path=res.resource_federation_path,
+                                                       res_id=resource_id),
+                '{fed_path}/{res_id}/manifest-sha2.txt'.format(
+                    fed_path=res.resource_federation_path, res_id=resource_id),
+                '{fed_path}/{res_id}/tagmanifest-sha2.txt'.format(
+                    fed_path=res.resource_federation_path, res_id=resource_id),
+                '{fed_path}/bags/{res_id}.zip'.format(fed_path=res.resource_federation_path,
+                                                      res_id=resource_id)
         ]
     else:
         if not istorage:
@@ -173,24 +194,27 @@ def create_bag_by_irods(resource_id, istorage=None):
         irods_dest_prefix = "/" + settings.IRODS_ZONE + "/home/" + settings.IRODS_USERNAME
         irods_bagit_input_path = os.path.join(irods_dest_prefix, resource_id)
         bagit_input_path = "*BAGITDATA='{path}'".format(path=irods_bagit_input_path)
-        bagit_input_resource = "*DESTRESC='{def_res}'".format(def_res=settings.IRODS_DEFAULT_RESOURCE)
+        bagit_input_resource = "*DESTRESC='{def_res}'".format(
+            def_res=settings.IRODS_DEFAULT_RESOURCE)
         bagit_files = [
                 '{res_id}/bagit.txt'.format(res_id=resource_id),
-                '{res_id}/manifest-md5.txt'.format(res_id=resource_id),
-                '{res_id}/tagmanifest-md5.txt'.format(res_id=resource_id),
+                '{res_id}/manifest-sha2.txt'.format(res_id=resource_id),
+                '{res_id}/tagmanifest-sha2.txt'.format(res_id=resource_id),
                 'bags/{res_id}.zip'.format(res_id=resource_id)
         ]
 
-    # only proceed when the resource is not deleted potentially by another request when being downloaded
+    # only proceed when the resource is not deleted potentially by another request
+    # when being downloaded
     if is_exist:
         # call iRODS bagit rule here
-        bagit_rule_file = getattr(settings, 'IRODS_BAGIT_RULE', 'hydroshare/irods/ruleGenerateBagIt_HS.r')
+        bagit_rule_file = getattr(settings, 'IRODS_BAGIT_RULE',
+                                  'hydroshare/irods/ruleGenerateBagIt_HS.r')
 
         try:
-            # call iRODS run and ibun command to create and zip the bag,
-            # ignore SessionException for now as a workaround which could be raised
-            # from potential race conditions when multiple ibun commands try to create the same zip file or
-            # the very same resource gets deleted by another request when being downloaded
+            # call iRODS run and ibun command to create and zip the bag, ignore SessionException
+            # for now as a workaround which could be raised from potential race conditions when
+            # multiple ibun commands try to create the same zip file or the very same resource
+            # gets deleted by another request when being downloaded
             istorage.runBagitRule(bagit_rule_file, bagit_input_path, bagit_input_resource)
             istorage.zipup(irods_bagit_input_path, bag_full_name)
             istorage.setAVU(irods_bagit_input_path, 'bag_modified', "false")

--- a/hydroshare/irods/ruleGenerateBagIt_HS.r
+++ b/hydroshare/irods/ruleGenerateBagIt_HS.r
@@ -16,63 +16,65 @@ generateBagIt {
 ###   files in place without creating new bagit root directory
 ### - writes bagit.txt to BAGITDATA/bagit.txt
 ### - generates payload manifest file of BAGITDATA/data
-### - writes payload manifest to BAGITDATA/manifest-md5.txt
-### - writes tagmanifest file to BAGITDATA/tagmanifest-md5.txt
+### - writes payload manifest to BAGITDATA/manifest-sha2.txt
+### - writes tagmanifest file to BAGITDATA/tagmanifest-sha2.txt
 ### - writes to rodsLog
 #
 # -----------------------------------------------------
 
   ### - writes bagit.txt to NEWBAGITROOT/bagit.txt
-  writeLine("stdout","BagIt-Version: 0.96");
-  writeLine("stdout","Tag-File-Character-Encoding: UTF-8");
-  msiDataObjCreate("*BAGITDATA" ++ "/bagit.txt","destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=",*FD);
-  msiDataObjWrite(*FD,"stdout",*WLEN);
-  msiDataObjClose(*FD,*Status);
+  writeLine("stdout", "BagIt-Version: 0.96");
+  writeLine("stdout", "Tag-File-Character-Encoding: UTF-8");
+  msiDataObjCreate("*BAGITDATA" ++ "/bagit.txt", "destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=", *FD);
+  msiDataObjWrite(*FD, "stdout", *WLEN);
+  msiDataObjClose(*FD, *Status);
   msiFreeBuffer("stdout");
 
   ### - generates payload manifest file of BAGITDATA/data
-  msiStrlen(*BAGITDATA,*ROOTLENGTH);
+  msiStrlen(*BAGITDATA, *ROOTLENGTH);
   *OFFSET = int(*ROOTLENGTH) + 1;
   *NEWBAGITDATA = "*BAGITDATA" ++ "/data";
   *ContInxOld = 1;
   *Condition = "COLL_NAME like '*NEWBAGITDATA%%'";
-  msiMakeGenQuery("DATA_ID, DATA_NAME, COLL_NAME",*Condition,*GenQInp);
+  msiMakeGenQuery("DATA_ID, DATA_NAME, COLL_NAME", *Condition, *GenQInp);
   msiExecGenQuery(*GenQInp, *GenQOut);
-  msiGetContInxFromGenQueryOut(*GenQOut,*ContInxNew);
+  msiGetContInxFromGenQueryOut(*GenQOut, *ContInxNew);
   while(*ContInxOld > 0) {
     foreach(*GenQOut) {
-       msiGetValByKey(*GenQOut, "DATA_NAME", *Object);
-       msiGetValByKey(*GenQOut, "COLL_NAME", *Coll);
-       *FULLPATH = "*Coll" ++ "/" ++ "*Object";
-       msiDataObjChksum(*FULLPATH, "forceChksum=", *CHKSUM);
-       msiSubstr(*FULLPATH,str(*OFFSET),"null",*RELATIVEPATH);
-       writeString("stdout", *RELATIVEPATH);
-       writeLine("stdout","   *CHKSUM")
+      msiGetValByKey(*GenQOut, "DATA_NAME", *Object);
+      msiGetValByKey(*GenQOut, "COLL_NAME", *Coll);
+      *FULLPATH = "*Coll" ++ "/" ++ "*Object";
+      msiDataObjChksum(*FULLPATH, "forceChksum=", *CHKSUM);
+      msiSubstr(*FULLPATH,str(*OFFSET), "null", *RELATIVEPATH);
+      writeString("stdout", *CHKSUM);
+      writeLine("stdout", "    *RELATIVEPATH")
     }
     *ContInxOld = *ContInxNew;
-    if(*ContInxOld > 0) {msiGetMoreRows(*GenQInp,*GenQOut,*ContInxNew);}
+    if(*ContInxOld > 0) {
+      msiGetMoreRows(*GenQInp, *GenQOut, *ContInxNew);
+    }
   }
 
-  ### - writes payload manifest to BAGITDATA/manifest-md5.txt
-  msiDataObjCreate("*BAGITDATA" ++ "/manifest-md5.txt","destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=",*FD);
-  msiDataObjWrite(*FD,"stdout",*WLEN);
-  msiDataObjClose(*FD,*Status);
+  ### - writes payload manifest to BAGITDATA/manifest-sha2.txt
+  msiDataObjCreate("*BAGITDATA" ++ "/manifest-sha2.txt", "destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=", *FD);
+  msiDataObjWrite(*FD, "stdout", *WLEN);
+  msiDataObjClose(*FD, *Status);
   msiFreeBuffer("stdout");
 
-  ### - writes tagmanifest file to BAGITDATA/tagmanifest-md5.txt
-  writeString("stdout","bagit.txt    ");
-  msiDataObjChksum("*BAGITDATA" ++ "/bagit.txt","forceChksum",*CHKSUM);
-  writeLine("stdout",*CHKSUM);
-  writeString("stdout","manifest-md5.txt    ");
-  msiDataObjChksum("*BAGITDATA" ++ "/manifest-md5.txt","forceChksum",*CHKSUM);
-  writeLine("stdout",*CHKSUM);
-  msiDataObjCreate("*BAGITDATA" ++ "/tagmanifest-md5.txt","destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=",*FD);
-  msiDataObjWrite(*FD,"stdout",*WLEN);
-  msiDataObjClose(*FD,*Status);
+  ### - writes tagmanifest file to BAGITDATA/tagmanifest-sha2.txt
+  msiDataObjChksum("*BAGITDATA" ++ "/bagit.txt", "forceChksum", *CHKSUM);
+  writeString("stdout", *CHKSUM);
+  writeLine("stdout", "    bagit.txt")
+  msiDataObjChksum("*BAGITDATA" ++ "/manifest-sha2.txt", "forceChksum", *CHKSUM);
+  writeString("stdout", *CHKSUM);
+  writeLine("stdout", "    manifest-sha2.txt");
+  msiDataObjCreate("*BAGITDATA" ++ "/tagmanifest-sha2.txt", "destRescName=" ++ "*DESTRESC" ++ "++++forceFlag=", *FD);
+  msiDataObjWrite(*FD, "stdout", *WLEN);
+  msiDataObjClose(*FD, *Status);
   msiFreeBuffer("stdout");
 
   ### - writes to rodsLog
-  msiWriteRodsLog("BagIt bag files created in place: *BAGITDATA <- *BAGITDATA",*Status);
+  msiWriteRodsLog("BagIt bag files created in place: *BAGITDATA <- *BAGITDATA", *Status);
 }
 INPUT *BAGITDATA="/dummy/dummy/dummy", *DESTRESC="dummy"
 OUTPUT ruleExecOut

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,7 +124,6 @@ exclude=
   hs_core/search_indexes.py,
   hs_core/serialization.py,
   hs_core/signals.py,
-  hs_core/tasks.py,
   hs_core/templatetags/hydroshare_tags.py,
   hs_core/tests/api/native/__init__.py,
   hs_core/tests/api/native/test_bagit.py,


### PR DESCRIPTION
This PR fixed bagit checksum compliance issues detailed in issue [#1418]. After this PR is merged, before deployment, bag_modified AVU metadata needs to be set to false for all bags so that all bags can be regenerated when being downloaded. In addition, all old manifest-md5.txt and tagmanifest-md5.txt files under all existing resource collections need to be deleted so that they will not be included in the newly generated bags. @mjstealey I think you can get this done pretty easily on iRODS side after this is merged before next deployment, and we can discuss any issues offline if needed. @pkdash Can you do code review for this PR? I also removed hs_core/tasks.py from config.cfg file to subject it for style check, so 99% of changes in hs_core/tasks.py are for code styling. 