### PR TITLE
[WIP] [#1410] Simplification on Publisher metadata

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -740,7 +740,6 @@ class Publisher(AbstractMetaDataElement):
             raise ValidationError("Publisher element can't be created for a resource that "
                                   "is not yet published.")
 
-
         if 'name' in kwargs:
             if kwargs['name'].lower() != cls.publisher_name_CUAHSI.lower():
                 raise ValidationError("Invalid publisher name")

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -717,6 +717,10 @@ class Identifier(AbstractMetaDataElement):
 
 
 class Publisher(AbstractMetaDataElement):
+    publisher_name_CUAHSI = "Consortium of Universities for the Advancement of Hydrologic " \
+                           "Science, Inc. (CUAHSI)"
+
+    publisher_url_CUAHSI = 'https://www.cuahsi.org'
     term = 'Publisher'
     name = models.CharField(max_length=200)
     url = models.URLField()
@@ -736,30 +740,18 @@ class Publisher(AbstractMetaDataElement):
             raise ValidationError("Publisher element can't be created for a resource that "
                                   "is not yet published.")
 
-        publisher_CUAHSI = "Consortium of Universities for the Advancement of Hydrologic " \
-                           "Science, Inc. (CUAHSI)"
 
-        if resource.files.all():
-            # if the resource has content files, set CUAHSI as the publisher
-            if 'name' in kwargs:
-                if kwargs['name'].lower() != publisher_CUAHSI.lower():
-                    raise ValidationError("Invalid publisher name")
-
-            kwargs['name'] = publisher_CUAHSI
-            if 'url' in kwargs:
-                if kwargs['url'].lower() != 'https://www.cuahsi.org':
-                    raise ValidationError("Invalid publisher URL")
-
-            kwargs['url'] = 'https://www.cuahsi.org'
+        if 'name' in kwargs:
+            if kwargs['name'].lower() != cls.publisher_name_CUAHSI.lower():
+                raise ValidationError("Invalid publisher name")
         else:
-            # make sure we are not setting CUAHSI as publisher for a resource
-            # that has no content files
-            if 'name' in kwargs:
-                if kwargs['name'].lower() == publisher_CUAHSI.lower():
-                    raise ValidationError("Invalid publisher name")
-            if 'url' in kwargs:
-                if kwargs['url'].lower() == 'https://www.cuahsi.org':
-                    raise ValidationError("Invalid publisher URL")
+            kwargs['name'] = cls.publisher_name_CUAHSI
+
+        if 'url' in kwargs:
+            if kwargs['url'].lower() != cls.publisher_url_CUAHSI.lower():
+                raise ValidationError("Invalid publisher URL")
+        else:
+            kwargs['url'] = cls.publisher_url_CUAHSI
 
         return super(Publisher, cls).create(**kwargs)
 

--- a/hs_core/tests/api/native/test_core_metadata.py
+++ b/hs_core/tests/api/native/test_core_metadata.py
@@ -946,73 +946,42 @@ class TestCoreMetadata(MockIRODSTestCaseMixin, TestCase):
         self.res.raccess.published = False
         self.res.raccess.save()
         with self.assertRaises(Exception):
-            resource.create_metadata_element(self.res.short_id, 'publisher', name='HydroShare',
-                                             url="http://hydroshare.org")
+            resource.create_metadata_element(self.res.short_id, 'publisher', name=publisher_CUAHSI,
+                                             url=url_CUAHSI)
 
         # publisher element can be added when the resource is published
         self.res.raccess.published = True
         self.res.raccess.save()
-        resource.create_metadata_element(self.res.short_id, 'publisher', name='USGS', url="http://usgs.gov")
-        self.assertEqual(self.res.metadata.publisher.url, "http://usgs.gov",
+
+        # try to add a Publisher that is not CUAHSI - should raise exception
+        with self.assertRaises(Exception):
+            resource.create_metadata_element(self.res.short_id, 'publisher', name="BYU",
+                                             url="https://www.byu.edu")
+
+        # add CUAHSI as publisher
+        resource.create_metadata_element(self.res.short_id, 'publisher', name=publisher_CUAHSI,
+                                         url=url_CUAHSI)
+        self.assertEqual(self.res.metadata.publisher.url, url_CUAHSI,
                          msg="Resource publisher url did not match.")
-        self.assertEqual(self.res.metadata.publisher.name, "USGS", msg="Resource publisher name did not match.")
+        self.assertEqual(self.res.metadata.publisher.name, publisher_CUAHSI,
+                         msg="Resource publisher name did not match.")
 
         # a 2nd publisher element can't be created - should raise exception
         with self.assertRaises(Exception):
-            resource.create_metadata_element(self.res.short_id, 'publisher', name='USU', url="http://usu.edu")
+            resource.create_metadata_element(self.res.short_id, 'publisher', name=publisher_CUAHSI,
+                                             url=url_CUAHSI)
 
         # test that updating publisher element raises exception
         with self.assertRaises(Exception):
-            resource.update_metadata_element(self.res.short_id, 'publisher', self.res.metadata.publisher.id,
+            resource.update_metadata_element(self.res.short_id, 'publisher',
+                                             self.res.metadata.publisher.id,
                                              name='USU', url="http://usu.edu")
 
-        # Test that when a resource has one or more content files, the publisher has to be CUASHI
-        # publisher name 'CUAHSI' only and publisher url to 'https://www.cuahsi.org' only.
-        # create a different resource
-        res_with_files = hydroshare.create_resource(
-            resource_type='GenericResource',
-            owner=self.user,
-            title='Generic resource with files',
-        )
-
-        # check the resource is not published
-        self.assertFalse(res_with_files.raccess.published)
-
-        res_with_files.raccess.published = True
-        res_with_files.raccess.save()
-
-        # trying to make CUAHSI as the publisher for a resource that has no content files should raise exception
-        with self.assertRaises(Exception):
-            resource.create_metadata_element(res_with_files.short_id, 'publisher', name=publisher_CUAHSI,
-                                             url=url_CUAHSI)
-
-        # create a file
-        original_file_name = 'original.txt'
-        original_file = open(original_file_name, 'w')
-        original_file.write("original text")
-        original_file.close()
-
-        original_file = open(original_file_name, 'r')
-        # add the file to the resource
-        hydroshare.add_resource_files(res_with_files.short_id, original_file)
-
-        # trying to set publisher someone other than CUAHSI for a resource that has content files
-        # should raise exception
-        with self.assertRaises(Exception):
-            resource.create_metadata_element(res_with_files.short_id, 'publisher', name='USU', url="http://usu.edu")
-
-        # only 'CUAHSI" can be set as the publisher for a resource that has content files
-        resource.create_metadata_element(res_with_files.short_id, 'publisher', name=publisher_CUAHSI,
-                                         url=url_CUAHSI)
-
-        self.assertEqual(res_with_files.metadata.publisher.name, publisher_CUAHSI,
-                         msg="Resource publisher name did not match.")
-        self.assertEqual(res_with_files.metadata.publisher.url, url_CUAHSI,
-                         msg="Resource publisher url did not match.")
 
         # trying to delete the publisher should raise exception
         with self.assertRaises(Exception):
-            resource.delete_metadata_element(res_with_files.short_id, 'publisher', self.res.metadata.publisher.id)
+            resource.delete_metadata_element(self.res.short_id, 'publisher',
+                                             self.res.metadata.publisher.id)
 
     def test_relation(self):
         # at this point there should not be any relation elements
@@ -1489,11 +1458,6 @@ class TestCoreMetadata(MockIRODSTestCaseMixin, TestCase):
         resource.create_metadata_element(self.res.short_id,'relation', type='isPartOf',
                                 value='http://hydroshare.org/resource/001')
 
-        # add publisher element
-        self.res.raccess.published = True
-        self.res.raccess.save()
-        resource.create_metadata_element(self.res.short_id, 'publisher', name='USGS', url="http://usgs.gov")
-
         # add funding agency element
         resource.create_metadata_element(self.res.short_id, 'fundingagency', agency_name='NSF',
                                          award_title="Cyber Infrastructure", award_number="NSF-101-20-6789",
@@ -1512,8 +1476,6 @@ class TestCoreMetadata(MockIRODSTestCaseMixin, TestCase):
         self.assertTrue(Source.objects.filter(object_id=core_metadata_obj.id).exists())
         # there should be Relation metadata objects
         self.assertTrue(Relation.objects.filter(object_id=core_metadata_obj.id).exists())
-        # there should be Publisher metadata objects
-        self.assertTrue(Publisher.objects.filter(object_id=core_metadata_obj.id).exists())
         # there should be Title metadata objects
         self.assertTrue(Title.objects.filter(object_id=core_metadata_obj.id).exists())
         # there should be Description (Abstract) metadata objects
@@ -1549,8 +1511,6 @@ class TestCoreMetadata(MockIRODSTestCaseMixin, TestCase):
         self.assertFalse(Source.objects.filter(object_id=core_metadata_obj.id).exists())
         # there should be Relation metadata objects
         self.assertFalse(Relation.objects.filter(object_id=core_metadata_obj.id).exists())
-        # there should be Publisher metadata objects
-        self.assertFalse(Publisher.objects.filter(object_id=core_metadata_obj.id).exists())
         # there should be no Title metadata objects
         self.assertFalse(Title.objects.filter(object_id=core_metadata_obj.id).exists())
         # there should be no Description (Abstract) metadata objects


### PR DESCRIPTION
The changes are based on the discussion we had in this issue #1410 .
System creates Publisher metadata automatically when publishing a resource. The publisher name is always CUAHSI's full name and url is always CUAHSI's website. User can not change/delete this metadata ( because the res is published). 

A published collection res for testing purpose is here 
https://riverdev.hydroshare.org/resource/26246d356ed54097afb79b334ba33267/

@pkdash could you review this? thanks
