### PR TITLE
Reset tmp dir

### DIFF
--- a/gunicorn_start
+++ b/gunicorn_start
@@ -5,7 +5,7 @@
 
 NAME="hydroshare_app"                               # Name of the application
 DJANGODIR=/hydroshare                               # Django project directory
-SOCKFILE=/hs_tmp/gunicorn.sock              # we will communicate using this unix socket
+SOCKFILE=/tmp/gunicorn.sock              # we will communicate using this unix socket
 USER=hydro-service                                  # the user to run as
 GROUP=storage-hydro                                 # the group to run as
 NUM_WORKERS=$(python -c "exec(\"import multiprocessing\nprint( multiprocessing.cpu_count() * 2 + 1)\")")

--- a/hsctl
+++ b/hsctl
@@ -183,7 +183,8 @@ preflight_hs() {
             exit 1;
         fi
         if [[ ! -d ${HOST_SSL_DIR} ]]; then
-            mkdir -p ${HOST_SSL_DIR};
+            mkdir -p ${HOST_SSL_DIR}
+            cp ${HS_PATH}/nginx/cert-files/* ${HOST_SSL_DIR};
         fi
         cp -rf ${SSL_CERT_DIR}/${SSL_CERT_FILE} ${HOST_SSL_DIR}
         cp -rf ${SSL_CERT_DIR}/${SSL_KEY_FILE} ${HOST_SSL_DIR}

--- a/hsctl
+++ b/hsctl
@@ -311,8 +311,8 @@ rebuild_hs() {
     if [ "$2" == "--db" ]; then
         loaddb_hs;
     fi
-    echo "  - docker exec hydroshare chown -R hydro-service:storage-hydro /hydroshare /hs_tmp /shared_tmp"
-    docker exec hydroshare chown -R hydro-service:storage-hydro /hydroshare /hs_tmp /shared_tmp
+    echo "  - docker exec hydroshare chown -R hydro-service:storage-hydro /hydroshare /tmp /shared_tmp"
+    docker exec hydroshare chown -R hydro-service:storage-hydro /hydroshare /tmp /shared_tmp
     if [ "${USE_NGINX,,}" = true ]; then
         start_nginx;
     fi

--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -76,7 +76,7 @@ DOCKER_API_VERSION = '1.12'
 
 
 # CartoCSS
-CARTO_HOME='/hs_tmp/node_modules/carto'
+CARTO_HOME='/tmp/node_modules/carto'
 
 
 USE_SOUTH = False

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -484,7 +484,7 @@ PASSWORD_RESET_TIMEOUT_DAYS = 1
 RESOURCE_LOCK_TIMEOUT_SECONDS = 300 # in seconds
 
 # customized temporary file path for large files retrieved from iRODS user zone for metadata extraction
-TEMP_FILE_DIR = '/hs_tmp'
+TEMP_FILE_DIR = '/tmp'
 
 ####################
 # OAUTH TOKEN SETTINGS #

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("PYTHONPATH", '/hydroshare')
-    os.environ.setdefault("TMPDIR", "/hs_tmp")
+    os.environ.setdefault("TMPDIR", "/tmp")
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hydroshare.settings")
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/nginx/config-files/hydroshare-nginx.conf
+++ b/nginx/config-files/hydroshare-nginx.conf
@@ -30,7 +30,7 @@ server {
     }
 
     location @proxy {
-        proxy_pass  http://unix:/hs_tmp/gunicorn.sock;
+        proxy_pass  http://unix:/tmp/gunicorn.sock;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/config-files/hydroshare-ssl-nginx.conf
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf
@@ -39,7 +39,7 @@ server {
     }
 
     location @proxy {
-        proxy_pass  http://unix:/hs_tmp/gunicorn.sock;
+        proxy_pass  http://unix:/tmp/gunicorn.sock;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/scripts/templates/docker-compose.template
+++ b/scripts/templates/docker-compose.template
@@ -44,7 +44,7 @@ hydroshare:
     # log files
     - "HS_LOG_FILES:/hydroshare/log"
     # shared location for uwsgi.sock between containers
-    - "/hs_tmp"
+    - "/tmp"
     # temp directory shared with celery workers
     - "/shared_tmp"
   ports:

--- a/scripts/templates/init-hydroshare.template
+++ b/scripts/templates/init-hydroshare.template
@@ -9,7 +9,7 @@ cp /hydroshare/hydroshare.conf /etc/supervisor/conf.d/hydroshare.conf
 usermod -u HS_SERVICE_UID hydro-service
 groupmod -g HS_SERVICE_GID storage-hydro
 chown -R hydro-service:storage-hydro /etc/ssh
-chown -R hydro-service:storage-hydro /hs_tmp
+chown -R hydro-service:storage-hydro /tmp
 chown -R hydro-service:storage-hydro /shared_tmp
 sed -i "/\<UsePrivilegeSeparation\>/c\UsePrivilegeSeparation no" /etc/ssh/sshd_config
 sed -i "/\<Port 22\>/c\Port 2022" /etc/ssh/sshd_config


### PR DESCRIPTION
Changes all occurrences of /hs_tmp back to /tmp
- Seemed to cause issues wrt iRODS authorization files
- /tmp is shared between certain containers in the way it is defined

Update hsctl to include SSL certs if USE_SSL is set to true

@hyi - this is what we discussed in HipChat. Please review once Jenkins completes it's build/test run.