### PR TITLE
make url in abstract clickable

### DIFF
--- a/theme/templates/resource-landing-page/abstract.html
+++ b/theme/templates/resource-landing-page/abstract.html
@@ -2,7 +2,7 @@
     {% if abstract %}
         <div class="col-sm-12 content-block">
             <h3>Abstract</h3>
-            <span class="abstract">{{ abstract|linebreaks }}</span>
+            <span class="abstract">{{ abstract|urlize|linebreaks }}</span>
         </div>
     {% endif %}
 {% else %}


### PR DESCRIPTION
@mjstealey there is essentially only one line change to "urlize" the abstract text so that urls included in the abstract are clickable. This is at request of @rayi113 who wants this feature quick (the earlier, the better), and I have tested it out locally and it worked well with this one line change. Can you test it out and if it works, get it merged and deployed? @rayi113 if you want this one line change to be a hotfix on www, @mjstealey can apply it on www easily. Just let us know.