### PR TITLE
1425 url pattern improvement

### DIFF
--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -107,11 +107,7 @@ def create_bag_files(resource, fed_zone_home_path=''):
 
     # make the resource map
     current_site_url = current_site_url()
-    if fed_zone_home_path:
-        hs_res_url = '{hs_url}/resource/{res_id}/data'.format(hs_url=current_site_url,
-                                                                    res_id=resource.short_id)
-    else:
-        hs_res_url = '{hs_url}/resource/{res_id}/data'.format(hs_url=current_site_url,
+    hs_res_url = '{hs_url}/resource/{res_id}/data'.format(hs_url=current_site_url,
                                                               res_id=resource.short_id)
     metadata_url = os.path.join(hs_res_url, 'resourcemetadata.xml')
     res_map_url = os.path.join(hs_res_url, 'resourcemap.xml')
@@ -153,24 +149,22 @@ def create_bag_files(resource, fed_zone_home_path=''):
             # in federated zone
             from_fname = f.fed_resource_file_name_or_path
             filename = from_fname.rsplit('/')[-1]
-            res_path = os.path.join(
-                '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
+            res_path = '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
                     hs_url=current_site_url,
                     res_id=resource.short_id,
-                    file_name=filename))
+                    file_name=filename)
         elif f.resource_file:
             filename = os.path.basename(f.resource_file.name)
-            res_path = os.path.join('{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
+            res_path = '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
                     hs_url=current_site_url,
                     res_id=resource.short_id,
-                    file_name=filename))
+                    file_name=filename)
         elif f.fed_resource_file:
             filename = os.path.basename(f.fed_resource_file.name)
-            res_path = os.path.join(
-                '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
+            res_path = '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
                     hs_url=current_site_url,
                     res_id=resource.short_id,
-                    file_name=filename))
+                    file_name=filename)
         else:
             filename = ''
         if filename:
@@ -188,14 +182,10 @@ def create_bag_files(resource, fed_zone_home_path=''):
     if resource.resource_type == "CollectionResource" and resource.resources:
         for contained_res in resource.resources.all():
             contained_res_id = contained_res.short_id
-            if contained_res.resource_federation_path:
-                resource_map_url = '{hs_url}/resource/{res_id}/data/resourcemap.xml'.format(
+            resource_map_url = '{hs_url}/resource/{res_id}/data/resourcemap.xml'.format(
                     hs_url=current_site_url,
                     res_id=contained_res_id)
-            else:
-                resource_map_url = '{hs_url}/resource/{res_id}/data/resourcemap.xml'.format(
-                    hs_url=current_site_url,
-                    res_id=contained_res_id)
+
             ar = AggregatedResource(resource_map_url)
             ar._ore.isAggregatedBy = ag_url
             ar._dc.format = "application/rdf+xml"

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -149,25 +149,17 @@ def create_bag_files(resource, fed_zone_home_path=''):
             # in federated zone
             from_fname = f.fed_resource_file_name_or_path
             filename = from_fname.rsplit('/')[-1]
-            res_path = '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
-                    hs_url=current_site_url,
-                    res_id=resource.short_id,
-                    file_name=filename)
         elif f.resource_file:
             filename = os.path.basename(f.resource_file.name)
-            res_path = '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
-                    hs_url=current_site_url,
-                    res_id=resource.short_id,
-                    file_name=filename)
         elif f.fed_resource_file:
             filename = os.path.basename(f.fed_resource_file.name)
-            res_path = '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
-                    hs_url=current_site_url,
-                    res_id=resource.short_id,
-                    file_name=filename)
         else:
             filename = ''
         if filename:
+            res_path = '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
+                hs_url=current_site_url,
+                res_id=resource.short_id,
+                file_name=filename)
             resFiles.append(AggregatedResource(res_path))
             resFiles[n]._ore.isAggregatedBy = ag_url
             resFiles[n]._dc.format = get_file_mime_type(filename)

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -108,8 +108,7 @@ def create_bag_files(resource, fed_zone_home_path=''):
     # make the resource map
     current_site_url = current_site_url()
     if fed_zone_home_path:
-        hs_res_url = '{hs_url}/resource{zone}/{res_id}/data'.format(hs_url=current_site_url,
-                                                                    zone=fed_zone_home_path,
+        hs_res_url = '{hs_url}/resource/{res_id}/data'.format(hs_url=current_site_url,
                                                                     res_id=resource.short_id)
     else:
         hs_res_url = '{hs_url}/resource/{res_id}/data'.format(hs_url=current_site_url,
@@ -155,9 +154,8 @@ def create_bag_files(resource, fed_zone_home_path=''):
             from_fname = f.fed_resource_file_name_or_path
             filename = from_fname.rsplit('/')[-1]
             res_path = os.path.join(
-                '{hs_url}/resource{zone}/{res_id}/data/contents/{file_name}'.format(
+                '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
                     hs_url=current_site_url,
-                    zone=resource.resource_federation_path,
                     res_id=resource.short_id,
                     file_name=filename))
         elif f.resource_file:
@@ -169,9 +167,8 @@ def create_bag_files(resource, fed_zone_home_path=''):
         elif f.fed_resource_file:
             filename = os.path.basename(f.fed_resource_file.name)
             res_path = os.path.join(
-                '{hs_url}/resource{zone}/{res_id}/data/contents/{file_name}'.format(
+                '{hs_url}/resource/{res_id}/data/contents/{file_name}'.format(
                     hs_url=current_site_url,
-                    zone=resource.resource_federation_path,
                     res_id=resource.short_id,
                     file_name=filename))
         else:
@@ -192,9 +189,8 @@ def create_bag_files(resource, fed_zone_home_path=''):
         for contained_res in resource.resources.all():
             contained_res_id = contained_res.short_id
             if contained_res.resource_federation_path:
-                resource_map_url = '{hs_url}/resource{zone}/{res_id}/data/resourcemap.xml'.format(
+                resource_map_url = '{hs_url}/resource/{res_id}/data/resourcemap.xml'.format(
                     hs_url=current_site_url,
-                    zone=contained_res.resource_federation_path,
                     res_id=contained_res_id)
             else:
                 resource_map_url = '{hs_url}/resource/{res_id}/data/resourcemap.xml'.format(

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -108,7 +108,7 @@ def create_bag_files(resource, fed_zone_home_path=''):
     # make the resource map
     current_site_url = current_site_url()
     hs_res_url = '{hs_url}/resource/{res_id}/data'.format(hs_url=current_site_url,
-                                                              res_id=resource.short_id)
+                                                          res_id=resource.short_id)
     metadata_url = os.path.join(hs_res_url, 'resourcemetadata.xml')
     res_map_url = os.path.join(hs_res_url, 'resourcemap.xml')
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1241,11 +1241,6 @@ class AbstractResource(ResourcePermissionsMixin):
         bag_path = "{path}/{resource_id}.{postfix}".format(path=bagit_path,
                                                            resource_id=resource_id,
                                                            postfix=bagit_postfix)
-        res = get_resource_by_shortkey(resource_id)
-        if res.resource_federation_path:
-            rel_fed_path = res.resource_federation_path[1:]
-            bag_path = os.path.join(rel_fed_path, bag_path)
-
         istorage = IrodsStorage()
         bag_url = istorage.url(bag_path)
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1235,7 +1235,6 @@ class AbstractResource(ResourcePermissionsMixin):
 
     @classmethod
     def bag_url(cls, resource_id):
-        from hs_core.hydroshare.utils import get_resource_by_shortkey
         bagit_path = getattr(settings, 'IRODS_BAGIT_PATH', 'bags')
         bagit_postfix = getattr(settings, 'IRODS_BAGIT_POSTFIX', 'zip')
         bag_path = "{path}/{resource_id}.{postfix}".format(path=bagit_path,

--- a/hs_core/resourcemap_urls.py
+++ b/hs_core/resourcemap_urls.py
@@ -12,9 +12,4 @@ urlpatterns = patterns('',
     url(r'^resource/(?P<shortkey>[A-z0-9]+)/data/contents/([^/]+)/$', views.file_download_url_mapper,
         name='get_resource_file'),
 
-    url(r'^resource/([A-z0-9]+)/home/{}/(?P<shortkey>[A-z0-9]+)/data/([^/]+)/$'.format(settings.HS_LOCAL_PROXY_USER_IN_FED_ZONE),
-        views.file_download_url_mapper, name='get_resourcemap_or_metadata_file'),
-
-    url(r'^resource/([A-z0-9]+)/home/{}/(?P<shortkey>[A-z0-9]+)/data/contents/([^/]+)/$'.format(settings.HS_LOCAL_PROXY_USER_IN_FED_ZONE),
-        views.file_download_url_mapper, name='get_resource_file'),
      )

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -143,13 +143,13 @@
                                                                                                   title="Download"
                                                                                                   class="glyphicon glyphicon-download icon-button btn-download"></span></a>
                                                         {% elif f.fed_resource_file and f.fed_resource_file.size < 1000000000 %}
-                                                            <a href="{{ f.fed_resource_file.url }}"><span data-toggle="tooltip"
+                                                            <a href="{{ f.fed_resource_file.url|relative_irods_path }}"><span data-toggle="tooltip"
                                                                                                   data-placement="auto"
                                                                                                   title="Download"
                                                                                                   class="glyphicon glyphicon-download icon-button btn-download"></span></a>
                                                         {# only allow download from irods user zone for files smaller than 1GB #}
                                                         {% elif f.fed_resource_file_name_or_path and f.fed_resource_file_size|to_int < 1000000000 %}
-                                                            <a href="/django_irods/download{{ cm.resource_federation_path }}/{{ cm.short_id }}/{{ f.fed_resource_file_name_or_path }}"><span data-toggle="tooltip"
+                                                            <a href="/django_irods/download/{{ cm.short_id }}/{{ f.fed_resource_file_name_or_path }}"><span data-toggle="tooltip"
                                                                                                   data-placement="auto"
                                                                                                   title="Download"
                                                                                                   class="glyphicon glyphicon-download icon-button btn-download"></span></a>


### PR DESCRIPTION
@alvacouch @pkdash This PR needs to be reviewed together with the corresponding PR for django_irods submodule here: https://github.com/hydroshare/django_irods/pull/17. After this PR is merged, federation zone name will be removed from all urls used in HydroShare. So resourcemap.xml download url will be www.hydroshare.org/resource/id/data/resourcemap.xml regardless of which iRODS zone the resource resides. Thanks @alvacouch for pushing forward with this url issue and I am glad I have this issue worked out before federation zone really comes into full use. I am hoping this PR can be merged sooner rather than later since resourcemap.xml file needs to be regenerated for resources that reside in a federated zone. We only have very few such resources as of now, so it'd be good to have this url issue fixed before the number of such resources grow over time. 