### PR TITLE
fixed issue #1474

### DIFF
--- a/hs_tracking/migrations/0004_auto_20161010_1402.py
+++ b/hs_tracking/migrations/0004_auto_20161010_1402.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hs_tracking', '0003_auto_20160623_1718'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='variable',
+            name='value',
+            field=models.CharField(max_length=500),
+        ),
+    ]

--- a/hs_tracking/models.py
+++ b/hs_tracking/models.py
@@ -115,7 +115,7 @@ class Variable(models.Model):
     timestamp = models.DateTimeField(auto_now_add=True)
     name = models.CharField(max_length=32)
     type = models.IntegerField(choices=TYPE_CHOICES)
-    value = models.CharField(max_length=130)
+    value = models.CharField(max_length=500)
 
     def get_value(self):
         v = self.value


### PR DESCRIPTION
@mjstealey Can you code review this? The only change is to increase max_length from 130 to 500 for value field in hs_tracking/models.py with corresponding migration file. Have tested in my local environment and bag with long file names (over 230 characters) can be downloaded without issues with this fix. 