### PR TITLE
[#1407] added isCopiedFrom and isHostedBy to the terms page

### DIFF
--- a/hs_core/templates/pages/metadata_terms.html
+++ b/hs_core/templates/pages/metadata_terms.html
@@ -121,14 +121,14 @@
             <li><strong>Term: </strong>isCopiedFrom</li>
             <li><strong>URI: </strong><a href="#isCopiedFrom">http://www.hydroshare.org/terms/isCopiedFrom</a></li>
             <li><strong>Label: </strong>Copied From</li>
-            <li><strong>Description: </strong>The source URL or name where the resource is copied from.</li>
+            <li><strong>Description: </strong>Name or URL of the source from which a resource is copied.</li>
         </ul>
 
         <ul >
             <li><strong>Term: </strong>isHostedBy</li>
             <li><strong>URI: </strong><a href="#isHostedBy">http://www.hydroshare.org/terms/isHostedBy</a></li>
             <li><strong>Label: </strong>Hosted By</li>
-            <li><strong>Description: </strong>The host URL or name of the external sytem where the resource is located.</li>
+            <li><strong>Description: </strong>Name or URL of the external system where a resource is located.</li>
         </ul>
 
 

--- a/hs_core/templates/pages/metadata_terms.html
+++ b/hs_core/templates/pages/metadata_terms.html
@@ -108,13 +108,27 @@
             <li><strong>Description: </strong> a text statement that points to a rights
                 management or usage statement for the resource.</li>
         </ul>
-
+        <a name="isCopiedFrom"></a>
         <ul>
             <li><strong>Term: </strong>URL</li>
             <li><strong>URI: </strong><a href="#URL">http://www.hydroshare.org/terms/URL</a></li>
             <li><strong>Label: </strong>Uniform Resource Locator</li>
             <li><strong>Description: </strong>URL that points to a rights
                 management or usage statement for the resource.</li>
+        </ul>
+        <a name="isHostedBy"></a>
+        <ul >
+            <li><strong>Term: </strong>isCopiedFrom</li>
+            <li><strong>URI: </strong><a href="#isCopiedFrom">http://www.hydroshare.org/terms/isCopiedFrom</a></li>
+            <li><strong>Label: </strong>Copied From</li>
+            <li><strong>Description: </strong>The source URL or name where the resource is copied from.</li>
+        </ul>
+
+        <ul >
+            <li><strong>Term: </strong>isHostedBy</li>
+            <li><strong>URI: </strong><a href="#isHostedBy">http://www.hydroshare.org/terms/isHostedBy</a></li>
+            <li><strong>Label: </strong>Hosted By</li>
+            <li><strong>Description: </strong>The host URL or name of the external sytem where the resource is located.</li>
         </ul>
 
 


### PR DESCRIPTION
This is a minor fix to add isCopiedFrom and isHostedBy to the terms page