### PR TITLE
1501 Docker implementation of federated iRODS zones for HydroShare

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -26,6 +26,8 @@ DEV_SSH_COMMAND='runuser -p -u hydro-service -g storage-hydro /usr/sbin/sshd'
 PROD_SERVER='./run-server'
 PROD_SSH_COMMAND='# REMOVED SSH COMPONENT'
 
+USE_LOCAL_IRODS=False
+
 display_usage() {
     echo "*** HydroShare Control script ***"
     echo "usage: $0 loaddb          # loads database specified in hydroshare-config.yaml into running container"
@@ -147,7 +149,11 @@ preflight_hs() {
     echo "  - USE_NGINX     :${USE_NGINX}"
     echo "  - USE_SSL       :${USE_SSL}"
     # Generate docker-compose.yml
-    cp -rf ${HS_PATH}/scripts/templates/docker-compose.template ${HS_PATH}/docker-compose.yml
+    [[ if $USE_LOCAL_IRODS ]]; then
+        cp -rf ${HS_PATH}/scripts/templates/docker-compose-local-irods.template ${HS_PATH}/docker-compose.yml
+    else
+        cp -rf ${HS_PATH}/scripts/templates/docker-compose.template ${HS_PATH}/docker-compose.yml
+    fi
     sed -i 's!HS_PATH!'${HS_PATH}'!g' ${HS_PATH}/docker-compose.yml
     sed -i 's!HS_LOG_FILES!'${HS_LOG_FILES}'!g' ${HS_PATH}/docker-compose.yml
     # Create static directory if it does not exist

--- a/hsctl
+++ b/hsctl
@@ -57,12 +57,10 @@ stop_nginx() {
 restart_hs() {
     echo "RESTART HYDROSHARE:"
     stop_nginx
-    docker-compose stop hydroshare
-    docker-compose stop defaultworker
+    docker-compose stop hydroshare defaultworker dockerworker
     delete_celerybeat_scheduler
     preflight_hs
-    docker-compose start hydroshare
-    docker-compose start defaultworker
+    docker-compose start hydroshare defaultworker dockerworker
     if [ "${USE_NGINX,,}" = true ]; then
         start_nginx;
     fi
@@ -227,6 +225,8 @@ loaddb_hs() {
 
 migrate_hs() {
     echo "MIGRATE:"
+    echo "  - docker exec -u hydro-service hydroshare python manage.py migrate sites"
+    docker exec -u hydro-service hydroshare python manage.py migrate sites
     echo "  - docker exec -u hydro-service hydroshare python manage.py migrate --fake-initial"
     docker exec -u hydro-service hydroshare python manage.py migrate --fake-initial
     echo "  - docker exec -u hydro-service hydroshare python manage.py fix_permissions"

--- a/hsctl
+++ b/hsctl
@@ -26,7 +26,7 @@ DEV_SSH_COMMAND='runuser -p -u hydro-service -g storage-hydro /usr/sbin/sshd'
 PROD_SERVER='./run-server'
 PROD_SSH_COMMAND='# REMOVED SSH COMPONENT'
 
-USE_LOCAL_IRODS=False
+USE_LOCAL_IRODS=false
 
 display_usage() {
     echo "*** HydroShare Control script ***"
@@ -149,7 +149,7 @@ preflight_hs() {
     echo "  - USE_NGINX     :${USE_NGINX}"
     echo "  - USE_SSL       :${USE_SSL}"
     # Generate docker-compose.yml
-    [[ if $USE_LOCAL_IRODS ]]; then
+    if [[ "$USE_LOCAL_IRODS" = true ]]; then
         cp -rf ${HS_PATH}/scripts/templates/docker-compose-local-irods.template ${HS_PATH}/docker-compose.yml
     else
         cp -rf ${HS_PATH}/scripts/templates/docker-compose.template ${HS_PATH}/docker-compose.yml

--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -108,21 +108,21 @@ DATABASES = {
 POSTGIS_VERSION=(2,1,1)
 
 # Local resource iRODS configuration
-USE_IRODS = True
-IRODS_ROOT = '/tmp'
-IRODS_ICOMMANDS_PATH = '/usr/bin'
-IRODS_HOST = 'hydrotest41.renci.org'
-IRODS_PORT = '1247'
-IRODS_DEFAULT_RESOURCE = 'hydrotest41Resc'
-IRODS_HOME_COLLECTION = '/hydrotest41Zone/home/hsproxy'
-IRODS_CWD = '/hydrotest41Zone/home/hsproxy'
-IRODS_ZONE = 'hydrotest41Zone'
-IRODS_USERNAME = 'hsproxy'
-IRODS_AUTH = 'proxywater1'
-IRODS_GLOBAL_SESSION = True
+USE_IRODS=True
+IRODS_ROOT='/tmp'
+IRODS_ICOMMANDS_PATH='/usr/bin'
+IRODS_HOST='data.local.org'
+IRODS_PORT='1247'
+IRODS_DEFAULT_RESOURCE='hydroshareReplResc'
+IRODS_HOME_COLLECTION='/hydroshareZone/home/wwwHydroProxy'
+IRODS_CWD='/hydroshareZone/home/wwwHydroProxy'
+IRODS_ZONE='hydroshareZone'
+IRODS_USERNAME='wwwHydroProxy'
+IRODS_AUTH='wwwHydroProxy'
+IRODS_GLOBAL_SESSION=True
 
 # Remote user zone iRODS configuration
-REMOTE_USE_IRODS = False
+REMOTE_USE_IRODS = True
 
 # iRODS customized bagit rule path
 IRODS_BAGIT_RULE='hydroshare/irods/ruleGenerateBagIt_HS.r'
@@ -147,27 +147,27 @@ HYRAX_SSH_PROXY_USER_PWD = ''
 HYRAX_SCRIPT_RUN_COMMAND = ''
 
 # hsuserproxy system user configuration used to create hydroshare iRODS users on-demand
-HS_USER_ZONE_HOST = ''
-HS_USER_ZONE_PROXY_USER = ''
-HS_USER_ZONE_PROXY_USER_PWD = ''
-HS_USER_ZONE_PROXY_USER_CREATE_USER_CMD = ''
-HS_USER_ZONE_PROXY_USER_DELETE_USER_CMD = ''
+HS_USER_ZONE_HOST='users.local.org'
+HS_USER_ZONE_PROXY_USER='hsuserproxy'
+HS_USER_ZONE_PROXY_USER_PWD='hsuserproxy'
+HS_USER_ZONE_PROXY_USER_CREATE_USER_CMD='/home/hsuserproxy/create_user.sh'
+HS_USER_ZONE_PROXY_USER_DELETE_USER_CMD='/home/hsuserproxy/delete_user.sh'
 
 # the local HydroShare proxy user (a counterpart of wwwHydroProxy) in a federated zone with HydroShare Zone
-HS_LOCAL_PROXY_USER_IN_FED_ZONE = 'localTestHydroProxy'
+HS_LOCAL_PROXY_USER_IN_FED_ZONE='localHydroProxy'
 
 # Please keep the line below unchanged since it is used to check whether
 # the current site is in production or not
-HS_WWW_IRODS_PROXY_USER = 'wwwHydroProxy'
+HS_WWW_IRODS_PROXY_USER='wwwHydroProxy'
 # credentials for HydroShare proxy user iRODS account which is set to have own access control
 # to all collections in any federated zone with HydroShare zone, which is only useful when
 # testing HydroShare federated zone in local test development environment since in www
 # production environment, IRODS_USERNAME and other associated settings already represent wwwHydroProxy settings
-HS_WWW_IRODS_PROXY_USER_PWD = ''
-HS_WWW_IRODS_HOST = ''
-HS_IRODS_LOCAL_ZONE_DEF_RES = 'hydroshareLocalResc'
-HS_WWW_IRODS_ZONE = ''
-HS_USER_IRODS_ZONE = 'hydroshareuserZone'
+HS_WWW_IRODS_PROXY_USER_PWD='wwwHydroProxy'
+HS_WWW_IRODS_HOST='data.local.org'
+HS_IRODS_LOCAL_ZONE_DEF_RES='hydroshareLocalResc'
+HS_WWW_IRODS_ZONE='hydroshareZone'
+HS_USER_IRODS_ZONE='hydroshareuserZone'
 
 # Email configuration
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -108,21 +108,21 @@ DATABASES = {
 POSTGIS_VERSION=(2,1,1)
 
 # Local resource iRODS configuration
-USE_IRODS=True
-IRODS_ROOT='/tmp'
-IRODS_ICOMMANDS_PATH='/usr/bin'
-IRODS_HOST='data.local.org'
-IRODS_PORT='1247'
-IRODS_DEFAULT_RESOURCE='hydroshareReplResc'
-IRODS_HOME_COLLECTION='/hydroshareZone/home/wwwHydroProxy'
-IRODS_CWD='/hydroshareZone/home/wwwHydroProxy'
-IRODS_ZONE='hydroshareZone'
-IRODS_USERNAME='wwwHydroProxy'
-IRODS_AUTH='wwwHydroProxy'
-IRODS_GLOBAL_SESSION=True
+USE_IRODS = True
+IRODS_ROOT = '/tmp'
+IRODS_ICOMMANDS_PATH = '/usr/bin'
+IRODS_HOST = 'hydrotest41.renci.org'
+IRODS_PORT = '1247'
+IRODS_DEFAULT_RESOURCE = 'hydrotest41Resc'
+IRODS_HOME_COLLECTION = '/hydrotest41Zone/home/hsproxy'
+IRODS_CWD = '/hydrotest41Zone/home/hsproxy'
+IRODS_ZONE = 'hydrotest41Zone'
+IRODS_USERNAME = 'hsproxy'
+IRODS_AUTH = 'proxywater1'
+IRODS_GLOBAL_SESSION = True
 
 # Remote user zone iRODS configuration
-REMOTE_USE_IRODS = True
+REMOTE_USE_IRODS = False
 
 # iRODS customized bagit rule path
 IRODS_BAGIT_RULE='hydroshare/irods/ruleGenerateBagIt_HS.r'
@@ -147,27 +147,27 @@ HYRAX_SSH_PROXY_USER_PWD = ''
 HYRAX_SCRIPT_RUN_COMMAND = ''
 
 # hsuserproxy system user configuration used to create hydroshare iRODS users on-demand
-HS_USER_ZONE_HOST='users.local.org'
-HS_USER_ZONE_PROXY_USER='hsuserproxy'
-HS_USER_ZONE_PROXY_USER_PWD='hsuserproxy'
-HS_USER_ZONE_PROXY_USER_CREATE_USER_CMD='/home/hsuserproxy/create_user.sh'
-HS_USER_ZONE_PROXY_USER_DELETE_USER_CMD='/home/hsuserproxy/delete_user.sh'
+HS_USER_ZONE_HOST = ''
+HS_USER_ZONE_PROXY_USER = ''
+HS_USER_ZONE_PROXY_USER_PWD = ''
+HS_USER_ZONE_PROXY_USER_CREATE_USER_CMD = ''
+HS_USER_ZONE_PROXY_USER_DELETE_USER_CMD = ''
 
 # the local HydroShare proxy user (a counterpart of wwwHydroProxy) in a federated zone with HydroShare Zone
-HS_LOCAL_PROXY_USER_IN_FED_ZONE='localHydroProxy'
+HS_LOCAL_PROXY_USER_IN_FED_ZONE = 'localTestHydroProxy'
 
 # Please keep the line below unchanged since it is used to check whether
 # the current site is in production or not
-HS_WWW_IRODS_PROXY_USER='wwwHydroProxy'
+HS_WWW_IRODS_PROXY_USER = 'wwwHydroProxy'
 # credentials for HydroShare proxy user iRODS account which is set to have own access control
 # to all collections in any federated zone with HydroShare zone, which is only useful when
 # testing HydroShare federated zone in local test development environment since in www
 # production environment, IRODS_USERNAME and other associated settings already represent wwwHydroProxy settings
-HS_WWW_IRODS_PROXY_USER_PWD='wwwHydroProxy'
-HS_WWW_IRODS_HOST='data.local.org'
-HS_IRODS_LOCAL_ZONE_DEF_RES='hydroshareLocalResc'
-HS_WWW_IRODS_ZONE='hydroshareZone'
-HS_USER_IRODS_ZONE='hydroshareuserZone'
+HS_WWW_IRODS_PROXY_USER_PWD = ''
+HS_WWW_IRODS_HOST = ''
+HS_IRODS_LOCAL_ZONE_DEF_RES = 'hydroshareLocalResc'
+HS_WWW_IRODS_ZONE = ''
+HS_USER_IRODS_ZONE = 'hydroshareuserZone'
 
 # Email configuration
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/irods/.gitignore
+++ b/irods/.gitignore
@@ -1,0 +1,1 @@
+env-files/rods@*

--- a/irods/README.md
+++ b/irods/README.md
@@ -12,6 +12,8 @@ Effected files:
 
 From within the `irods` directory, run the script named **use-local-irods.sh**
 
+**NOTE:** This script requires that package `jq` be installed on the host from which the script is being run. If it's not present it can be installed by invoking `sudo apt-get install jq` in Ubuntu (or similar) environments. 
+
 ```bash
 $ cd irods
 $ ./use-local-irods.sh

--- a/irods/README.md
+++ b/irods/README.md
@@ -1,0 +1,77 @@
+## Using local federated iRODS
+
+The scripts herein are a one-way street that update the configuration of HydroShare to use a locally deployed federated pair 
+of iCAT v.4.1.8 servers in Docker.
+
+Effected files:
+-	modified:   hsctl
+-	modified:   hydroshare/local_settings.py
+-	modified:   scripts/templates/docker-compose-local-irods.template
+
+### How to use
+
+From within the `irods` directory, run the script named **use-local-irods.sh**
+
+```bash
+$ cd irods
+$ ./use-local-irods.sh
+```
+The script will run, deploy and federate two iCAT servers, and modify the three aforementioned files to be configured to use the 
+newly created iRODS Docker servers. Once the script has completed, return back the the main `hydroshare` directory and run
+the **hsctl** script as you normally would.
+
+```bash
+$ cd ../
+$ ./hsctl rebuild --db
+```
+
+### In Docker
+
+If all deploys as it should you will see this reflected in the `docker ps` output. As an example:
+
+```
+$ docker ps
+CONTAINER ID        IMAGE                               COMMAND                  CREATED             STATUS              PORTS                                                                                 NAMES
+40fbf4c5ce0d        hydroshare_defaultworker            "/bin/bash init-defau"   53 minutes ago      Up 46 minutes                                                                                             defaultworker
+d6dd948dd220        hydroshare_dockerworker             "/bin/bash init-docke"   53 minutes ago      Up 46 minutes                                                                                             dockerworker
+46e74eb63c86        hydroshare_hydroshare               "/bin/bash init-hydro"   53 minutes ago      Up 46 minutes       0.0.0.0:8000->8000/tcp, 0.0.0.0:1338->2022/tcp                                        hydroshare
+aabeaf3b88e3        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   56 minutes ago      Up 56 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32779->22/tcp, 0.0.0.0:32778->1247/tcp   users.local.org
+120b4b31a3b9        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   56 minutes ago      Up 56 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32777->1247/tcp                          data.local.org
+abdbbf412771        mjstealey/hs_postgres:9.4.7         "/docker-entrypoint.s"   About an hour ago   Up 53 minutes       5432/tcp                                                                              postgis
+f9dfb9981949        makuk66/docker-solr:4.10.4          "sh -c '/bin/bash /op"   About an hour ago   Up 53 minutes       0.0.0.0:32780->8983/tcp                                                               solr
+e259b96f8731        redis:2.8                           "docker-entrypoint.sh"   About an hour ago   Up 53 minutes       6379/tcp                                                                              redis
+cf1828ee0096        rabbitmq:3.5                        "/docker-entrypoint.s"   About an hour ago   Up 53 minutes       4369/tcp, 5671-5672/tcp, 25672/tcp                                                    rabbitmq
+```
+
+### Known issues at this time
+
+There is an iRODS related error that occurs when an attempt is made to create an iRODS account in the user zone from the profile 
+edit page. The error is denoted in the yellow popup as "*Failure iRODS server failed to create this iRODS account mjs. 
+Check the server log for details.*" As well as in the **hydroshare.log** file.
+
+```
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] starting thread (client mode): 0x7b0d3f90L
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Local version/idstring: SSH-2.0-paramiko_1.16.0
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Remote version/idstring: SSH-2.0-OpenSSH_6.7p1 Debian-5+deb8u3
+[22/Oct/2016 01:37:16] INFO [paramiko.transport:282] Connected (version 2.0, client OpenSSH_6.7p1)
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] kex algos:[u'curve25519-sha256@libssh.org', u'ecdh-sha2-nistp256', u'ecdh-sha2-nistp384', u'ecdh-sha2-nistp521', u'diffie-hellman-group-exchange-sha256', u'diffie-hellman-group14-sha1'] server key:[u'ssh-rsa', u'ssh-dss', u'ecdsa-sha2-nistp256', u'ssh-ed25519'] client encrypt:[u'aes128-ctr', u'aes192-ctr', u'aes256-ctr', u'aes128-gcm@openssh.com', u'aes256-gcm@openssh.com', u'chacha20-poly1305@openssh.com'] server encrypt:[u'aes128-ctr', u'aes192-ctr', u'aes256-ctr', u'aes128-gcm@openssh.com', u'aes256-gcm@openssh.com', u'chacha20-poly1305@openssh.com'] client mac:[u'umac-64-etm@openssh.com', u'umac-128-etm@openssh.com', u'hmac-sha2-256-etm@openssh.com', u'hmac-sha2-512-etm@openssh.com', u'hmac-sha1-etm@openssh.com', u'umac-64@openssh.com', u'umac-128@openssh.com', u'hmac-sha2-256', u'hmac-sha2-512', u'hmac-sha1'] server mac:[u'umac-64-etm@openssh.com', u'umac-128-etm@openssh.com', u'hmac-sha2-256-etm@openssh.com', u'hmac-sha2-512-etm@openssh.com', u'hmac-sha1-etm@openssh.com', u'umac-64@openssh.com', u'umac-128@openssh.com', u'hmac-sha2-256', u'hmac-sha2-512', u'hmac-sha1'] client compress:[u'none', u'zlib@openssh.com'] server compress:[u'none', u'zlib@openssh.com'] client lang:[u''] server lang:[u''] kex follows?False
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Kex agreed: diffie-hellman-group14-sha1
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Cipher agreed: aes128-ctr
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] MAC agreed: hmac-sha2-256
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Compression agreed: none
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] kex engine KexGroup14 specified hash_algo <built-in function openssl_sha1>
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Switch to new keys ...
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Adding ssh-rsa host key for users.local.org: 0e6525f0ff7006dd555e9d4a161a49ed
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] userauth is OK
+[22/Oct/2016 01:37:16] INFO [paramiko.transport:282] Authentication (password) successful!
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Max packet in: 32768 bytes
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Max packet out: 32768 bytes
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Secsh channel 0 opened.
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Sesch channel 0 request ok
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Sesch channel 0 request ok
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] EOF received (0)
+[22/Oct/2016 01:37:16] DEBUG [django:106] ['  - iadmin mkuser mjs rodsuser\r\n', 'hsuserproxy\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n', 'ERROR: rcConnect failure USER_SOCK_CONNECT_ERR (Connection refused) (-305111) _rcConnect: connectToRhost failed\r\n', '  - iadmin moduser mjs password 12345678\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n', 'ERROR: rcConnect failure USER_SOCK_CONNECT_ERR (Connection refused) (-305111) _rcConnect: connectToRhost failed\r\n', '  - ichmod -rM own wwwHydroProxy#hydroshareZone /hydroshareuserZone/home\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n', '  - ichmod -rM inherit /hydroshareuserZone/home/mjs\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n']
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] EOF sent (0)
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Dropping user packet because connection is dead.
+[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Dropping user packet because connection is dead.
+```

--- a/irods/README.md
+++ b/irods/README.md
@@ -27,6 +27,14 @@ $ cd ../
 $ ./hsctl rebuild --db
 ```
 
+Subsequent runs may require a git checkout of the three effected files since there is no guarantee that the internal Docker IP addresses originally assigned to the containers will reused each time. 
+
+Example:
+
+```bash
+$ git checkout hsctl hydroshare/local_settings.py scripts/templates/docker-compose-local-irods.template
+```
+
 ### In Docker
 
 If all deploys as it should you will see this reflected in the `docker ps` output. As an example:
@@ -34,46 +42,17 @@ If all deploys as it should you will see this reflected in the `docker ps` outpu
 ```
 $ docker ps
 CONTAINER ID        IMAGE                               COMMAND                  CREATED             STATUS              PORTS                                                                                 NAMES
-40fbf4c5ce0d        hydroshare_defaultworker            "/bin/bash init-defau"   53 minutes ago      Up 46 minutes                                                                                             defaultworker
-d6dd948dd220        hydroshare_dockerworker             "/bin/bash init-docke"   53 minutes ago      Up 46 minutes                                                                                             dockerworker
-46e74eb63c86        hydroshare_hydroshare               "/bin/bash init-hydro"   53 minutes ago      Up 46 minutes       0.0.0.0:8000->8000/tcp, 0.0.0.0:1338->2022/tcp                                        hydroshare
-aabeaf3b88e3        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   56 minutes ago      Up 56 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32779->22/tcp, 0.0.0.0:32778->1247/tcp   users.local.org
-120b4b31a3b9        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   56 minutes ago      Up 56 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32777->1247/tcp                          data.local.org
-abdbbf412771        mjstealey/hs_postgres:9.4.7         "/docker-entrypoint.s"   About an hour ago   Up 53 minutes       5432/tcp                                                                              postgis
-f9dfb9981949        makuk66/docker-solr:4.10.4          "sh -c '/bin/bash /op"   About an hour ago   Up 53 minutes       0.0.0.0:32780->8983/tcp                                                               solr
-e259b96f8731        redis:2.8                           "docker-entrypoint.sh"   About an hour ago   Up 53 minutes       6379/tcp                                                                              redis
-cf1828ee0096        rabbitmq:3.5                        "/docker-entrypoint.s"   About an hour ago   Up 53 minutes       4369/tcp, 5671-5672/tcp, 25672/tcp                                                    rabbitmq
+13892b4e5487        hydroshare_dockerworker             "/bin/bash init-docke"   17 minutes ago      Up 9 minutes                                                                                              dockerworker
+5af966576bff        hydroshare_defaultworker            "/bin/bash init-defau"   17 minutes ago      Up 9 minutes                                                                                              defaultworker
+7047505e0374        hydroshare_hydroshare               "/bin/bash init-hydro"   17 minutes ago      Up 9 minutes        0.0.0.0:8000->8000/tcp, 0.0.0.0:1338->2022/tcp                                        hydroshare
+3132355d9d4b        redis:2.8                           "docker-entrypoint.sh"   17 minutes ago      Up 17 minutes       6379/tcp                                                                              redis
+82aefa42b4f6        makuk66/docker-solr:4.10.4          "sh -c '/bin/bash /op"   17 minutes ago      Up 17 minutes       0.0.0.0:32786->8983/tcp                                                               solr
+e67b799315ab        mjstealey/hs_postgres:9.4.7         "/docker-entrypoint.s"   17 minutes ago      Up 17 minutes       5432/tcp                                                                              postgis
+52c67ebb6b57        rabbitmq:3.5                        "/docker-entrypoint.s"   17 minutes ago      Up 17 minutes       4369/tcp, 5671-5672/tcp, 25672/tcp                                                    rabbitmq
+0b1a6c66a585        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32785->22/tcp, 0.0.0.0:32784->1247/tcp   users.local.org
+a4d976bcdeb7        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32783->1247/tcp                          data.local.org
 ```
 
 ### Known issues at this time
 
-There is an iRODS related error that occurs when an attempt is made to create an iRODS account in the user zone from the profile 
-edit page. The error is denoted in the yellow popup as "*Failure iRODS server failed to create this iRODS account mjs. 
-Check the server log for details.*" As well as in the **hydroshare.log** file.
-
-```
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] starting thread (client mode): 0x7b0d3f90L
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Local version/idstring: SSH-2.0-paramiko_1.16.0
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Remote version/idstring: SSH-2.0-OpenSSH_6.7p1 Debian-5+deb8u3
-[22/Oct/2016 01:37:16] INFO [paramiko.transport:282] Connected (version 2.0, client OpenSSH_6.7p1)
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] kex algos:[u'curve25519-sha256@libssh.org', u'ecdh-sha2-nistp256', u'ecdh-sha2-nistp384', u'ecdh-sha2-nistp521', u'diffie-hellman-group-exchange-sha256', u'diffie-hellman-group14-sha1'] server key:[u'ssh-rsa', u'ssh-dss', u'ecdsa-sha2-nistp256', u'ssh-ed25519'] client encrypt:[u'aes128-ctr', u'aes192-ctr', u'aes256-ctr', u'aes128-gcm@openssh.com', u'aes256-gcm@openssh.com', u'chacha20-poly1305@openssh.com'] server encrypt:[u'aes128-ctr', u'aes192-ctr', u'aes256-ctr', u'aes128-gcm@openssh.com', u'aes256-gcm@openssh.com', u'chacha20-poly1305@openssh.com'] client mac:[u'umac-64-etm@openssh.com', u'umac-128-etm@openssh.com', u'hmac-sha2-256-etm@openssh.com', u'hmac-sha2-512-etm@openssh.com', u'hmac-sha1-etm@openssh.com', u'umac-64@openssh.com', u'umac-128@openssh.com', u'hmac-sha2-256', u'hmac-sha2-512', u'hmac-sha1'] server mac:[u'umac-64-etm@openssh.com', u'umac-128-etm@openssh.com', u'hmac-sha2-256-etm@openssh.com', u'hmac-sha2-512-etm@openssh.com', u'hmac-sha1-etm@openssh.com', u'umac-64@openssh.com', u'umac-128@openssh.com', u'hmac-sha2-256', u'hmac-sha2-512', u'hmac-sha1'] client compress:[u'none', u'zlib@openssh.com'] server compress:[u'none', u'zlib@openssh.com'] client lang:[u''] server lang:[u''] kex follows?False
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Kex agreed: diffie-hellman-group14-sha1
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Cipher agreed: aes128-ctr
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] MAC agreed: hmac-sha2-256
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Compression agreed: none
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] kex engine KexGroup14 specified hash_algo <built-in function openssl_sha1>
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Switch to new keys ...
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Adding ssh-rsa host key for users.local.org: 0e6525f0ff7006dd555e9d4a161a49ed
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] userauth is OK
-[22/Oct/2016 01:37:16] INFO [paramiko.transport:282] Authentication (password) successful!
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Max packet in: 32768 bytes
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Max packet out: 32768 bytes
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Secsh channel 0 opened.
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Sesch channel 0 request ok
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] Sesch channel 0 request ok
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] EOF received (0)
-[22/Oct/2016 01:37:16] DEBUG [django:106] ['  - iadmin mkuser mjs rodsuser\r\n', 'hsuserproxy\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n', 'ERROR: rcConnect failure USER_SOCK_CONNECT_ERR (Connection refused) (-305111) _rcConnect: connectToRhost failed\r\n', '  - iadmin moduser mjs password 12345678\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n', 'ERROR: rcConnect failure USER_SOCK_CONNECT_ERR (Connection refused) (-305111) _rcConnect: connectToRhost failed\r\n', '  - ichmod -rM own wwwHydroProxy#hydroshareZone /hydroshareuserZone/home\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n', '  - ichmod -rM inherit /hydroshareuserZone/home/mjs\r\n', 'ERROR: _rcConnect: connectToRhost error, server on users.local.org:0 is probably down status = -305111 USER_SOCK_CONNECT_ERR, Connection refused\r\n']
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] [chan 0] EOF sent (0)
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Dropping user packet because connection is dead.
-[22/Oct/2016 01:37:16] DEBUG [paramiko.transport:282] Dropping user packet because connection is dead.
-```
+None at this time

--- a/irods/config-hsctl-compose.sh
+++ b/irods/config-hsctl-compose.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+

--- a/irods/config-hsctl-compose.sh
+++ b/irods/config-hsctl-compose.sh
@@ -1,2 +1,30 @@
 #!/usr/bin/env bash
 
+source env-files/use-local-irods.env
+
+# set extra_hosts in docker-compose-local-irods.template
+IRODS_DATA_HOSTNAME=$IRODS_HOST
+IRODS_DATA_IP=$(docker ps -a | rev | cut -d ' ' -f 1 | rev | grep ${IRODS_HOST})
+IRODS_USER_HOSTNAME=$HS_USER_ZONE_HOST
+IRODS_USER_IP=$(docker ps -a | rev | cut -d ' ' -f 1 | rev | grep ${HS_USER_ZONE_HOST})
+
+echo "CONFIGURE: docker-compose-local-irods.template"
+echo "$ sed -i /\<IRODS_DATA_HOSTNAME\>/${IRODS_DATA_HOSTNAME} ../scripts/templates/docker-compose-local-irods.template"
+sed -i "/\<IRODS_DATA_HOSTNAME\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+
+echo "$ sed -i /\<IRODS_DATA_IP\>/${IRODS_DATA_IP} ../scripts/templates/docker-compose-local-irods.template"
+sed -i "/\<IRODS_DATA_IP\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+
+echo "$ sed -i /\<IRODS_USER_HOSTNAME\>/${IRODS_USER_HOSTNAME} ../scripts/templates/docker-compose-local-irods.template"
+sed -i "/\<IRODS_USER_HOSTNAME\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+
+echo "$ sed -i /\<IRODS_USER_IP\>/${IRODS_USER_IP} ../scripts/templates/docker-compose-local-irods.template"
+sed -i "/\<IRODS_USER_IP\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+
+# update hsctl to use-local-irods
+USE_LOCAL_IRODS=True
+echo "CONFIGURE: hsctl"
+echo "$ sed -i /\<USE_LOCAL_IRODS\>/c\\USE_LOCAL_IRODS=${USE_LOCAL_IRODS} ../hsctl"
+sed -i "/\<USE_LOCAL_IRODS\>/c\USE_LOCAL_IRODS="${USE_LOCAL_IRODS}"" ../hsctl
+
+exit 0;

--- a/irods/config-hsctl-compose.sh
+++ b/irods/config-hsctl-compose.sh
@@ -4,27 +4,27 @@ source env-files/use-local-irods.env
 
 # set extra_hosts in docker-compose-local-irods.template
 IRODS_DATA_HOSTNAME=$IRODS_HOST
-IRODS_DATA_IP=$(docker ps -a | rev | cut -d ' ' -f 1 | rev | grep ${IRODS_HOST})
+IRODS_DATA_IP=$(docker exec ${IRODS_HOST} /sbin/ip -f inet -4 -o addr | grep eth | cut -d '/' -f 1 | rev | cut -d ' ' -f 1 | rev)
 IRODS_USER_HOSTNAME=$HS_USER_ZONE_HOST
-IRODS_USER_IP=$(docker ps -a | rev | cut -d ' ' -f 1 | rev | grep ${HS_USER_ZONE_HOST})
+IRODS_USER_IP=$(docker exec ${HS_USER_ZONE_HOST} /sbin/ip -f inet -4 -o addr | grep eth | cut -d '/' -f 1 | rev | cut -d ' ' -f 1 | rev)
 
 echo "CONFIGURE: docker-compose-local-irods.template"
-echo "$ sed -i /\<IRODS_DATA_HOSTNAME\>/${IRODS_DATA_HOSTNAME} ../scripts/templates/docker-compose-local-irods.template"
-sed -i "/\<IRODS_DATA_HOSTNAME\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+echo "$ sed -i s/\<IRODS_DATA_HOSTNAME\>/${IRODS_DATA_HOSTNAME}/ ../scripts/templates/docker-compose-local-irods.template"
+sed -i "s/\<IRODS_DATA_HOSTNAME\>/"${IRODS_DATA_HOSTNAME}"/" ../scripts/templates/docker-compose-local-irods.template
 
-echo "$ sed -i /\<IRODS_DATA_IP\>/${IRODS_DATA_IP} ../scripts/templates/docker-compose-local-irods.template"
-sed -i "/\<IRODS_DATA_IP\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+echo "$ sed -i s/\<IRODS_DATA_IP\>/${IRODS_DATA_IP}/ ../scripts/templates/docker-compose-local-irods.template"
+sed -i "s/\<IRODS_DATA_IP\>/"${IRODS_DATA_IP}"/" ../scripts/templates/docker-compose-local-irods.template
 
-echo "$ sed -i /\<IRODS_USER_HOSTNAME\>/${IRODS_USER_HOSTNAME} ../scripts/templates/docker-compose-local-irods.template"
-sed -i "/\<IRODS_USER_HOSTNAME\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+echo "$ sed -i s/\<IRODS_USER_HOSTNAME\>/${IRODS_USER_HOSTNAME}/ ../scripts/templates/docker-compose-local-irods.template"
+sed -i "s/\<IRODS_USER_HOSTNAME\>/"${IRODS_USER_HOSTNAME}"/" ../scripts/templates/docker-compose-local-irods.template
 
-echo "$ sed -i /\<IRODS_USER_IP\>/${IRODS_USER_IP} ../scripts/templates/docker-compose-local-irods.template"
-sed -i "/\<IRODS_USER_IP\>/"${HSVAL}"" ../scripts/templates/docker-compose-local-irods.template
+echo "$ sed -i s/\<IRODS_USER_IP\>/${IRODS_USER_IP}/ ../scripts/templates/docker-compose-local-irods.template"
+sed -i "s/\<IRODS_USER_IP\>/"${IRODS_USER_IP}"/" ../scripts/templates/docker-compose-local-irods.template
 
 # update hsctl to use-local-irods
-USE_LOCAL_IRODS=True
+USE_LOCAL_IRODS=true
 echo "CONFIGURE: hsctl"
 echo "$ sed -i /\<USE_LOCAL_IRODS\>/c\\USE_LOCAL_IRODS=${USE_LOCAL_IRODS} ../hsctl"
-sed -i "/\<USE_LOCAL_IRODS\>/c\USE_LOCAL_IRODS="${USE_LOCAL_IRODS}"" ../hsctl
+sed -i "/^\<USE_LOCAL_IRODS\>/c\USE_LOCAL_IRODS="${USE_LOCAL_IRODS}"" ../hsctl
 
 exit 0;

--- a/irods/config-local-settings.sh
+++ b/irods/config-local-settings.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source env-files/use-local-irods.env
+echo "CONFIGURE: local_settings.py"
+grep -v '^#' < env-files/use-local-irods.env | { \
+    while read line; do
+        if [[ ! -z "${line}" ]]; then
+            HSVAR=$(echo ${line} | cut -d '=' -f 1)
+            HSVAL=$(echo ${line} | cut -d '=' -f 2)
+            echo "$ sed -i /^\<"${HSVAR}"\>.*/c\\"${HSVAR}"="${HSVAL}" ../hydroshare/local_settings.py"
+            sed -i "/^\<"${HSVAR}"\>.*/c\\"${HSVAR}"="${HSVAL}"" ../hydroshare/local_settings.py
+        fi
+    done
+}
+
+exit 0;

--- a/irods/create_user.sh
+++ b/irods/create_user.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# HydroShare user zone control script to create iRODS users on-demand corresponding to HydroShare users
+# AUthor: Hong Yi <hongyi@renci.org>
+
+HS_WWW_IRODS_PROXY_USER=wwwHydroProxy
+HS_WWW_IRODS_ZONE=hydroshareZone
+HS_USER_IRODS_ZONE=hydroshareuserZone
+
+echo "  - iadmin mkuser $1 rodsuser"
+iadmin mkuser $1 rodsuser
+echo "  - iadmin moduser $1 password $2"
+iadmin moduser $1 password $2
+echo "  - ichmod -rM own ${HS_WWW_IRODS_PROXY_USER}#${HS_WWW_IRODS_ZONE} /${HS_USER_IRODS_ZONE}/home"
+ichmod -rM own ${HS_WWW_IRODS_PROXY_USER}#${HS_WWW_IRODS_ZONE} /${HS_USER_IRODS_ZONE}/home
+echo "  - ichmod -rM inherit /${HS_USER_IRODS_ZONE}/home/$1"
+ichmod -rM inherit /${HS_USER_IRODS_ZONE}/home/$1

--- a/irods/delete_user.sh
+++ b/irods/delete_user.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# HydroShare user zone control script to delete a specific iRODS users on-demand corresponding to HydroShare users
+# AUthor: Hong Yi <hongyi@renci.org>
+# change permission so that hsuserproxy can delete all collections on behalf of the user before deleting the user
+ichmod -rM own hsuserproxy /hydroshareuserZone/home/$1
+ils /hydroshareuserZone/home/$1 | rev | cut -d '/' -f 1 | rev | sed '1d' > resource_list
+while read line; do irm -rf /hydroshareuserZone/home/$1/$line; done < <(cat resource_list)
+
+iadmin rmuser $1
+
+exit 0;

--- a/irods/env-files/use-local-irods.env
+++ b/irods/env-files/use-local-irods.env
@@ -34,7 +34,7 @@ HS_WWW_IRODS_PROXY_USER='wwwHydroProxy'
 # to all collections in any federated zone with HydroShare zone, which is only useful when
 # testing HydroShare federated zone in local test development environment since in www
 # production environment, IRODS_USERNAME and other associated settings already represent wwwHydroProxy settings
-HS_WWW_IRODS_PROXY_USER_PWD='localHydroProxy'
+HS_WWW_IRODS_PROXY_USER_PWD='wwwHydroProxy'
 HS_WWW_IRODS_HOST='data.local.org'
 HS_IRODS_LOCAL_ZONE_DEF_RES='hydroshareLocalResc'
 HS_WWW_IRODS_ZONE='hydroshareZone'

--- a/irods/env-files/use-local-irods.env
+++ b/irods/env-files/use-local-irods.env
@@ -1,0 +1,41 @@
+SHARED_NEG_KEY=hydroshareZonehydroshareuserZone
+
+# Local resource iRODS configuration
+USE_IRODS=True
+IRODS_ROOT='/tmp'
+IRODS_ICOMMANDS_PATH='/usr/bin'
+IRODS_HOST='data.local.org'
+IRODS_PORT='1247'
+IRODS_DEFAULT_RESOURCE='hydroshareReplResc'
+IRODS_HOME_COLLECTION='/hydroshareZone/home/wwwHydroProxy'
+IRODS_CWD='/hydroshareZone/home/wwwHydroProxy'
+IRODS_ZONE='hydroshareZone'
+IRODS_USERNAME='wwwHydroProxy'
+IRODS_AUTH='wwwHydroProxy'
+IRODS_GLOBAL_SESSION=True
+
+# Remote user zone iRODS configuration
+REMOTE_USE_IRODS=True
+
+# hsuserproxy system user configuration used to create hydroshare iRODS users on-demand
+HS_USER_ZONE_HOST='users.local.org'
+HS_USER_ZONE_PROXY_USER='hsuserproxy'
+HS_USER_ZONE_PROXY_USER_PWD='hsuserproxy'
+HS_USER_ZONE_PROXY_USER_CREATE_USER_CMD='/home/hsuserproxy/create_user.sh'
+HS_USER_ZONE_PROXY_USER_DELETE_USER_CMD='/home/hsuserproxy/delete_user.sh'
+
+# the local HydroShare proxy user (a counterpart of wwwHydroProxy) in a federated zone with HydroShare Zone
+HS_LOCAL_PROXY_USER_IN_FED_ZONE='localHydroProxy'
+
+# Please keep the line below unchanged since it is used to check whether
+# the current site is in production or not
+HS_WWW_IRODS_PROXY_USER='wwwHydroProxy'
+# credentials for HydroShare proxy user iRODS account which is set to have own access control
+# to all collections in any federated zone with HydroShare zone, which is only useful when
+# testing HydroShare federated zone in local test development environment since in www
+# production environment, IRODS_USERNAME and other associated settings already represent wwwHydroProxy settings
+HS_WWW_IRODS_PROXY_USER_PWD='localHydroProxy'
+HS_WWW_IRODS_HOST='data.local.org'
+HS_IRODS_LOCAL_ZONE_DEF_RES='hydroshareLocalResc'
+HS_WWW_IRODS_ZONE='hydroshareZone'
+HS_USER_IRODS_ZONE='hydroshareuserZone'

--- a/irods/use-local-irods.sh
+++ b/irods/use-local-irods.sh
@@ -51,8 +51,8 @@ done
 
 # Install OpenSSH on ${HS_USER_ZONE_HOST}
 echo "INFO: Install OpenSSH on ${HS_USER_ZONE_HOST}"
-echo "[root@${HS_USER_ZONE_HOST}]$ apt-get install -y openssh-client openssh-server && /etc/init.d/ssh restart"
-docker exec ${HS_USER_ZONE_HOST} sh -c "apt-get install -y openssh-client openssh-server && /etc/init.d/ssh restart"
+echo "[root@${HS_USER_ZONE_HOST}]$ apt-get install -y openssh-client openssh-server && mkdir /var/run/sshd && sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && /etc/init.d/ssh restart"
+docker exec ${HS_USER_ZONE_HOST} sh -c "apt-get install -y openssh-client openssh-server && mkdir /var/run/sshd && sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && /etc/init.d/ssh restart"
 
 # Create Linux user ${HS_USER_ZONE_PROXY_USER} on ${HS_USER_ZONE_HOST}
 echo "INFO: Create Linux user ${HS_USER_ZONE_PROXY_USER} on ${HS_USER_ZONE_HOST}"
@@ -62,6 +62,7 @@ echo "[root@${HS_USER_ZONE_HOST}]$ cp create_user.sh delete_user.sh /home/${HS_U
 docker cp create_user.sh ${HS_USER_ZONE_HOST}:/home/${HS_USER_ZONE_PROXY_USER}
 docker cp delete_user.sh ${HS_USER_ZONE_HOST}:/home/${HS_USER_ZONE_PROXY_USER}
 docker exec ${HS_USER_ZONE_HOST} chown -R ${HS_USER_ZONE_PROXY_USER}:${HS_USER_ZONE_PROXY_USER} /home/${HS_USER_ZONE_PROXY_USER}
+docker exec ${HS_USER_ZONE_HOST} sh -c "echo "${HS_USER_ZONE_PROXY_USER}":"${HS_USER_ZONE_PROXY_USER}" | chpasswd"
 
 # Make ${IRODS_HOST} and ${HS_USER_ZONE_HOST} aware of each other via /etc/hosts
 echo "INFO: update /etc/hosts"
@@ -100,7 +101,13 @@ docker exec ${HS_USER_ZONE_HOST} sh -c "jq '.federation[0].icat_host=\"${IRODS_H
 docker exec ${HS_USER_ZONE_HOST} sh -c "cat /tmp/tmp.json | jq '.' > /etc/irods/server_config.json && chown irods:irods /etc/irods/server_config.json && rm -f /tmp/tmp.json"
 docker exec ${HS_USER_ZONE_HOST} sh -c "cat /etc/irods/server_config.json | jq '.federation'"
 
-# make ${IRODS_USERNAME} in ${IRODS_ZONE}
+# make resource ${IRODS_DEFAULT_RESOURCE} in ${IRODS_ZONE}
+echo "[rods@${IRODS_HOST}]$ iadmin mkresc ${IRODS_DEFAULT_RESOURCE} unixfilesystem ${IRODS_HOST}:/var/lib/irods/iRODS/Vault"
+docker run --rm --env-file env-files/rods@${IRODS_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c 'iadmin mkresc '${IRODS_DEFAULT_RESOURCE}' unixfilesystem '${IRODS_HOST}':${IRODS_VAULT_DIRECTORY}'
+
+# make user ${IRODS_USERNAME} in ${IRODS_ZONE}
 echo "[rods@${IRODS_HOST}]$ iadmin mkuser ${IRODS_USERNAME} rodsuser"
 echo "[rods@${IRODS_HOST}]$ iadmin moduser ${IRODS_USERNAME} password ${IRODS_AUTH}"
 docker run --rm --env-file env-files/rods@${IRODS_HOST}.env \
@@ -114,6 +121,19 @@ docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
     mjstealey/docker-irods-icommands:4.1.8 \
     sh -c "iadmin mkuser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} rodsuser && iadmin moduser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} password ${HS_WWW_IRODS_PROXY_USER_PWD}"
 
+
+#echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin"
+#echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
+#docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+#    mjstealey/docker-irods-icommands:4.1.8 \
+#    sh -c "iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin && iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
+
+# make resource ${HS_IRODS_LOCAL_ZONE_DEF_RES} in ${HS_USER_ZONE_HOST}
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkresc ${HS_IRODS_LOCAL_ZONE_DEF_RES} unixfilesystem ${HS_WWW_IRODS_HOST}:/var/lib/irods/iRODS/Vault"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c 'iadmin mkresc '${HS_IRODS_LOCAL_ZONE_DEF_RES}' unixfilesystem '${HS_USER_ZONE_HOST}':${IRODS_VAULT_DIRECTORY}'
+
 # iint the ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} to operate as rods
 echo "[${HS_USER_ZONE_PROXY_USER}@${HS_USER_ZONE_HOST}]$ iinit"
 docker exec -u ${HS_USER_ZONE_PROXY_USER} ${HS_USER_ZONE_HOST} sh -c "export IRODS_HOST=${ICAT2IP} && export IRODS_USER_NAME=rods && export IRODS_PASSWORD=rods && iinit rods"
@@ -121,5 +141,28 @@ docker exec -u ${HS_USER_ZONE_PROXY_USER} ${HS_USER_ZONE_HOST} sh -c "export IRO
 jq -n --arg h "${HS_USER_ZONE_HOST}" --arg p "${IRODS_PORT}" --arg z "${HS_USER_IRODS_ZONE}" '{"irods_host": $h, "irods_port": $p, "irods_zone_name": $z, "irods_user_name": "rods"}' > env-files/rods@${HS_USER_ZONE_HOST}.json
 docker cp env-files/rods@${HS_USER_ZONE_HOST}.json ${HS_USER_ZONE_HOST}:/home/${HS_USER_ZONE_PROXY_USER}/.irods/irods_environment.json
 docker exec ${HS_USER_ZONE_HOST} chown ${HS_USER_ZONE_PROXY_USER}:${HS_USER_ZONE_PROXY_USER} /home/${HS_USER_ZONE_PROXY_USER}/.irods/irods_environment.json
+
+# give ${IRODS_USERNAME} own rights over ${HS_USER_IRODS_ZONE}/home
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkuser ${IRODS_USERNAME}#${IRODS_ZONE} rodsuser"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "iadmin mkuser "${IRODS_USERNAME}"#"${IRODS_ZONE}" rodsuser"
+
+echo "[rods@${HS_USER_ZONE_HOST}]$ ichmod -r -M own ${IRODS_USERNAME}#${IRODS_ZONE} /${HS_USER_IRODS_ZONE}/home"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "ichmod -r -M own "${IRODS_USERNAME}"#"${IRODS_ZONE}" /${HS_USER_IRODS_ZONE}/home"
+
+# give ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} own rights over ${HS_USER_IRODS_ZONE}/home
+echo "[rods@${HS_USER_ZONE_HOST}]$ ichmod -r -M own ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} /${HS_USER_IRODS_ZONE}/home"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "ichmod -r -M own "${HS_LOCAL_PROXY_USER_IN_FED_ZONE}" /${HS_USER_IRODS_ZONE}/home"
+
+# set ${HS_USER_IRODS_ZONE}/home to inherit
+echo "[rods@${HS_USER_ZONE_HOST}]$ ichmod -r -M inherit /${HS_USER_IRODS_ZONE}/home"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "ichmod -r -M inherit /"${HS_USER_IRODS_ZONE}"/home"
 
 exit 0;

--- a/irods/use-local-irods.sh
+++ b/irods/use-local-irods.sh
@@ -105,7 +105,7 @@ docker exec ${HS_USER_ZONE_HOST} sh -c "cat /etc/irods/server_config.json | jq '
 echo "[rods@${IRODS_HOST}]$ iadmin mkresc ${IRODS_DEFAULT_RESOURCE} unixfilesystem ${IRODS_HOST}:/var/lib/irods/iRODS/Vault"
 docker run --rm --env-file env-files/rods@${IRODS_HOST}.env \
     mjstealey/docker-irods-icommands:4.1.8 \
-    sh -c 'iadmin mkresc '${IRODS_DEFAULT_RESOURCE}' unixfilesystem '${IRODS_HOST}':${IRODS_VAULT_DIRECTORY}'
+    sh -c "iadmin mkresc ${IRODS_DEFAULT_RESOURCE} unixfilesystem ${IRODS_HOST}:/var/lib/irods/iRODS/Vault"
 
 # make user ${IRODS_USERNAME} in ${IRODS_ZONE}
 echo "[rods@${IRODS_HOST}]$ iadmin mkuser ${IRODS_USERNAME} rodsuser"
@@ -128,10 +128,10 @@ docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
     sh -c "iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin && iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
 
 # make resource ${HS_IRODS_LOCAL_ZONE_DEF_RES} in ${HS_USER_ZONE_HOST}
-echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkresc ${HS_IRODS_LOCAL_ZONE_DEF_RES} unixfilesystem ${HS_WWW_IRODS_HOST}:/var/lib/irods/iRODS/Vault"
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkresc ${HS_IRODS_LOCAL_ZONE_DEF_RES} unixfilesystem ${HS_USER_ZONE_HOST}:/var/lib/irods/iRODS/Vault"
 docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
     mjstealey/docker-irods-icommands:4.1.8 \
-    sh -c 'iadmin mkresc '${HS_IRODS_LOCAL_ZONE_DEF_RES}' unixfilesystem '${HS_USER_ZONE_HOST}':${IRODS_VAULT_DIRECTORY}'
+    sh -c "iadmin mkresc ${HS_IRODS_LOCAL_ZONE_DEF_RES} unixfilesystem ${HS_USER_ZONE_HOST}:/var/lib/irods/iRODS/Vault"
 
 # iint the ${HS_USER_ZONE_PROXY_USER} in ${HS_USER_ZONE_HOST}
 echo "[${HS_USER_ZONE_PROXY_USER}@${HS_USER_ZONE_HOST}]$ iinit"

--- a/irods/use-local-irods.sh
+++ b/irods/use-local-irods.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# use-local-irods.sh
+# Federated local iRODS for HydroShare in Docker
+# Author: Michael Stealey <michael.j.stealey@gmail.com>
+
+# Pull in environment variables to use for federated local iRODS
+source env-files/use-local-irods.env
+
+# Remove ${IRODS_HOST} and ${HS_USER_ZONE_HOST} containers if the already exist
+ISICAT1=$(docker ps -a | rev | cut -d ' ' -f 1 | rev | grep ${IRODS_HOST})
+ISICAT2=$(docker ps -a | rev | cut -d ' ' -f 1 | rev | grep ${HS_USER_ZONE_HOST})
+
+if [[ "${ISICAT1}" == "${IRODS_HOST}" ]]; then
+    echo "REMOVE: ${IRODS_HOST}"
+    echo "  - docker stop ${IRODS_HOST} && docker rm -fv ${IRODS_HOST}"
+    docker stop ${IRODS_HOST} && docker rm -fv ${IRODS_HOST}
+fi
+if [[ "${ISICAT2}" == "${HS_USER_ZONE_HOST}" ]]; then
+    echo "REMOVE: ${HS_USER_ZONE_HOST}"
+    echo "  - docker stop ${HS_USER_ZONE_HOST} && docker rm -fv ${HS_USER_ZONE_HOST}"
+    docker stop ${HS_USER_ZONE_HOST} && docker rm -fv ${HS_USER_ZONE_HOST}
+fi
+
+# Create ${IRODS_HOST} container from irods v.4.1.8
+echo "CREATE: ${IRODS_HOST} container"
+docker run -d --name ${IRODS_HOST} \
+    -e IRODS_ZONE_NAME=${IRODS_ZONE} \
+    -e IRODS_SERVER_ZONE_KEY=${IRODS_ZONE}_KEY \
+    -e IRODS_DATABASE_SERVER_HOSTNAME=${IRODS_HOST} \
+    -p ${IRODS_PORT} \
+    --hostname ${IRODS_HOST} \
+    mjstealey/docker-irods-icat:4.1.8
+
+# Create ${HS_USER_ZONE_HOST} container from irods v.4.1.8
+echo "CREATE: ${HS_USER_ZONE_HOST} container"
+docker run -d --name ${HS_USER_ZONE_HOST} \
+    -e IRODS_ZONE_NAME=${HS_USER_IRODS_ZONE} \
+    -e IRODS_SERVER_ZONE_KEY=${HS_USER_IRODS_ZONE}_KEY \
+    -e IRODS_DATABASE_SERVER_HOSTNAME=${HS_USER_ZONE_HOST} \
+    -p 1247 \
+    -p 22 \
+    --hostname ${HS_USER_ZONE_HOST} \
+    mjstealey/docker-irods-icat:4.1.8
+
+# wait for ${IRODS_HOST} and ${HS_USER_ZONE_HOST} to finish standing up
+echo "INFO: allow data.local.org and users.local.org to stand up and be configured"
+for pc in $(seq 20 -1 1); do
+    echo -ne "$pc ...\033[0K\r" && sleep 1;
+done
+
+# Install OpenSSH on ${HS_USER_ZONE_HOST}
+echo "INFO: Install OpenSSH on ${HS_USER_ZONE_HOST}"
+echo "[root@${HS_USER_ZONE_HOST}]$ apt-get install -y openssh-client openssh-server && /etc/init.d/ssh restart"
+docker exec ${HS_USER_ZONE_HOST} sh -c "apt-get install -y openssh-client openssh-server && /etc/init.d/ssh restart"
+
+# Create Linux user ${HS_USER_ZONE_PROXY_USER} on ${HS_USER_ZONE_HOST}
+echo "INFO: Create Linux user ${HS_USER_ZONE_PROXY_USER} on ${HS_USER_ZONE_HOST}"
+echo "[root@${HS_USER_ZONE_HOST}]$ useradd -m -p ${HS_USER_ZONE_PROXY_USER_PWD} -s /bin/bash ${HS_USER_ZONE_PROXY_USER}"
+docker exec ${HS_USER_ZONE_HOST} sh -c "useradd -m -p ${HS_USER_ZONE_PROXY_USER_PWD} -s /bin/bash ${HS_USER_ZONE_PROXY_USER}"
+echo "[root@${HS_USER_ZONE_HOST}]$ cp create_user.sh delete_user.sh /home/${HS_USER_ZONE_PROXY_USER}"
+docker cp create_user.sh ${HS_USER_ZONE_HOST}:/home/${HS_USER_ZONE_PROXY_USER}
+docker cp delete_user.sh ${HS_USER_ZONE_HOST}:/home/${HS_USER_ZONE_PROXY_USER}
+docker exec ${HS_USER_ZONE_HOST} chown -R ${HS_USER_ZONE_PROXY_USER}:${HS_USER_ZONE_PROXY_USER} /home/${HS_USER_ZONE_PROXY_USER}
+
+# Make ${IRODS_HOST} and ${HS_USER_ZONE_HOST} aware of each other via /etc/hosts
+echo "INFO: update /etc/hosts"
+ICAT1IP=$(docker exec ${IRODS_HOST} /sbin/ip -f inet -4 -o addr | grep eth | cut -d '/' -f 1 | rev | cut -d ' ' -f 1 | rev)
+ICAT2IP=$(docker exec ${HS_USER_ZONE_HOST} /sbin/ip -f inet -4 -o addr | grep eth | cut -d '/' -f 1 | rev | cut -d ' ' -f 1 | rev)
+echo "[root@${IRODS_HOST}]$ echo \"'${ICAT2IP}' ${HS_USER_ZONE_HOST}\" >> /etc/hosts"
+docker exec ${IRODS_HOST} sh -c 'echo "'${ICAT2IP}' '${HS_USER_ZONE_HOST}'" >> /etc/hosts'
+echo "[root@${HS_USER_ZONE_HOST}]$ echo \"'${ICAT1IP}' ${IRODS_HOST}\" >> /etc/hosts"
+docker exec ${HS_USER_ZONE_HOST} sh -c 'echo "'${ICAT1IP}' '${IRODS_HOST}'" >> /etc/hosts'
+
+# Generate .env files for rods@${IRODS_HOST} and rods@${HS_USER_ZONE_HOST}
+printf "IRODS_HOST=${ICAT1IP}\nIRODS_PORT=${IRODS_PORT}\nIRODS_USER_NAME=rods\nIRODS_ZONE_NAME=${IRODS_ZONE}\nIRODS_PASSWORD=rods" > env-files/rods@${IRODS_HOST}.env
+printf "IRODS_HOST=${ICAT2IP}\nIRODS_PORT=1247\nIRODS_USER_NAME=rods\nIRODS_ZONE_NAME=${HS_USER_IRODS_ZONE}\nIRODS_PASSWORD=rods" > env-files/rods@${HS_USER_ZONE_HOST}.env
+
+# Federate ${IRODS_ZONE} with ${HS_USER_IRODS_ZONE}
+echo "INFO: make remote zone for each"
+echo "[rods@${IRODS_HOST}]$ iadmin mkzone ${HS_USER_IRODS_ZONE} remote ${ICAT2IP}:1247"
+sleep 1s
+docker run --rm --env-file env-files/rods@${IRODS_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    iadmin mkzone ${HS_USER_IRODS_ZONE} remote ${ICAT2IP}:1247
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkzone ${IRODS_ZONE} remote ${ICAT1IP}:${IRODS_PORT}"
+sleep 1s
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    iadmin mkzone ${IRODS_ZONE} remote ${ICAT1IP}:${IRODS_PORT}
+
+# modify /etc/irods/server_config.json
+echo "INFO: federation configuration for ${IRODS_HOST}"
+docker exec ${IRODS_HOST} sh -c "jq '.federation[0].icat_host=\"${HS_USER_ZONE_HOST}\" | .federation[0].zone_name=\"${HS_USER_IRODS_ZONE}\" | .federation[0].zone_key=\"${HS_USER_IRODS_ZONE}_KEY\" | .federation[0].negotiation_key=\"${SHARED_NEG_KEY}\"' /etc/irods/server_config.json > /tmp/tmp.json"
+docker exec ${IRODS_HOST} sh -c "cat /tmp/tmp.json | jq '.' > /etc/irods/server_config.json && chown irods:irods /etc/irods/server_config.json && rm -f /tmp/tmp.json"
+docker exec ${IRODS_HOST} sh -c "cat /etc/irods/server_config.json | jq '.federation'"
+
+echo "INFO: federation configuration for ${HS_USER_ZONE_HOST}"
+docker exec ${HS_USER_ZONE_HOST} sh -c "jq '.federation[0].icat_host=\"${IRODS_HOST}\" | .federation[0].zone_name=\"${IRODS_ZONE}\" | .federation[0].zone_key=\"${IRODS_ZONE}_KEY\" | .federation[0].negotiation_key=\"${SHARED_NEG_KEY}\"' /etc/irods/server_config.json > /tmp/tmp.json"
+docker exec ${HS_USER_ZONE_HOST} sh -c "cat /tmp/tmp.json | jq '.' > /etc/irods/server_config.json && chown irods:irods /etc/irods/server_config.json && rm -f /tmp/tmp.json"
+docker exec ${HS_USER_ZONE_HOST} sh -c "cat /etc/irods/server_config.json | jq '.federation'"
+
+# make ${IRODS_USERNAME} in ${IRODS_ZONE}
+echo "[rods@${IRODS_HOST}]$ iadmin mkuser ${IRODS_USERNAME} rodsuser"
+echo "[rods@${IRODS_HOST}]$ iadmin moduser ${IRODS_USERNAME} password ${IRODS_AUTH}"
+docker run --rm --env-file env-files/rods@${IRODS_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "iadmin mkuser ${IRODS_USERNAME} rodsuser && iadmin moduser ${IRODS_USERNAME} password ${IRODS_AUTH}"
+
+# make ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} and ${HS_USER_ZONE_PROXY_USER} in ${HS_USER_ZONE_HOST}
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkuser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} rodsuser"
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin moduser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} password ${HS_WWW_IRODS_PROXY_USER_PWD}"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "iadmin mkuser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} rodsuser && iadmin moduser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} password ${HS_WWW_IRODS_PROXY_USER_PWD}"
+
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin"
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin && iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
+
+exit 0;

--- a/irods/use-local-irods.sh
+++ b/irods/use-local-irods.sh
@@ -165,4 +165,9 @@ docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
     mjstealey/docker-irods-icommands:4.1.8 \
     sh -c "ichmod -r -M inherit /"${HS_USER_IRODS_ZONE}"/home"
 
+# configure local_settings.py
+./config-local-settings.sh
+# configure hsctl and docker-compose-local-irods.template
+./config-hsctl-compose.sh
+
 exit 0;

--- a/irods/use-local-irods.sh
+++ b/irods/use-local-irods.sh
@@ -121,12 +121,11 @@ docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
     mjstealey/docker-irods-icommands:4.1.8 \
     sh -c "iadmin mkuser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} rodsuser && iadmin moduser ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} password ${HS_WWW_IRODS_PROXY_USER_PWD}"
 
-
-#echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin"
-#echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
-#docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
-#    mjstealey/docker-irods-icommands:4.1.8 \
-#    sh -c "iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin && iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin"
+echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
+docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
+    mjstealey/docker-irods-icommands:4.1.8 \
+    sh -c "iadmin mkuser ${HS_USER_ZONE_PROXY_USER} rodsadmin && iadmin moduser ${HS_USER_ZONE_PROXY_USER} password ${HS_USER_ZONE_PROXY_USER_PWD}"
 
 # make resource ${HS_IRODS_LOCAL_ZONE_DEF_RES} in ${HS_USER_ZONE_HOST}
 echo "[rods@${HS_USER_ZONE_HOST}]$ iadmin mkresc ${HS_IRODS_LOCAL_ZONE_DEF_RES} unixfilesystem ${HS_WWW_IRODS_HOST}:/var/lib/irods/iRODS/Vault"
@@ -134,11 +133,11 @@ docker run --rm --env-file env-files/rods@${HS_USER_ZONE_HOST}.env \
     mjstealey/docker-irods-icommands:4.1.8 \
     sh -c 'iadmin mkresc '${HS_IRODS_LOCAL_ZONE_DEF_RES}' unixfilesystem '${HS_USER_ZONE_HOST}':${IRODS_VAULT_DIRECTORY}'
 
-# iint the ${HS_LOCAL_PROXY_USER_IN_FED_ZONE} to operate as rods
+# iint the ${HS_USER_ZONE_PROXY_USER} in ${HS_USER_ZONE_HOST}
 echo "[${HS_USER_ZONE_PROXY_USER}@${HS_USER_ZONE_HOST}]$ iinit"
-docker exec -u ${HS_USER_ZONE_PROXY_USER} ${HS_USER_ZONE_HOST} sh -c "export IRODS_HOST=${ICAT2IP} && export IRODS_USER_NAME=rods && export IRODS_PASSWORD=rods && iinit rods"
+docker exec -u ${HS_USER_ZONE_PROXY_USER} ${HS_USER_ZONE_HOST} sh -c "export IRODS_HOST=${ICAT2IP} && export IRODS_PORT=${IRODS_PORT} && export IRODS_USER_NAME=${HS_USER_ZONE_PROXY_USER} && export IRODS_PASSWORD=${HS_USER_ZONE_PROXY_USER_PWD} && iinit ${HS_USER_ZONE_PROXY_USER_PWD}"
 # add irods_environment.json file for rods user
-jq -n --arg h "${HS_USER_ZONE_HOST}" --arg p "${IRODS_PORT}" --arg z "${HS_USER_IRODS_ZONE}" '{"irods_host": $h, "irods_port": $p, "irods_zone_name": $z, "irods_user_name": "rods"}' > env-files/rods@${HS_USER_ZONE_HOST}.json
+jq -n --arg h "${HS_USER_ZONE_HOST}" --arg p ${IRODS_PORT} --arg z "${HS_USER_IRODS_ZONE}" --arg n "${HS_USER_ZONE_PROXY_USER}" '{"irods_host": $h, "irods_port": 1247, "irods_zone_name": $z, "irods_user_name": $n}' > env-files/rods@${HS_USER_ZONE_HOST}.json
 docker cp env-files/rods@${HS_USER_ZONE_HOST}.json ${HS_USER_ZONE_HOST}:/home/${HS_USER_ZONE_PROXY_USER}/.irods/irods_environment.json
 docker exec ${HS_USER_ZONE_HOST} chown ${HS_USER_ZONE_PROXY_USER}:${HS_USER_ZONE_PROXY_USER} /home/${HS_USER_ZONE_PROXY_USER}/.irods/irods_environment.json
 

--- a/scripts/templates/docker-compose-local-irods.template
+++ b/scripts/templates/docker-compose-local-irods.template
@@ -55,6 +55,9 @@ hydroshare:
     - redis:redis
     - rabbitmq:rabbitmq
     - solr:solr
+  extra_hosts:
+    - "IRODS_DATA_HOSTNAME:IRODS_DATA_IP"
+    - "IRODS_USER_HOSTNAME:IRODS_USER_IP"
   command: /bin/bash init-hydroshare
 defaultworker:
   build: .
@@ -76,6 +79,9 @@ defaultworker:
     - postgis:postgis
     - redis:redis
     - rabbitmq:rabbitmq
+  extra_hosts:
+    - "IRODS_DATA_HOSTNAME:IRODS_DATA_IP"
+    - "IRODS_USER_HOSTNAME:IRODS_USER_IP"
   command: /bin/bash init-defaultworker
 dockerworker:
   build: .
@@ -97,4 +103,7 @@ dockerworker:
     - postgis:postgis
     - redis:redis
     - rabbitmq:rabbitmq
+  extra_hosts:
+    - "IRODS_DATA_HOSTNAME:IRODS_DATA_IP"
+    - "IRODS_USER_HOSTNAME:IRODS_USER_IP"
   command: /bin/bash init-dockerworker

--- a/scripts/templates/docker-compose.template
+++ b/scripts/templates/docker-compose.template
@@ -55,6 +55,9 @@ hydroshare:
     - redis:redis
     - rabbitmq:rabbitmq
     - solr:solr
+  extra_hosts:
+    - "data.local.org:172.17.0.2"
+    - "users.local.org:172.17.0.3"
   command: /bin/bash init-hydroshare
 defaultworker:
   build: .
@@ -76,6 +79,9 @@ defaultworker:
     - postgis:postgis
     - redis:redis
     - rabbitmq:rabbitmq
+  extra_hosts:
+    - "data.local.org:172.17.0.2"
+    - "users.local.org:172.17.0.3"
   command: /bin/bash init-defaultworker
 dockerworker:
   build: .
@@ -97,4 +103,7 @@ dockerworker:
     - postgis:postgis
     - redis:redis
     - rabbitmq:rabbitmq
+  extra_hosts:
+    - "data.local.org:172.17.0.2"
+    - "users.local.org:172.17.0.3"
   command: /bin/bash init-dockerworker


### PR DESCRIPTION
Implement federated iRODS servers in Docker space for HydroShare
- replicates hydroshareZone and hydroshareuserZone
- follows the same workflow as found in production
- enabled by running one additional script prior to using `hsctl`
- see [README.md](https://github.com/hydroshare/hydroshare/tree/1501-docker-irods/irods) for usage details
