### PR TITLE
fix-multiple-owner-names-bug-in-collection-list-text

### DIFF
--- a/hs_collection_resource/utils.py
+++ b/hs_collection_resource/utils.py
@@ -129,7 +129,8 @@ def _get_owners_string(owners_list):
             name_str = owner.username
         name_list.append(name_str)
     if len(name_list) > 1:
-        return '"' + ', '.join(name_list) + '"'
+        # csv.writer can correctly handle comma in string. No need to add extra quotes here.
+        return ', '.join(name_list)
     else:
         return name_list[0]
 


### PR DESCRIPTION
This pr is to fix the following bug in collection list text file. Only one pair of quote is required to wrap multiple owner names.
 
![image](https://cloud.githubusercontent.com/assets/10070599/19775993/ad6d9172-9c2f-11e6-9fa0-d8215a77894d.png)


