### PR TITLE
fixed the issue [#1512]

### DIFF
--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -1331,8 +1331,9 @@ def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_valu
         istorage.setAVU(res_coll, "isPublic", str(resource.raccess.public))
 
         # run script to update hyrax input files when a private netCDF resource is made public
-        if flag_to_set=='public' and flag_value and settings.RUN_HYRAX_UPDATE and resource.resource_type=='NetcdfResource':
-            run_script_to_update_hyrax_input_files()
+        if flag_to_set=='public' and flag_value and settings.RUN_HYRAX_UPDATE and \
+                        resource.resource_type=='NetcdfResource':
+            run_script_to_update_hyrax_input_files(resource.short_id)
 
 
 def _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag):

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -112,10 +112,10 @@ def run_ssh_command(host, uname, pwd, exec_cmd):
 # run the update script on hyrax server via ssh session for netCDF resources on demand
 # when private netCDF resources are made public so that all links of data services
 # provided by Hyrax service are instantaneously available on demand
-def run_script_to_update_hyrax_input_files():
+def run_script_to_update_hyrax_input_files(shortkey):
     run_ssh_command(host=settings.HYRAX_SSH_HOST, uname=settings.HYRAX_SSH_PROXY_USER,
                     pwd=settings.HYRAX_SSH_PROXY_USER_PWD,
-                    exec_cmd=settings.HYRAX_SCRIPT_RUN_COMMAND)
+                    exec_cmd=settings.HYRAX_SCRIPT_RUN_COMMAND + ' ' + shortkey)
 
 
 def authorize(request, res_id, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE,


### PR DESCRIPTION
@gantian127 @dtarb This PR is to address the slow response with exposing the netCDF resources to OpeNDAP service when making a netCDF resource from private to public. I have changed the script that takes an extra optional parameter with resource id now which will expose the specified resource to hyrax server without looping through all resources to detect the newly made public netCDF resource. Since this can only be tested on www and the change is small on HydroShare side, just add an optional parameter with resource id, I took the liberty of updating the www with the updated code just for testing purposes. My test reveals everything works as expected and now when you make a private netCDF resource public, it is almost instantaneous without much delay to see the OpeNDAP services exposed for the just-made-public netCDF resource. You can test on www now and let me know if you see any issues. @gantian127 After you test it out to make sure it works as expected and after giving a quick review of the minor code change I did in this PR, you can +1 so that I can merge it in time in for 1.8 deploy.  