### PR TITLE
[#1529] Download files Firefox and IE workaround

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -69,9 +69,6 @@
                 {% block content_block %}
                 {# ======= Content (code moved here because django does not render blocks inside included templates) ======= #}
                 {% if cm.resource_type != "ToolResource" %}
-                    {# Used to force browser to download a file instead of opening it #}
-                    <iframe id="download-frame" style="display:none;"></iframe>
-
                     {# POPUP MENU - Right clicking items #}
                     <ul id="right-click-menu" class="dropdown-menu fb-dropdown selection-menu">
                         {% if cm|resource_type == "Generic" or cm|resource_type == "Model Program Resource" or cm|resource_type == "MODFLOW Model Instance Resource" or cm|resource_type == "SWAT Model Instance Resource" or cm|resource_type == "Model Instance Resource" %}

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -919,14 +919,28 @@ $(document).ready(function () {
         });
     });
 
-     // Download method
+    // Download method
     $("#btn-download, #fb-download").click(function () {
         var downloadList = $("#fb-files-container li.ui-selected");
+
+        // Remove previous temporary download frames
+        $(".temp-download-frame").remove();
+
         if (downloadList.length) {
-            for (var i = 0; i < downloadList.length; i++) {
-                var url = $(downloadList[i]).attr("data-url");
-                var fileName = $(downloadList[i]).children(".fb-file-name").text();
-                downloadURI(url, fileName);
+            // Workaround for Firefox and IE
+            if (jQuery.browser.mozilla == true || !!navigator.userAgent.match(/Trident\/7\./)) {
+                for (var i = 0; i < downloadList.length; i++) {
+                    var url = $(downloadList[i]).attr("data-url");
+                    var frameID = "download-frame-" + i;
+                    $("body").append("<iframe class='temp-download-frame' id='" + frameID + "' style='display:none;' src='" + url + "'></iframe>");
+                }
+            }
+            else {
+                for (var i = 0; i < downloadList.length; i++) {
+                    var url = $(downloadList[i]).attr("data-url");
+                    var fileName = $(downloadList[i]).children(".fb-file-name").text();
+                    downloadURI(url, fileName);
+                }
             }
         }
     });


### PR DESCRIPTION
While fixing this issue for Firefox I found out that it also occurs for IE in a worse way. Download wasn't working at all for IE. I have made it work completely for Firefox and single files download for IE in the meantime. I will be addressing IE multiple file download in another issue.