### PR TITLE
Add persist option to using local iRODS

### DIFF
--- a/irods/README.md
+++ b/irods/README.md
@@ -18,6 +18,15 @@ From within the `irods` directory, run the script named **use-local-irods.sh**
 $ cd irods
 $ ./use-local-irods.sh
 ```
+
+  - Optionally the user can choose to persist the iRODS vault and datbase to their local filesystem so that these files would be available even if the containers are destroyed and recreated.
+
+  ```bash
+  $ cd irods
+  $ ./use-local-irods.sh --persist
+  ```
+  The `--persist` flag will create two new directories as `/home/${USER}/icat1` and `/home/${USER}/icat2` where iRODS vault and database files will be persisted. These directories will remain in place until the user manually destroys them.
+
 The script will run, deploy and federate two iCAT servers, and modify the three aforementioned files to be configured to use the 
 newly created iRODS Docker servers. Once the script has completed, return back the the main `hydroshare` directory and run
 the **hsctl** script as you normally would.
@@ -52,6 +61,34 @@ e67b799315ab        mjstealey/hs_postgres:9.4.7         "/docker-entrypoint.s"  
 0b1a6c66a585        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32785->22/tcp, 0.0.0.0:32784->1247/tcp   users.local.org
 a4d976bcdeb7        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32783->1247/tcp                          data.local.org
 ```
+
+### Restarting after all containers have been stopped or host has been shutdown
+
+It can be useful to retain the system state after all containers have been stopped or a system running HydroShare with local iRODS has been shutdown.
+
+Assuming that the user has initially started with the `--persist` option, a normal initial deployment would look like this.
+
+```bash
+$ cd irods
+$ ./use-local-irods.sh --persist
+$ cd ../
+$ ./hsctl rebuild --db
+```
+After some time the user could choose to stop all containers, or shut down the system they are running on.
+
+```bash
+$ docker stop $(docker ps -a -q)
+```
+To bring all containers back up, and to have the state of the local iRODS containers persisited, the user would do the following.
+
+```bash
+$ cd irods
+$ ./use-local-irods.sh --persist
+$ cd ../
+$ ./hsctl start
+```
+
+This should recreate the HydroShare application as it was prior to beign stopped or shut down with all iRODS related information intact.
 
 ### Known issues at this time
 

--- a/irods/use-local-irods.sh
+++ b/irods/use-local-irods.sh
@@ -26,11 +26,11 @@ fi
 
 if [[ "${1}" == "--persist" ]]; then
     # mkdir for ${IRODS_HOST} and ${HS_USER_ZONE_HOST} persistence files
-    if [[ ! -d /home/${USER}icat1 ]]; then
+    if [[ ! -d /home/${USER}/icat1 ]]; then
         mkdir -p /home/${USER}/icat1/vault
         mkdir -p /home/${USER}/icat1/pgdata
     fi
-    if [[ ! -d /home/${USER}icat2 ]]; then
+    if [[ ! -d /home/${USER}/icat2 ]]; then
         mkdir -p /home/${USER}/icat2/vault
         mkdir -p /home/${USER}/icat2/pgdata
     fi


### PR DESCRIPTION
Addition of a `--persist` flag when using local iRODS.
- persists iRODS data for **data** and **users** instances on local disk so that subsequent runs can reuse it
- creates two new directories on the host at `/home/${USER}/icat1` and `/home/${USER}/icat2`
- flag must be present during initial standup of environment for files to be persisted locally.
- documentation updated in README.md