### PR TITLE
fix missing supported res type in webapp

### DIFF
--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -6,6 +6,7 @@ from crispy_forms.layout import Layout, Field
 from models import RequestUrlBase, ToolVersion, SupportedResTypes, ToolIcon,\
     SupportedSharingStatus, AppHomePageUrl
 from hs_core.forms import BaseFormHelper
+from utils import get_SupportedResTypes_choices
 
 
 # TODO: reference hs_core.forms
@@ -156,19 +157,6 @@ class ToolIconForm(ModelForm):
 class ToolIconValidationForm(forms.Form):
     url = forms.CharField(max_length=1024)
 
-SupportedResTypes_choices = (
-    ('GenericResource', 'Generic Resource'),
-    ('RasterResource', 'Raster Resource'),
-    ('RefTimeSeriesResource', 'HIS Referenced Time Series Resource'),
-    ('TimeSeriesResource', 'Time Series Resource'),
-    ('NetcdfResource', 'NetCDF Resource'),
-    ('ModelProgramResource', 'Model Program Resource'),
-    ('ModelInstanceResource', 'Model Instance Resource'),
-    ('SWATModelInstanceResource', 'SWAT Model Instance Resource'),
-    ('GeographicFeatureResource', 'Geographic Feature Resource'),
-    ('ScriptResource', 'Script Resource'),
-)
-
 
 class MetadataField(Field):
     def __init__(self, *args, **kwargs):
@@ -193,7 +181,7 @@ class SupportedResTypeFormHelper(BaseFormHelper):
 
 class SupportedResTypesForm(ModelForm):
     supported_res_types = forms.\
-        MultipleChoiceField(choices=SupportedResTypes_choices,
+        MultipleChoiceField(choices=get_SupportedResTypes_choices(),
                             widget=forms.CheckboxSelectMultiple(
                                     attrs={'style': 'width:auto;margin-top:-5px'}))
 
@@ -222,7 +210,7 @@ class SupportedResTypesForm(ModelForm):
 
 
 class SupportedResTypesValidationForm(forms.Form):
-    supported_res_types = forms.MultipleChoiceField(choices=SupportedResTypes_choices,
+    supported_res_types = forms.MultipleChoiceField(choices=get_SupportedResTypes_choices(),
                                                     required=False)
 
 SupportedSharingStatus_choices = (

--- a/hs_tools_resource/page_processors.py
+++ b/hs_tools_resource/page_processors.py
@@ -36,9 +36,9 @@ def landing_page(request, page):
                 supported_res_types.first().get_supported_res_types_str()
             supported_res_types_array = supported_res_types_str.split(',')
             for type_name in supported_res_types_array:
-                for display_name_tuple in get_SupportedResTypes_choices():
-                    if type_name.lower() == display_name_tuple[0].lower():
-                        new_supported_res_types_array += [display_name_tuple[1]]
+                for class_verbose_list in get_SupportedResTypes_choices():
+                    if type_name.lower() == class_verbose_list[0].lower():
+                        new_supported_res_types_array += [class_verbose_list[1]]
                         break
 
             context['supported_res_types'] = ", ".join(new_supported_res_types_array)

--- a/hs_tools_resource/page_processors.py
+++ b/hs_tools_resource/page_processors.py
@@ -5,8 +5,9 @@ from hs_core import page_processors
 from hs_core.views import add_generic_context
 
 from forms import UrlBaseForm, VersionForm, SupportedResTypesForm, ToolIconForm, \
-    SupportedResTypes_choices, SupportedSharingStatusForm, AppHomePageUrlForm
+                  SupportedSharingStatusForm, AppHomePageUrlForm
 from models import ToolResource
+from utils import get_SupportedResTypes_choices
 
 
 @processor_for(ToolResource)
@@ -35,7 +36,7 @@ def landing_page(request, page):
                 supported_res_types.first().get_supported_res_types_str()
             supported_res_types_array = supported_res_types_str.split(',')
             for type_name in supported_res_types_array:
-                for display_name_tuple in SupportedResTypes_choices:
+                for display_name_tuple in get_SupportedResTypes_choices():
                     if type_name.lower() == display_name_tuple[0].lower():
                         new_supported_res_types_array += [display_name_tuple[1]]
                         break

--- a/hs_tools_resource/utils.py
+++ b/hs_tools_resource/utils.py
@@ -1,5 +1,6 @@
 from string import Template
 import logging
+from hs_core.hydroshare.utils import get_resource_types
 
 logger = logging.getLogger(__name__)
 
@@ -27,3 +28,25 @@ def parse_app_url_template(url_template_string, term_dict_list=()):
         new_url_string = None
     finally:
         return new_url_string
+
+
+def get_SupportedResTypes_choices():
+    """
+    This function harvests all existing resource types in system,
+    and puts them in a list (except for WebApp Resource type):
+    [
+        ["RESOURCE_CLASS_NAME_1", "RESOURCE_VERBOSE_NAME_1"],
+        ["RESOURCE_CLASS_NAME_2", "RESOURCE_VERBOSE_NAME_2"],
+        ...
+        ["RESOURCE_CLASS_NAME_N", "RESOURCE_VERBOSE_NAME_N"],
+    ]
+    """
+
+    result_list = []
+    res_types_list = get_resource_types()
+    for r_type in res_types_list:
+        class_name = r_type.__name__
+        verbose_name = r_type._meta.verbose_name
+        if "toolresource" not in class_name.lower():
+            result_list.append([class_name, verbose_name])
+    return result_list

--- a/hs_tools_resource/utils.py
+++ b/hs_tools_resource/utils.py
@@ -33,7 +33,7 @@ def parse_app_url_template(url_template_string, term_dict_list=()):
 def get_SupportedResTypes_choices():
     """
     This function harvests all existing resource types in system,
-    and puts them in a list (except for WebApp Resource type):
+    and puts them in a list (except for WebApp (ToolResource) Resource type):
     [
         ["RESOURCE_CLASS_NAME_1", "RESOURCE_VERBOSE_NAME_1"],
         ["RESOURCE_CLASS_NAME_2", "RESOURCE_VERBOSE_NAME_2"],
@@ -47,6 +47,6 @@ def get_SupportedResTypes_choices():
     for r_type in res_types_list:
         class_name = r_type.__name__
         verbose_name = r_type._meta.verbose_name
-        if "toolresource" not in class_name.lower():
+        if "toolresource" != class_name.lower():
             result_list.append([class_name, verbose_name])
     return result_list


### PR DESCRIPTION
This pr was to fix issue #1583 .

We removed the hard-coded "supported resource type" options. The revised webapp res type is able to dynamically harvest all existing resource types from system and use them to build "supported resource type" options.