### PR TITLE
remove index for BaseResource.rating

### DIFF
--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -21,7 +21,6 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
     organizations = indexes.MultiValueField(faceted=True)
     author_emails = indexes.MultiValueField()
     publisher = indexes.CharField(faceted=True)
-    rating = indexes.IntegerField(model_attr='rating_sum')
     coverages = indexes.MultiValueField()
     coverage_types = indexes.MultiValueField()
     coverage_east = indexes.FloatField()

--- a/hs_core/templates/search/indexes/hs_core/baseresource_text.txt
+++ b/hs_core/templates/search/indexes/hs_core/baseresource_text.txt
@@ -7,7 +7,6 @@
 {{ object.discoverable }}
 {{ object.created }}
 {{ object.modified }}
-{{ object.rating_sum }}
 {{ object.metadata.publisher.name }}
 {{ object.metadata.language.code }}
 {{ object.resource_type }}


### PR DESCRIPTION
This PR tries to solve issue #1611 .
@alvacouch Can you take a look at it? i just removed the code for indexing rating field. After checking the models.py file, it seems 'rating' is still a field in AbstractResource class.