### PR TITLE
1625 1608 version publish wording changes

### DIFF
--- a/theme/templates/resource-landing-page/modals.html
+++ b/theme/templates/resource-landing-page/modals.html
@@ -439,9 +439,11 @@
             </div>
             <div class="modal-body">
                 Creating a new version will obsolete this resource. This resource will be still available in HydroShare,
-                but only the newer version will be discoverable via the HydroShare search interface. A link to this
-                resource will be created on the landing page of the new version. Only one newer version
-                is allowed for each resource.
+                but only the newer version will be discoverable via the HydroShare search interface. The new version is
+                a complete new resource with new identifier. It will contain a link back to the previous version and the
+                previous version will have a link to the next version. This can be repeated resulting in a sequence of
+                multiple versions each linked to next and previous versions. Only the most recent version can be edited
+                or deleted. If you delete the most recent version, the previous version becomes the most recent and editable.
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/theme/templates/resource-landing-page/modals.html
+++ b/theme/templates/resource-landing-page/modals.html
@@ -423,8 +423,36 @@
                 <input type="checkbox" id="agree-chk"><label for="agree-chk" class="checkbox-label">I accept the HydroShare Publication Agreement.</label>
             </div>
             <div class="modal-footer">
+                <button class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button class="btn btn-danger" id="publish-btn" data-toggle="modal" data-dismiss="modal" data-target="#submit-for-publication-dialog-2" disabled>Publish</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="submit-for-publication-dialog-2" tabindex="-1" role="dialog"
+     aria-labelledby="myModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="submit-for-publication-title">Are you sure you want to formally publish this resource?</h4>
+            </div>
+            <div class="modal-body">
+                <p>
+                    <strong>Are you sure you want to formally publish this resource?</strong> You will <strong>NOT</strong>
+                    be able to edit your resource or its metadata if you proceed. This is a permanent step and should only
+                    be done when you are finished modifying your resource and you are ready to formally publish it.
+                </p>
+                <p>
+                    If you want to make your resource public or share with specific HydroShare users without formally
+                    publishing it, click <strong>"Cancel"</strong> and use the manage access panel or toggle your resource
+                    to be public instead.
+                </p>
+            </div>
+            <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                <a type="button" id="publish-btn" class="btn btn-danger" href="/hsapi/_internal/{{ cm.short_id }}/publish/" disabled>Publish</a>
+                <a type="button" id="publish-btn-2" class="btn btn-danger" href="/hsapi/_internal/{{ cm.short_id }}/publish/">Publish</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is purely wording change for resource versioning and addition of another dialog for resource publishing, which has been tested by @horsburgh as good to go. So I will merge it in without further code review once I see a green check from Jenkins.