### PR TITLE
Changes to resource status message upon metadata element update

### DIFF
--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -399,7 +399,15 @@ function metadata_update_ajax_submit(form_id){
                     if (json_response.metadata_status !== $('#metadata-status').text()) {
                         $('#metadata-status').text(json_response.metadata_status);
                         if (json_response.metadata_status.toLowerCase().indexOf("insufficient") == -1) {
-                            customAlert("<i class='glyphicon glyphicon-flag custom-alert-icon'></i><strong>Metadata Status:</strong> sufficient to publish or make public", 3000);
+                            if (json_response.hasOwnProperty('res_public_status')){
+                                if (json_response.res_public_status.toLowerCase() === "not public"){
+                                // if the resource is already public no need to show the following alert message
+                                customAlert("<i class='glyphicon glyphicon-flag custom-alert-icon'></i><strong>Resource Status:</strong> This resource can be published or made public", 3000);
+                                }
+                            }
+                            else {
+                                customAlert("<i class='glyphicon glyphicon-flag custom-alert-icon'></i><strong>Resource Status:</strong> This resource can be published or made public", 3000);
+                            }
                             $("#btn-public").prop("disabled", false);
                             $("#btn-discoverable").prop("disabled", false);
                         }


### PR DESCRIPTION
The PR includes the following changes:
The green alert message that comes up when any metadata gets updated will appear only if all the  following conditions are met:
- Resource has the required content files
- Resource has the required metadata
- Resource is currently not set to public

The alert message has been changed and it would now say:
**Resource Status:** This resource can be published or made public
____________________________________________

**Note:** This PR needs to go in for AGU release.