### PR TITLE
Keep resource in edit mode

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -60,7 +60,11 @@
                 {% include "resource-landing-page/abstract.html" %}
 
                 {# ======= Citation ======= #}
-                {% include "resource-landing-page/citation.html" %}
+                {% if metadata_form %}
+                    {% include "resource-landing-page/citation.html" with resource_mode="edit" %}
+                {% else %}
+                    {% include "resource-landing-page/citation.html" with resource_mode="view" %}
+                {% endif %}
 
                 {# ======= Subject ======= #}
                 {% include "resource-landing-page/subject.html" %}

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -1719,6 +1719,16 @@
                 else
                     $('#publish-btn').attr('disabled', 'disabled');
             });
+            // add input element to each of the comment/rating forms to track resource mode (edit or view)
+            var resourceMode = $("#resource-mode").val().toLowerCase();
+            var inputElementToAdd = '<input type="hidden" name="resource-mode" value="mode_to_replace" />';
+            inputElementToAdd = inputElementToAdd.replace('mode_to_replace', resourceMode);
+            $("[id^=comment-]").find('form').each(function () {
+                $(this).append(inputElementToAdd);
+            });
+            // new comment form
+            $("#comment").append(inputElementToAdd);
+
             // On manage access interface, prevent form submission when pressing the enter key on the search box.
             $('#id_user-autocomplete').keypress(function (e) {
                 e = e || event;

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -527,6 +527,7 @@ def set_resource_flag(request, shortkey, *args, **kwargs):
     elif t == 'make_shareable':
        _set_resource_sharing_status(request, user, res, flag_to_set='shareable', flag_value=True)
 
+    request.session['resource-mode'] = request.POST.get('resource-mode', 'view')
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
 

--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -116,6 +116,7 @@
                               method="POST">
                             {% csrf_token %}
                             <input name="t" type="hidden" value="make_public"/>
+                            <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
                             <button {% if not cm.can_be_public_or_discoverable %} disabled {% endif %}
                                     id="btn-public" data-toggle="tooltip" data-placement="auto"
                                     title='Can be viewed and downloaded by anyone.' type="submit"
@@ -135,6 +136,7 @@
                               action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
                               method="POST">
                             <input name="t" type="hidden" value="make_discoverable"/>
+                            <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
                             {% csrf_token %}
                             <button {% if not cm.can_be_public_or_discoverable %} disabled {% endif %}
                                     id="btn-discoverable" data-toggle="tooltip" data-placement="auto"
@@ -155,6 +157,7 @@
                               action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
                               method="POST">
                             <input name="t" type="hidden" value="make_private"/>
+                            <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
                             {% csrf_token %}
                             <button id="btn-private" data-toggle="tooltip" data-placement="auto"
                                     title='Can be viewed and downloaded only by designated users or research groups.' type="submit"

--- a/theme/views.py
+++ b/theme/views.py
@@ -87,6 +87,8 @@ def comment(request, template="generic/comments.html"):
     if isinstance(response, HttpResponse):
         return response
     obj, post_data = response
+    resource_mode = post_data.get('resource-mode', 'view')
+    request.session['resource-mode'] = resource_mode
     form = ThreadedCommentForm(request, obj, post_data)
     if form.is_valid():
         url = obj.get_absolute_url()
@@ -120,6 +122,8 @@ def rating(request):
     obj, post_data = response
     url = add_cache_bypass(obj.get_absolute_url().split("#")[0])
     response = redirect(url + "#rating-%s" % obj.id)
+    resource_mode = post_data.get('resource-mode', 'view')
+    request.session['resource-mode'] = resource_mode
     rating_form = RatingForm(request, obj, post_data)
     if rating_form.is_valid():
         rating_form.save()


### PR DESCRIPTION
This PR allows the resource to stay in edit mode when the resource sharing status (public, private, discoverable) are changed or if any comments/ratings related edits are made. With this change the resource should stay in edit mode always until the user selects the view mode.