### PR TITLE
hotfix -- fix migration issue in webapp res

### DIFF
--- a/hs_tools_resource/migrations/0010_auto_20161203_1913.py
+++ b/hs_tools_resource/migrations/0010_auto_20161203_1913.py
@@ -11,14 +11,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
+        migrations.AlterField(
             model_name='toolicon',
             name='url',
-        ),
-        migrations.AddField(
-            model_name='toolicon',
-            name='value',
             field=models.CharField(default=b'', max_length=1024, blank=True),
+        ),
+        migrations.RenameField(
+            model_name='toolicon',
+            old_name='url',
+            new_name='value'
         ),
         migrations.AlterField(
             model_name='apphomepageurl',

--- a/theme/templates/resource-landing-page/title-section.html
+++ b/theme/templates/resource-landing-page/title-section.html
@@ -93,7 +93,7 @@
         <h2 id="resource-title">{{ title }}</h2>
         {% if tool_homepage_url %}
             <span id="apps-dropdown"/>
-            <a class='btn btn-primary' href="{{ tool_homepage_url }}" target="_blank">Open WebApp</a>
+            <a class='btn btn-primary' href="{{ tool_homepage_url }}" target="_blank">Open Web App</a>
         {% endif %}
 
         {% if relevant_tools %}


### PR DESCRIPTION
This pr addressed the missing metadata issue in webapp res introduced by a newly merged migration file. 
That migration file was supposed to rename an existing db field, but actually it removed that existing data field then recreated a new field with the new name. So value stored in the old field were gone.

As suggested by @mjstealey, in this pr we manually modified that troublesome migration file to make it perform a renaming action instead of deletion and creation.

This pr has been deployed on riverdev and looks it has fixed said issue.

Also, this pr fixed #1635 in one line change: add a white space between "Web" and "App"

@mjstealey or @pkdash 
will you please review this pr? thanks

 