### PR TITLE
1711 ssl settings

### DIFF
--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -492,7 +492,7 @@ TEMP_FILE_DIR = '/tmp'
 
 OAUTH2_PROVIDER = {
    # 30 days
-   'ACCESS_TOKEN_EXPIRE_SECONDS': 2592000,
+   'ACCESS_TOKEN_EXPIRE_SECONDS': 30,
 }
 
 ####################

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -562,3 +562,6 @@ LOGGING = {
 TRACKING_SESSION_TIMEOUT = 60 * 15
 TRACKING_PROFILE_FIELDS = ["title", "user_type", "subject_areas", "public", "state", "country"]
 TRACKING_USER_FIELDS = ["username", "email", "first_name", "last_name"]
+
+# info django that a reverse proxy sever (nginx) is handling ssl/https for it
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -492,7 +492,7 @@ TEMP_FILE_DIR = '/tmp'
 
 OAUTH2_PROVIDER = {
    # 30 days
-   'ACCESS_TOKEN_EXPIRE_SECONDS': 30,
+   'ACCESS_TOKEN_EXPIRE_SECONDS': 2592000,
 }
 
 ####################

--- a/nginx/config-files/hydroshare-ssl-nginx.conf
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf
@@ -43,6 +43,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
         client_max_body_size 4096m;
         client_body_buffer_size 1m;


### PR DESCRIPTION
This PR is to address #1711. 
New settings have been added to nginx conf and django settings.py (see https://docs.djangoproject.com/en/1.10/ref/settings/#secure-proxy-ssl-header).

This pr has been deployed on playground. We tried logging in appsdev server though playground-hydroshare oauth. The "301 redirect" observed on www as described in #1711 did not happen on playground.

![image](https://cloud.githubusercontent.com/assets/10070599/21120712/f268f544-c085-11e6-9fde-54575b9f2fb0.png)

