### PR TITLE
Check duplicate keywords

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -1494,10 +1494,10 @@
                 }
 
                 // If does not exist, add it
-                if (!exists && keyword[i] != "") {
+                if (!exists && keyword[i] != "" && keyword[i].length <= 100) {
                     var li = $("<li class='tag'><span></span></li>");
                     li.find('span').text(keyword[i]);
-                    li.append('&nbsp;<a><span class="glyphicon glyphicon-remove-circle icon-remove"></span></a>')
+                    li.append('&nbsp;<a><span class="glyphicon glyphicon-remove-circle icon-remove"></span></a>');
                     $("#lst-tags").append(li);
 
                     $(".icon-remove").click(onRemoveKeyword);

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -35,7 +35,7 @@ from hs_core import hydroshare
 from hs_core.hydroshare.utils import get_resource_by_shortkey, resource_modified
 from .utils import authorize, upload_from_irods, ACTION_TO_AUTHORIZE, run_script_to_update_hyrax_input_files, \
     get_my_resources_list, send_action_to_take_email
-from hs_core.models import GenericResource, resource_processor, CoreMetaData, Relation
+from hs_core.models import GenericResource, resource_processor, CoreMetaData, Subject
 from hs_core.hydroshare.resource import METADATA_STATUS_SUFFICIENT, METADATA_STATUS_INSUFFICIENT
 
 from . import resource_rest_api
@@ -203,10 +203,13 @@ def add_metadata_element(request, shortkey, element_name, *args, **kwargs):
             if response['is_valid']:
                 element_data_dict = response['element_data_dict']
                 if element_name == 'subject':
-                    keywords = [k.strip() for k in element_data_dict['value'].split(',')]
-                    if res.metadata.subjects.all().count() > 0:
-                        res.metadata.subjects.all().delete()
+                    # using set() to remove any duplicate keywords
+                    keywords = set([k.strip() for k in element_data_dict['value'].split(',')])
+                    res.metadata.subjects.all().delete()
+                    keyword_maxlength = Subject._meta.get_field('value').max_length
                     for kw in keywords:
+                        if len(kw) > keyword_maxlength:
+                            kw = kw[:keyword_maxlength]
                         res.metadata.create_element(element_name, value=kw)
                     is_add_success = True
                 else:
@@ -1165,7 +1168,7 @@ def get_file(request, *args, **kwargs):
     from django_irods.icommands import RodsSession
     name = kwargs['name']
     session = RodsSession("./", "/usr/bin")
-    session.runCmd("iinit");
+    session.runCmd("iinit")
     session.runCmd('iget', [ name, 'tempfile.' + name ])
     return HttpResponse(open(name), content_type='x-binary/octet-stream')
 


### PR DESCRIPTION
View function now removes any duplicate keywords and trims the length of any keyword to the maximum length allowed.  This should minimize the chance of keyword update/editing failure. 