### PR TITLE
Allow cut and paste for generic file type

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -85,7 +85,7 @@
                         {% endif %}
 
                         {% if page.perms.change and metadata_form %}
-                            {% if cm|resource_type == "Generic" %}
+                            {% if cm|resource_type == "Generic" or cm.resource_type == "CompositeResource" %}
                                 <li id="btn-cut" data-menu-name="cut">
                                     <span class="fa fa-scissors icon-blue"></span>
                                     <span>Cut</span>
@@ -329,7 +329,7 @@
                                                         </button>
                                                         {% endif %}
 
-                                                        {% if cm|resource_type == "Generic" or cm|resource_type == "Model Program Resource" or cm|resource_type == "MODFLOW Model Instance Resource" or cm|resource_type == "SWAT Model Instance Resource" or cm|resource_type == "Model Instance Resource" %}
+                                                        {% if cm|resource_type == "Generic" or cm|resource_type == "Model Program Resource" or cm|resource_type == "MODFLOW Model Instance Resource" or cm|resource_type == "SWAT Model Instance Resource" or cm|resource_type == "Model Instance Resource" or cm.resource_type == "CompositeResource"  %}
                                                             <button id="fb-cut"
                                                                     class="disabled"
                                                                     title="Cut">

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -133,7 +133,6 @@ function updateSelectionMenuContext() {
         var fileName = $(selected[i]).children(".fb-file-name").text();
         var fileExt = fileName.substr(fileName.lastIndexOf(".") + 1, fileName.length);
         var logicalFileType = $(selected[i]).children(".fb-logical-file-type").text();
-        console.log(logicalFileType);
         if (fileExt.toUpperCase() != "ZIP") {
             flagDisableUnzip = true;
         }

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -144,6 +144,8 @@ function updateSelectionMenuContext() {
         if(logicalFileType === "GeoRasterLogicalFile"){
             flagDisableDelete = true;
             flagDisableRename = true;
+            flagDisableCut = true;
+            flagDisablePaste = true;
         }
     }
 


### PR DESCRIPTION
This enables cut and paste of any file that are part of the "GenericLogicalFile" type so that they can be moved around. Applies to Composite Resource type.