### PR TITLE
fix resource publication issue - has applied hot fix for it on www

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -1186,7 +1186,7 @@ def publish_resource(user, pk):
     """
     resource = utils.get_resource_by_shortkey(pk)
 
-    if not resource.can_be_published():
+    if not resource.can_be_published:
         raise ValidationError("This resource cannot be published since it does not have required "
                               "metadata or content files or this resource type is not allowed "
                               "for publication.")


### PR DESCRIPTION
@pkdash Can you give a quick review for this very small PR? Just one line change. I have verified in my local environment that it fixed the issue. I have also manually applied the fix to www since it is a regression error and resource publication no longer works without this fix. Not sure how this happened. My speculation is that ```can_be_published``` used to be a method but somehow was changed to a property in some recent PR merges without changing the calling method, hence causing an TypeError, which prevents resource publication to work. 