### PR TITLE
removed edit and remove icons for isVersionOf relation

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -1191,19 +1191,21 @@
                                                             <tr>
                                                                 <th scope="row" class="dataset-label">{{ relation.type }}:</th>
                                                                 <td class="dataset-details">{{ relation.value }}</td>
-                                                                <td>
-                                                                    <a data-toggle="modal" data-placement="auto" title="Edit"
-                                                                       class="glyphicon glyphicon-pencil icon-button icon-blue"
-                                                                       data-target="#edit-relation-dialog_{{ relation.id }}"
-                                                                       style="top: -5px; "></a>
-                                                                </td>
-                                                                <td>
-                                                                    <a data-toggle="modal" data-placement="auto"
-                                                                       title="Remove"
-                                                                       class="glyphicon glyphicon-trash icon-button btn-remove"
-                                                                       data-target="#delete-relation-element-dialog{{ relation.id }}"
-                                                                       style="top: -5px; right:20px;"></a>
-                                                                </td>
+                                                                {% if relation.type|lower != "isversionof" %}
+                                                                    <td>
+                                                                        <a data-toggle="modal" data-placement="auto" title="Edit"
+                                                                           class="glyphicon glyphicon-pencil icon-button icon-blue"
+                                                                           data-target="#edit-relation-dialog_{{ relation.id }}"
+                                                                           style="top: -5px; "></a>
+                                                                    </td>
+                                                                    <td>
+                                                                        <a data-toggle="modal" data-placement="auto"
+                                                                           title="Remove"
+                                                                           class="glyphicon glyphicon-trash icon-button btn-remove"
+                                                                           data-target="#delete-relation-element-dialog{{ relation.id }}"
+                                                                           style="top: -5px; right:20px;"></a>
+                                                                    </td>
+                                                                {% endif %}
                                                             </tr>
                                                         {% endif %}
                                                     {% endfor %}


### PR DESCRIPTION
@pkdash Can you give a quick review on this PR? Only one conditional statement is added on template page so that edit and remove icon buttons will not be displayed for isVersionOf relation since it should not be editable by owners but can only be created programmatically by the system.