### PR TITLE
Fixed the issue [#1824] - resource deletion issue

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1465,10 +1465,18 @@ class AbstractResource(ResourcePermissionsMixin):
                 if fl.fed_resource_file_name_or_path.find(self.short_id) >= 0:
                     istorage.delete('{}/{}'.format(self.resource_federation_path,
                                                    fl.fed_resource_file_name_or_path))
-                else:
+                elif self.resource_federation_path:
                     istorage.delete('{}/{}/{}'.format(self.resource_federation_path,
                                                       self.short_id,
                                                       fl.fed_resource_file_name_or_path))
+                else:
+                    # this scenario happens when adding a file from a federated zone into
+                    # a resource that is already created in the default hydroshare zone, in
+                    # which case resource_federation_path on the resource is empty, but
+                    # fede_resource_file_name_or_path stores the relative path without federated
+                    # zone on the path since the file ends up being stored in hydroshare zone
+                    istorage.delete('{}/{}'.format(self.short_id,
+                                                   fl.fed_resource_file_name_or_path))
             elif fl.resource_file:
                 fl.resource_file.delete()
             elif fl.fed_resource_file:

--- a/hs_core/tests/api/native/test_irods_user_zone_federation.py
+++ b/hs_core/tests/api/native/test_irods_user_zone_federation.py
@@ -230,3 +230,36 @@ class TestUserZoneIRODSFederation(TestCaseCommonUtilities, TransactionTestCase):
 
         # delete resources to clean up
         resource.delete_resource(self.res.short_id)
+
+        # test adding files from federated user zone to an empty resource
+        # created in hydroshare zone
+        res = resource.create_resource(
+            resource_type='GenericResource',
+            owner=self.user,
+            title='My Test Generic Resource in HydroShare Zone'
+        )
+        self.assertEqual(res.files.all().count(), 0,
+                         msg="Number of content files is not equal to 0")
+        fed_test_file1_full_path = '/{zone}/home/testuser/{fname}'.format(
+            zone=settings.HS_USER_IRODS_ZONE, fname=self.file_one)
+        hydroshare.add_resource_files(
+            res.short_id,
+            fed_res_file_names=[fed_test_file1_full_path],
+            fed_copy_or_move='copy')
+        # test resource has one file
+        self.assertEqual(res.files.all().count(), 1,
+                         msg="Number of content files is not equal to 1")
+
+        file_list = []
+        for f in res.files.all():
+            file_list.append(f.fed_resource_file_name_or_path.split('/')[-1])
+        self.assertTrue(self.file_one in file_list,
+                        msg='file 1 has not been added in the resource in hydroshare zone')
+        # test original file in user test zone still exist after adding it to the resource
+        # since 'copy' is used for fed_copy_or_move when adding the file to the resource
+        self.assertTrue(self.irods_storage.exists(user_path + self.file_one))
+
+        # test resource deletion
+        resource.delete_resource(res.short_id)
+        self.assertEquals(BaseResource.objects.all().count(), 0,
+                          msg='Number of resources not equal to 0')

--- a/hs_core/tests/api/native/test_irods_user_zone_federation.py
+++ b/hs_core/tests/api/native/test_irods_user_zone_federation.py
@@ -263,3 +263,5 @@ class TestUserZoneIRODSFederation(TestCaseCommonUtilities, TransactionTestCase):
         resource.delete_resource(res.short_id)
         self.assertEquals(BaseResource.objects.all().count(), 0,
                           msg='Number of resources not equal to 0')
+        # test to make sure original file still exist after resource deletion
+        self.assertTrue(self.irods_storage.exists(user_path + self.file_one))


### PR DESCRIPTION
@pkdash Can you code review this small PR when you have a chance? I believe it is a regression issue that used to work but does not work now. I have also added relevant unit tests to cover this specific scenario in which an empty resource is created first in hydroshare zone and then files from federated user zone is added into this resource in hydroshare zone. The added unit tests have passed in my local test environment. It'd be great if this PR can be merged to make into the next deploy if not earlier as a hot fix. Thanks.