### PR TITLE
1807 requires io integrations - badge only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
-FROM mjstealey/hs_docker_base:1.7.5
+FROM mjstealey/hs_docker_base:1.9.5
 MAINTAINER Michael J. Stealey <stealey@renci.org>
 
 ### Begin - HydroShare Development Image Additions ###
-RUN pip install --upgrade pip && pip install \
-  xmltodict==0.10.2 \
-  selenium \
-  dominate \
-  django-robots
-RUN curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
-RUN apt-get update && apt-get install -y nodejs
-RUN npm install -g phantomjs-prebuilt
+
 ### End - HydroShare Development Image Additions ###
 
 USER root

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 Build generate by [Jenkins CI](http://ci.hydroshare.org:8080)
 
+### require.io
+[![Requirements Status](https://requires.io/github/hydroshare/hs_docker_base/requirements.svg?branch=develop)](https://requires.io/github/hydroshare/hs_docker_base/requirements/?branch=develop)
+
 Hydroshare
 ============
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Build generate by [Jenkins CI](http://ci.hydroshare.org:8080)
 
-### require.io
+### requires.io
 [![Requirements Status](https://requires.io/github/hydroshare/hs_docker_base/requirements.svg?branch=develop)](https://requires.io/github/hydroshare/hs_docker_base/requirements/?branch=develop)
 
 Hydroshare

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Build generate by [Jenkins CI](http://ci.hydroshare.org:8080)
 
 ### requires.io
-[![Requirements Status](https://requires.io/github/hydroshare/hs_docker_base/requirements.svg?branch=develop)](https://requires.io/github/hydroshare/hs_docker_base/requirements/?branch=develop)
+[![Requirements Status](https://requires.io/github/hydroshare/hs_docker_base/requirements.svg?branch=develop)](https://requires.io/github/hydroshare/hs_docker_base/requirements/?branch=master)
 
 Hydroshare
 ============


### PR DESCRIPTION
- add initial requires.io linkage by requirements.txt file only (no automated updates at this time)
  - requirements.txt file created from a `pip freeze` call to the completed image.
- update reference to hs_docker_base to be current
  - Reference: [hs\_docker\_base:1.9.5](https://github.com/hydroshare/hs_docker_base) 
- badge linkage to [requires.io](https://requires.io/github/hydroshare/hs_docker_base/requirements/?branch=master)