### PR TITLE
simple http auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 /hydroshare/static
 /log
 /nginx/config-files/hs-nginx.conf
+/nginx/.htpasswd
+/nginx/htpasswd
 /static
 celeryd.pid
 docker-compose.yml

--- a/config/hydroshare-config.yaml
+++ b/config/hydroshare-config.yaml
@@ -9,6 +9,7 @@ HS_SERVICE_GID: 1000
 ### Deployment Options ###
 USE_NGINX: false
 USE_SSL: false
+USE_HTTP_AUTH: false
 
 ### nginx Configuration Variables ###
 FQDN_OR_IP: localhost

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,13 @@
-FROM nginx
-COPY config-files/hs-nginx.conf /etc/nginx/conf.d/default.conf
+FROM nginx:1.11
+MAINTAINER Michael J. Stealey <michael.j.stealey@gmail.com>
+
+COPY . /tmp
+RUN cp /tmp/config-files/hs-nginx.conf /etc/nginx/conf.d/default.conf \
+    && cp /tmp/.htpasswd /etc/nginx/.htpasswd \
+    && cp /tmp/docker-entrypoint.sh /docker-entrypoint.sh
+
+# cleanup
+RUN rm -rf /tmp/*
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["run"]

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,0 +1,55 @@
+## Using http auth
+
+If the user wants to use http auth by setting the **USE\_HTTP\_AUTH** variable to **true** in `hydroshare-config.yml`, the user will first need to generate a `.htpasswd` file for the nginx container to use.
+
+### Generating a new .htpasswd file
+
+By default the username/password combination for the Nginx Docker container using http auth is not set. To set this the user will need to run the **generate_htpasswd.exp** script with a new username and password combination.
+
+**Note** this script requires **sudo** rights and the **expect** package.
+
+```
+$ cd /home/hydro/hydroshare/nginx/
+$ sudo generate_htpasswd.sh new_username new_password
+```
+
+Once completed a new `.htpasswd` file will be generated using OpenSSL. A corresponding `htpasswd` plain text file is also generated as a reminder to the user of what the username/password configuration has been set to.
+
+Example:
+
+To set the username / password combination to be:
+
+- username: **my-user**
+- password: **my-password**
+
+The user would run the following:
+
+```
+$ cd /home/hydro/hydroshare/nginx/
+$ sudo ./generate_htpasswd.exp my-user my-password
+[sudo] password for hydro:
+spawn sudo sh -c echo -n 'my-user:' > .htpasswd
+spawn sudo sh -c openssl passwd -apr1 >> .htpasswd
+Password: my-password
+
+Verifying - Password: my-password
+
+spawn sudo sh -c echo 'Username: my-user, Password: my-password' > htpasswd
+
+$ cat .htpasswd
+my-user:$apr1$AzSGC/na$WLxG415Zl2AcJ5lukRbV./
+
+$ cat htpasswd
+Username: my-user, Password: my-password
+```
+
+Once completed, the user could enable the `USE_HTTP_AUTH` variable to be true in the `config/hydroshare-config.yml` file. Then anytime the `USE_NGINX` variable was set to true, simple http auth would be enforced using the contents of the `.htpasswd` file.
+
+```yaml
+...
+### Deployment Options ###
+USE_NGINX: true
+USE_SSL: false
+USE_HTTP_AUTH: true
+...
+```

--- a/nginx/config-files/hydroshare-nginx.conf
+++ b/nginx/config-files/hydroshare-nginx.conf
@@ -27,6 +27,8 @@ server {
             return 503;
         }
         try_files $uri @proxy;
+        AUTH_BASIC;
+        AUTH_BASIC_USER_FILE;
     }
 
     location @proxy {

--- a/nginx/config-files/hydroshare-ssl-nginx.conf
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf
@@ -36,6 +36,8 @@ server {
             return 503;
         }
         try_files $uri @proxy;
+        AUTH_BASIC;
+        AUTH_BASIC_USER_FILE;
     }
 
     location @proxy {

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This is the entry point of the Nginx docker container on instantiation
+# By default the "run" command is issued, other commands can be used when
+#  the container is initially run
+#
+# Usage: docker run -d -p EXTERNAL_PORT:80 -v /LOCAL_VOLUME:/NGINX_VOLUME --name CONTAINER_NAME IMAGE_NAME
+
+set -e
+
+if [ "$1" = 'run' ]; then
+    sleep 5s
+    echo "daemon off;" > /etc/nginx/nginx_temp.conf
+    cat /etc/nginx/nginx.conf >> /etc/nginx/nginx_temp.conf
+    mv /etc/nginx/nginx_temp.conf /etc/nginx/nginx.conf
+else
+    exec "$@"
+fi
+
+/etc/init.d/nginx restart

--- a/nginx/generate_htpasswd.exp
+++ b/nginx/generate_htpasswd.exp
@@ -1,0 +1,21 @@
+#!/usr/bin/expect -f
+
+# Generates the .htpasswd file used by Nginx to enforce user/pass permissions
+#   Will output the plain text Username: ${name}, Password: ${pass} in local htpasswd file
+#   This must be done prior to building the Nginx docker image to be deployed
+#
+# Usage: sudo generate_htpasswd.exp USERNAME PASSWORD
+
+set name [lindex $argv 0];
+set pass [lindex $argv 1];
+
+spawn sudo sh -c "echo -n '${name}:' > .htpasswd"
+expect eof
+
+spawn sudo sh -c "openssl passwd -apr1 >> .htpasswd"
+expect -re {Password:} {send "$pass\n"}
+expect -re {Verifying - Password:} {send "$pass\n"}
+expect eof
+
+spawn sudo sh -c "echo 'Username: ${name}, Password: ${pass}' > htpasswd"
+expect eof

--- a/nginx/run-nginx
+++ b/nginx/run-nginx
@@ -7,6 +7,8 @@
 NGINX_CONFIG_DIRECTORY='./config-files'
 NGINX_DOCKER_IMG='hydroshare_nginx'
 NGINX_DOCKER_CNTR='nginx'
+#AUTH_BASIC='auth_basic "Restricted Content"'
+#AUTH_BASIC_USER_FILE='auth_basic_user_file /etc/nginx/.htpasswd'
 
 display_usage() {
 	echo "*** run-nginx control script ***"
@@ -27,6 +29,19 @@ preflight_nginx() {
     else
         yes | cp -rf ${NGINX_CONFIG_DIRECTORY}/hydroshare-nginx.conf ${NGINX_CONFIG_DIRECTORY}/hs-nginx.conf
         sed -i 's/FQDN_OR_IP/'${FQDN_OR_IP}'/g' ${NGINX_CONFIG_DIRECTORY}/hs-nginx.conf;
+    fi
+    # Configure access based on USE_HTTP_AUTH
+    if [ "${USE_HTTP_AUTH,,}" = true ]; then
+        # check for existence of .htpasswd file
+        if [[ ! -f ${HS_PATH}/nginx/.htpasswd ]]; then
+            echo "ERROR: requires ${HS_PATH}/nginx/.htpasswd, run ${HS_PATH}/nginx/generate_htpasswd.exp first."
+            exit 1;
+        fi
+        sed -i 's!\<AUTH_BASIC\>!auth_basic "Restricted Content"!g' ${NGINX_CONFIG_DIRECTORY}/hs-nginx.conf
+        sed -i 's!\<AUTH_BASIC_USER_FILE\>!auth_basic_user_file /etc/nginx/.htpasswd!g' ${NGINX_CONFIG_DIRECTORY}/hs-nginx.conf
+    else
+        sed -i 's!\<AUTH_BASIC\>!# auth_basic "Restricted Content"!g' ${NGINX_CONFIG_DIRECTORY}/hs-nginx.conf
+        sed -i 's!\<AUTH_BASIC_USER_FILE\>!# auth_basic_user_file /etc/nginx/.htpasswd!g' ${NGINX_CONFIG_DIRECTORY}/hs-nginx.conf
     fi
 }
 

--- a/nginx/run-nginx
+++ b/nginx/run-nginx
@@ -7,8 +7,6 @@
 NGINX_CONFIG_DIRECTORY='./config-files'
 NGINX_DOCKER_IMG='hydroshare_nginx'
 NGINX_DOCKER_CNTR='nginx'
-#AUTH_BASIC='auth_basic "Restricted Content"'
-#AUTH_BASIC_USER_FILE='auth_basic_user_file /etc/nginx/.htpasswd'
 
 display_usage() {
 	echo "*** run-nginx control script ***"


### PR DESCRIPTION
Add simple http auth to HydroShare for deployment on public VMs
- enforced by nginx configuration using .htpasswd file set by user
- USE_HTTP_AUTH variable added to hydroshare-config.yml (true/false)
- requires **expect** package to generate .htpasswd file