### PR TITLE
Disable username change from profile page in preparation for quota management

### DIFF
--- a/theme/forms.py
+++ b/theme/forms.py
@@ -275,7 +275,7 @@ class SignupForm(forms.ModelForm):
 class UserForm(forms.ModelForm):
     class Meta:
         model = User
-        fields = ['username', 'first_name', 'last_name', 'email']
+        fields = ['first_name', 'last_name', 'email']
 
     def clean_first_name(self):
         data = self.cleaned_data['first_name']
@@ -293,12 +293,6 @@ class UserForm(forms.ModelForm):
         data = self.cleaned_data['email']
         if len(data.strip()) == 0:
             raise forms.ValidationError("Email is a required field.")
-        return data
-
-    def clean_username(self):
-        data = self.cleaned_data['username']
-        if len(data.strip()) == 0:
-            raise forms.ValidationError("Username is a required field.")
         return data
 
 

--- a/theme/templates/accounts/profile.html
+++ b/theme/templates/accounts/profile.html
@@ -157,15 +157,6 @@
                                 </div>
 
                                 <div class="row">
-                                    {# Username #}
-                                    <fieldset class="col-sm-4">
-                                        <label>Username *</label>
-                                        <input id="id_username" class="form-control form-required" value="{{ profile_user.username }}" name="username">
-                                        <small class="text-muted">Only letters, numbers, dashes, +, @, dot, or underscores.</small>
-                                    </fieldset>
-                                </div>
-
-                                <div class="row">
                                     {# Organization #}
                                     <fieldset class="col-sm-6">
                                         <label>Organization *</label>
@@ -911,27 +902,8 @@
             var flagRequiredElements = validateRequiredElements();
             var flagPasswords = validatePasswords();
             var flagEmail = validateEmail();
-            var flagUsername = validateUserName();
 
-            return  flagRequiredElements && flagPasswords && flagEmail && flagUsername;
-        }
-
-        // Only letters, numbers, dashes, dot, underscore, +, or @
-        // to conform to the same user name validation rules in Django
-        function validateUserName() {
-            var regex = /^[a-zA-Z0-9-_.@+]+$/;
-            var username = $("#id_username");
-
-            if (!username.val()) {
-                return false;
-            }
-
-            if (!regex.test(username.val())) {
-                username.parent().find(".error-label").remove();
-                username.parent().append(errorLabel("Not a valid username."));
-                return false;
-            }
-            return true;
+            return  flagRequiredElements && flagPasswords && flagEmail;
         }
 
         function validateRequiredElements() {
@@ -1010,7 +982,6 @@
 
             $(".form-required").change(onFormRequiredChange);
             $("#id_email").change(validateEmail);
-            $("#id_username").change(validateUserName);
 
             // Switch to overview tab
             $('.nav-tabs a[href="#overview"]').tab('show'); // Select first tab

--- a/theme/templates/accounts/profile.html
+++ b/theme/templates/accounts/profile.html
@@ -340,7 +340,7 @@
                                                     </tr>
                                                 {% endif %}
                                                 <tr>
-                                                    <td><span class="text-muted">User since</span></td>
+                                                    <td><span class="text-muted">User (username: <strong>{{ profile_user.username }}</strong>) since</span></td>
                                                     <td>{{ profile_user.date_joined }}</td>
                                                 </tr>
                                                 </tbody>

--- a/theme/templates/accounts/sign_up_form.html
+++ b/theme/templates/accounts/sign_up_form.html
@@ -55,6 +55,24 @@
          }
     });
 
+    // Only letters, numbers, dashes, dot, underscore, or @ are viewed as valid characters
+    // to conform to the same user name validation rules in Django with + removed from set of
+    // valid characters since although + is supported as a valid character in username field,
+    // it is not supported as a valid character in corresponding iRODS username
+    function validateUserName() {
+        var regex = /^[a-zA-Z0-9-_.@]+$/;
+        var username = $("#id_username");
+
+        if (!username.val()) {
+            return false;
+        }
+
+        if (!regex.test(username.val())) {
+            return false;
+        }
+        return true;
+    }
+
     $(function() {
         function cb() {
             $("#recaptcha_privacy").attr('style', "display:none");
@@ -90,8 +108,20 @@
                     missingFieldCount++;
                 }
            }
-           if(empty) {
-               $("#missing-data-div").html('<p class="alert alert-danger">' + missingFields +'</p>');
+           // validate username to make sure username not only passes django username validation
+           // but also passed iRODS username validation
+           var username_valid = validateUserName();
+           if(empty || !username_valid) {
+               var warning_str = '';
+               if(empty)
+                   warning_str += missingFields;
+               if(!username_valid) {
+                   if (empty)
+                       warning_str += "<br>";
+                   warning_str += "username is not valid - make sure username only contains " +
+                       "letters, numbers, dashes, dot, underscore, or @";
+               }
+               $("#missing-data-div").html('<p class="alert alert-danger">' + warning_str +'</p>');
                return;
            }
             function onSuccess() {


### PR DESCRIPTION
This PR is to disable username change from user profile page in preparation for quota management implementation. This decision was made during developer coordination meeting. A username validation rule is also added in user signup page to ensure "+" is not allowed as a valid character in username since "+" is treated as a valid character in username in Django but treated as an invalid username in iRODS and we need to keep username validation rule between Django and iRODS in sync so that each username created in Django can create a corresponding username in iRODS user zone. @pkdash Can you code review this PR?