### PR TITLE
[WIP] iRODS v.4.2.0 - for release 1.10.0 - do NOT merge before then

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mjstealey/hs_docker_base:1.9.5
+FROM mjstealey/hs_docker_base:irods-4.2.0
 MAINTAINER Michael J. Stealey <stealey@renci.org>
 
 ### Begin - HydroShare Development Image Additions ###

--- a/irods/README.md
+++ b/irods/README.md
@@ -1,7 +1,7 @@
 ## Using local federated iRODS
 
 The scripts herein are a one-way street that update the configuration of HydroShare to use a locally deployed federated pair 
-of iCAT v.4.1.8 servers in Docker.
+of iRODS provider v.4.2.0 (PostgreSQL) servers in Docker.
 
 Effected files:
 -	modified:   hsctl
@@ -57,8 +57,8 @@ CONTAINER ID        IMAGE                               COMMAND                 
 82aefa42b4f6        makuk66/docker-solr:4.10.4          "sh -c '/bin/bash /op"   17 minutes ago      Up 17 minutes       0.0.0.0:32786->8983/tcp                                                               solr
 e67b799315ab        mjstealey/hs_postgres:9.4.7         "/docker-entrypoint.s"   17 minutes ago      Up 17 minutes       5432/tcp                                                                              postgis
 52c67ebb6b57        rabbitmq:3.5                        "/docker-entrypoint.s"   17 minutes ago      Up 17 minutes       4369/tcp, 5671-5672/tcp, 25672/tcp                                                    rabbitmq
-0b1a6c66a585        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32785->22/tcp, 0.0.0.0:32784->1247/tcp   users.local.org
-a4d976bcdeb7        mjstealey/docker-irods-icat:4.1.8   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32783->1247/tcp                          data.local.org
+0b1a6c66a585        mjstealey/irods-provider-postgres:4.2.0   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32785->22/tcp, 0.0.0.0:32784->1247/tcp   users.local.org
+a4d976bcdeb7        mjstealey/irods-provider-postgres:4.2.0   "/irods-docker-entryp"   22 minutes ago      Up 22 minutes       1248/tcp, 5432/tcp, 20000-20199/tcp, 0.0.0.0:32783->1247/tcp                          data.local.org
 ```
 
 ### Restarting after all containers have been stopped or host has been shutdown


### PR DESCRIPTION
**NOTE**: To enable iRODS v.4.2.0 the user must use the `irods/use-local-irods.sh` script to deploy the locally federated iRODS Docker containers. There is no publicly available v.4.2.0 iRODS server at this time to test against.

- migrate HydroShare to iRODS v.4.2.0

@hyi - You're likely the best person to test this initially, then we can update the beta series iRODS VMs (hydrotest41 and usersdev) to iRODS v.4.2.0 for team testing prior to production release.