### PR TITLE
1858 irods file size

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -203,6 +203,11 @@ def check_resource_files(files=()):
     Returns:    True if files are supported; otherwise, returns False
     """
     for file in files:
+        if not isinstance(file, UploadedFile):
+            # if file is already on the server, e.g., a file transferred directly from iRODS,
+            # the file should not be subject to file size check since the file size check is
+            # only prompted by file upload limit
+            continue
         if hasattr(file, '_size'):
             if file._size > FILE_SIZE_LIMIT:
                 # file is greater than FILE_SIZE_LIMIT, which is not allowed

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -166,9 +166,9 @@ def is_federated(homepath):
     homepath = homepath.strip()
     homepath_list = homepath.split('/')
     # homepath is an iRODS logical path in the format of
-    # /irods_zone/home/irods_account/collection_path, so homepath_list[1] is the irods_zone
-    # which we can use to form the fed_proxy_path to check whether fed_proxy_path exists to
-    # hold hydroshare resources in a federated zone
+    # /irods_zone/home/irods_account_username/collection_relative_path, so homepath_list[1]
+    # is the irods_zone which we can use to form the fed_proxy_path to check whether
+    # fed_proxy_path exists to hold hydroshare resources in a federated zone
     if homepath_list[1]:
         fed_proxy_path = os.path.join(homepath_list[1], 'home',
                                       settings.HS_LOCAL_PROXY_USER_IN_FED_ZONE)

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -165,6 +165,10 @@ def is_federated(homepath):
     """
     homepath = homepath.strip()
     homepath_list = homepath.split('/')
+    # homepath is an iRODS logical path in the format of
+    # /irods_zone/home/irods_account/collection_path, so homepath_list[1] is the irods_zone
+    # which we can use to form the fed_proxy_path to check whether fed_proxy_path exists to
+    # hold hydroshare resources in a federated zone
     if homepath_list[1]:
         fed_proxy_path = os.path.join(homepath_list[1], 'home',
                                       settings.HS_LOCAL_PROXY_USER_IN_FED_ZONE)

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -163,10 +163,23 @@ def is_federated(homepath):
     Returns:
     True is the selected file indicated by homepath is from a federated zone, False if otherwise
     """
-    irods_storage = IrodsStorage('federated')
-    # if HS WWW iRODS proxy user can list homepath, homepath is federated; otherwise, it is not
-    # federated
-    return irods_storage.exists(homepath)
+    homepath = homepath.strip()
+    homepath_list = homepath.split('/')
+    if homepath_list[1]:
+        fed_proxy_path = os.path.join(homepath_list[1], 'home',
+                                      settings.HS_LOCAL_PROXY_USER_IN_FED_ZONE)
+        fed_proxy_path = '/' + fed_proxy_path
+    else:
+        # the test path input is invalid, return False meaning it is not federated
+        return False
+    if settings.REMOTE_USE_IRODS:
+        irods_storage = IrodsStorage('federated')
+    else:
+        irods_storage = IrodsStorage()
+
+    # if the iRODS proxy user in hydroshare zone can list homepath and the federation zone proxy
+    # user path, it is federated; otherwise, it is not federated
+    return irods_storage.exists(homepath) and irods_storage.exists(fed_proxy_path)
 
 
 def get_federated_zone_home_path(filepath):


### PR DESCRIPTION
This PR addresses the issue #1858 @dtarb raised. With the fix in this PR, any files users select from any irods zone will not be subject to 1GB size limit including nfie zone which is federated with hydroshare zone, but does not have the localHydroProxy account created to hold hydroshare resources created from a federated zone, in which case nfie zone will be treated as a non-federated zone so that users still can browse files from it to create hydroshare resources without being subject to 1GB file size limit. I removed use of any UploadedFile instance for this case so that all file transfers are done by iRODS icommands for non-federated case with parallel transfer capability, so it should have capability to handle large files without 1GB size limit. I have deployed it to playground for testing and tested it out myself with a 2GB files from a non-federated zone and the resource is created as expected within a reasonable wait time. @dtarb @rayi113 @mjstealey Feel free to test it out on playground and let me know if you observe any issues there. When this PR is merged in and deployed, we will be able to make the statement that any files from any iRODS server can be used to create hydroshare resources without 1GB size limit. @pkdash Can you code review it when you get a chance? @alvacouch If you have time, feel free to code review as well. 