### PR TITLE
[#1941] Display full citation

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -1676,7 +1676,7 @@
             });
 
             $("#list-roles a").click(onRoleSelect);
-            $("#id_user-autocomplete").attr("placeholder", "Search by name or username");
+            $("#add-access-form #id_user-autocomplete").attr("placeholder", "Search by name or username");
             $("#id_group-autocomplete").attr("placeholder", "Search by group name");
 
             var file_types = $("#supported-file-types").attr('value');

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1643,13 +1643,24 @@ body > .main-container {
 }
 
 #citation-text {
-    display: inline-block;
-    width: 100%;
-    min-height: 30px;
-    background: #EEE;
-    border: 1px solid #cccccc;
-    border-radius: 0px;
-    padding: 4px;
+	display: inline-block;
+	width: calc(100% - 65px);
+	min-height: 30px;
+	background: #EEE;
+	border: 1px solid #CCC;
+	border-radius: 0;
+	padding: 4px;
+	cursor: default;
+	line-height: 24px;
+}
+
+.clipboard-copy {
+	border-radius: 0;
+	margin-left: -1px;
+}
+
+.flex {
+	display: flex;
 }
 
 #citation-text a, .rights-url a{
@@ -4133,6 +4144,12 @@ form#covereage-search-fields {
 
 .fb-stack-netcdf {
 	color: #244960;
+}
+
+.fa-stack-clone .fa-asterisk {
+	font-size: 14px;
+	right: -36px;
+	top: -8px;
 }
 
 .fb-view-grid .fb-stack {

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -4146,12 +4146,6 @@ form#covereage-search-fields {
 	color: #244960;
 }
 
-.fa-stack-clone .fa-asterisk {
-	font-size: 14px;
-	right: -36px;
-	top: -8px;
-}
-
 .fb-view-grid .fb-stack {
 	height: 32px;
 }

--- a/theme/static/js/copyToClipboard.js
+++ b/theme/static/js/copyToClipboard.js
@@ -10,6 +10,8 @@ $(document).ready(function () {
 });
 
 function copyToClipboard(elem, event) {
+    var tempScrollTop = $(window).scrollTop();  // Save current scroll position
+
     // create hidden text element, if it doesn't already exist
     var targetId = "_hiddenCopyText_";
     var isInput = elem.tagName === "INPUT" || elem.tagName === "TEXTAREA";
@@ -61,6 +63,8 @@ function copyToClipboard(elem, event) {
     if (!isInput) {
         target.remove();
     }
+
+    $(window).scrollTop(tempScrollTop);  // Restore scroll position
 
     return succeed;
 }

--- a/theme/static/js/custom.js
+++ b/theme/static/js/custom.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
         // Regular expression to find FTP, HTTP(S) and email URLs.
         var regexToken = /(((ftp|https?):\/\/)[\-\w@:%_\+.~#?,&\/\/=]+)|((mailto:)?[_.\w-]+@([\w][\w\-]+\.)+[a-zA-Z]{2,3})/g;
 
-        var matchArray
+        var matchArray;
         // Extract the url
         while( (matchArray = regexToken.exec(oriCitationText)) !== null ){
             if (matchArray[0].slice(-1) === "." || matchArray[0].slice(-1) === ",") {

--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -10,9 +10,10 @@
 
                 <button class="btn btn-default clipboard-copy" data-target="citation-text"
                         type="button">
-                    <i class="fa fa-clipboard" aria-hidden="true"></i> Copy
+                    <i class="fa fa-clipboard" aria-hidden="true"></i>&nbsp;Copy
                 </button>
             </div>
+
             <br>
 
             {# ======= Sharing ======= #}
@@ -252,17 +253,16 @@
                     {% endif %}
                     </ul>
                 {% endif %}
-
-                <div id="user-permission-msg">
-                    {% if is_owner_user %}
-                        <div class="alert alert-info" role="alert"><i class="fa fa-lock" aria-hidden="true"></i> You are the owner of this resource.</div>
-                    {% elif is_edit_user %}
-                        <div class="alert alert-info" role="alert">You have been given specific permission to
-                            {% if cm.raccess.published %} view{% else %} edit{% endif %} this resource.</div>
-                    {% elif is_view_user %}
-                        <div class="alert alert-info" role="alert">You have been given specific permission to view this resource.</div>
-                    {% endif %}
-                </div>
+            <div id="user-permission-msg">
+                {% if is_owner_user %}
+                    <div class="alert alert-info" role="alert"><i class="fa fa-lock" aria-hidden="true"></i> You are the owner of this resource.</div>
+                {% elif is_edit_user %}
+                    <div class="alert alert-info" role="alert">You have been given specific permission to
+                        {% if cm.raccess.published %} view{% else %} edit{% endif %} this resource.</div>
+                {% elif is_view_user %}
+                    <div class="alert alert-info" role="alert">You have been given specific permission to view this resource.</div>
+                {% endif %}
             </div>
+        </div>
     </div>
 </div>

--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -5,103 +5,105 @@
 
     <div class="row">
         <div class="col-xs-12">
-            <div class="input-group" style="margin-bottom: 30px">
-                <input class="form-control" readonly id="citation-text" value="{{ citation }}"/>
-                <span class="input-group-btn">
-                    <button class="btn btn-default clipboard-copy" data-target="citation-text"
-                            type="button">Copy</button>
-                  </span>
+            <div class="flex">
+                <div id="citation-text">{{ citation }}</div>
+
+                <button class="btn btn-default clipboard-copy" data-target="citation-text"
+                        type="button">
+                    <i class="fa fa-clipboard" aria-hidden="true"></i> Copy
+                </button>
             </div>
+            <br>
 
-            {#        ======= Sharing =======#}
-    {% if not metadata_form %}
-        {% if rights.statement or rights.url %}
-            <div id="rights">
-                {% if rights.statement %}
-                    <span class="rights-text">{{ rights.statement|remove_last_char }} License.</span>
-                {% endif %}
-
-                        {% if rights.url %}
-                            <span class="rights-url"><a href="{{ rights.url }}">&nbsp{{ rights.url }}</a></span>
+            {# ======= Sharing ======= #}
+            {% if not metadata_form %}
+                {% if rights.statement or rights.url %}
+                    <div id="rights">
+                        {% if rights.statement %}
+                            <span class="rights-text">{{ rights.statement|remove_last_char }} License.</span>
                         {% endif %}
-                    </div>
-                    {% if rights.statement == "This resource is shared under the Creative Commons Attribution CC BY." %}
-                        <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY.png" alt="CC-BY"/>
-                    {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-ShareAlike CC BY-SA." %}
-                        <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-SA.png" alt="CC-BY-SA"/>
-                    {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoDerivs CC BY-ND." %}
-                        <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-ND.png" alt="CC-BY-ND"/>
-                    {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-ShareAlike CC BY-NC-SA." %}
-                        <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-SA.png" alt="CC-BY-NC-SA"/>
-                    {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial CC BY-NC." %}
-                        <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC.png" alt="CC-BY-NC"/>
-                    {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-NoDerivs CC BY-NC-ND." %}
-                        <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-ND.png" alt="CC-BY-NC-ND"/>
+
+                                {% if rights.url %}
+                                    <span class="rights-url"><a href="{{ rights.url }}">&nbsp;{{ rights.url }}</a></span>
+                                {% endif %}
+                            </div>
+                            {% if rights.statement == "This resource is shared under the Creative Commons Attribution CC BY." %}
+                                <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY.png" alt="CC-BY"/>
+                            {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-ShareAlike CC BY-SA." %}
+                                <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-SA.png" alt="CC-BY-SA"/>
+                            {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoDerivs CC BY-ND." %}
+                                <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-ND.png" alt="CC-BY-ND"/>
+                            {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-ShareAlike CC BY-NC-SA." %}
+                                <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-SA.png" alt="CC-BY-NC-SA"/>
+                            {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial CC BY-NC." %}
+                                <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC.png" alt="CC-BY-NC"/>
+                            {% elif rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-NoDerivs CC BY-NC-ND." %}
+                                <img class="cc-image" src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-ND.png" alt="CC-BY-NC-ND"/>
+                            {% endif %}
+                        {% endif %}
+                    {% else %}
+                        <div class="row">
+                            <form action="/hsapi/_internal/{{ cm.short_id }}/rights/{{ cm.metadata.rights.id }}/update-metadata/"#}
+                                  id="id-rights" method="post">
+                                {% csrf_token %}
+                                <fieldset>
+                                    <div class="col-md-6">
+                                        <span for="select_license"> Select a license </span>
+                                                <span data-toggle="tooltip" data-placement="auto"
+                                                      title='Information about rights held in and over the HydroShare resource. (e.g. Creative commons Attribution License)'
+                                                      class="glyphicon glyphicon-info-sign text-muted"></span>
+                                        <select id="select_license" class="form-control">
+                                            <option value="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution CC BY</option>
+                                            <option value="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike CC BY-SA</option>
+                                            <option value="http://creativecommons.org/licenses/by-nd/4.0/">Creative Commons Attribution-NoDerivs CC BY-ND</option>
+                                            <option value="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NoCommercial-ShareAlike CC BY-NC-SA</option>
+                                            <option value="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NoCommercial CC BY-NC</option>
+                                            <option value="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NoCommercial-NoDerivs CC BY-NC-ND</option>
+                                            <option value="other">Other</option>
+                                        </select>
+                                        <img id="img-badge" class="cc-image"
+                                                {% if cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution CC BY." %}
+                                             src="{{ STATIC_URL }}img/cc-badges/CC-BY.png" alt="CC-BY"
+                                                {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-ShareAlike CC BY-SA." %}
+                                             src="{{ STATIC_URL }}img/cc-badges/CC-BY-SA.png" alt="CC-BY-SA"
+                                                {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoDerivs CC BY-ND." %}
+                                             src="{{ STATIC_URL }}img/cc-badges/CC-BY-ND.png" alt="CC-BY-ND"
+                                                {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-ShareAlike CC BY-NC-SA." %}
+                                             src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-SA.png" alt="CC-BY-NC-SA"
+                                                {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial CC BY-NC." %}
+                                             src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC.png" alt="CC-BY-NC"
+                                                {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-NoDerivs CC BY-NC-ND." %}
+                                             src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-ND.png" alt="CC-BY-NC-ND"
+                                                {% endif %}/>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div id="div_id_statement" class="control-group">
+                                            <span for="id_statement"> Statement</span>
+
+                                            <div class="controls">
+                                                    <textarea class="form-control input-sm textarea" cols="40"
+                                                              id="id_statement" name="statement" readonly="True">{{ cm.metadata.rights.statement }}</textarea>
+                                            </div>
+                                        </div>
+                                        <div id="div_id_url" class="control-group">
+                                            <span for="id_url">Url</span>
+
+                                            <div class="controls">
+                                                <input class="form-control input-sm urlinput" id="id_url"
+                                                       maxlength="200" name="url" readonly="True" type="url"
+                                                       value={{ cm.metadata.rights.url }}>
+                                            </div>
+                                        </div>
+
+                                        <button type="button" class="btn btn-primary pull-right"
+                                                onclick="metadata_update_ajax_submit('id-rights'); return false;"
+                                                style="display: none;">Save changes
+                                        </button>
+                                    </div>
+                                </fieldset>
+                            </form>
+                        </div>
                     {% endif %}
-                {% endif %}
-            {% else %}
-                <div class="row">
-                    <form action="/hsapi/_internal/{{ cm.short_id }}/rights/{{ cm.metadata.rights.id }}/update-metadata/"#}
-                          id="id-rights" method="post">
-                        {% csrf_token %}
-                        <fieldset>
-                            <div class="col-md-6">
-                                <span for="select_license"> Select a license </span>
-                                        <span data-toggle="tooltip" data-placement="auto"
-                                              title='Information about rights held in and over the HydroShare resource. (e.g. Creative commons Attribution License)'
-                                              class="glyphicon glyphicon-info-sign text-muted"></span>
-                                <select id="select_license" class="form-control">
-                                    <option value="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution CC BY</option>
-                                    <option value="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike CC BY-SA</option>
-                                    <option value="http://creativecommons.org/licenses/by-nd/4.0/">Creative Commons Attribution-NoDerivs CC BY-ND</option>
-                                    <option value="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NoCommercial-ShareAlike CC BY-NC-SA</option>
-                                    <option value="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NoCommercial CC BY-NC</option>
-                                    <option value="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NoCommercial-NoDerivs CC BY-NC-ND</option>
-                                    <option value="other">Other</option>
-                                </select>
-                                <img id="img-badge" class="cc-image"
-                                        {% if cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution CC BY." %}
-                                     src="{{ STATIC_URL }}img/cc-badges/CC-BY.png" alt="CC-BY"
-                                        {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-ShareAlike CC BY-SA." %}
-                                     src="{{ STATIC_URL }}img/cc-badges/CC-BY-SA.png" alt="CC-BY-SA"
-                                        {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoDerivs CC BY-ND." %}
-                                     src="{{ STATIC_URL }}img/cc-badges/CC-BY-ND.png" alt="CC-BY-ND"
-                                        {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-ShareAlike CC BY-NC-SA." %}
-                                     src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-SA.png" alt="CC-BY-NC-SA"
-                                        {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial CC BY-NC." %}
-                                     src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC.png" alt="CC-BY-NC"
-                                        {% elif cm.metadata.rights.statement == "This resource is shared under the Creative Commons Attribution-NoCommercial-NoDerivs CC BY-NC-ND." %}
-                                     src="{{ STATIC_URL }}img/cc-badges/CC-BY-NC-ND.png" alt="CC-BY-NC-ND"
-                                        {% endif %}/>
-                            </div>
-                            <div class="col-md-6">
-                                <div id="div_id_statement" class="control-group">
-                                    <span for="id_statement"> Statement</span>
-
-                                    <div class="controls">
-                                            <textarea class="form-control input-sm textarea" cols="40"
-                                                      id="id_statement" name="statement" readonly="True">{{ cm.metadata.rights.statement }}</textarea>
-                                    </div>
-                                </div>
-                                <div id="div_id_url" class="control-group">
-                                    <span for="id_url">Url</span>
-
-                                    <div class="controls">
-                                        <input class="form-control input-sm urlinput" id="id_url"
-                                               maxlength="200" name="url" readonly="True" type="url"
-                                               value={{ cm.metadata.rights.url }}>
-                                    </div>
-                                </div>
-
-                                <button type="button" class="btn btn-primary pull-right"
-                                        onclick="metadata_update_ajax_submit('id-rights'); return false;"
-                                        style="display: none;">Save changes
-                                </button>
-                            </div>
-                        </fieldset>
-                    </form>
-                </div>
-            {% endif %}
         </div>
 
         <div id="sharing-status" class="col-xs-12">

--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -111,148 +111,148 @@
             <br>
             <h4>Sharing status:</h4>
             {% if can_change_resource_flags %}
-                    <div class="btn-group" role="group">
-                        {# -------- PUBLIC -------- #}
-                        <form class="pull-left"
-                                  action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
-                                  method="POST">
-                                {% csrf_token %}
-                                <input name="t" type="hidden" value="make_public"/>
-                                <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
-                                <button {% if not cm.can_be_public_or_discoverable or cm.raccess.public %} disabled {% endif %}
-                                        id="btn-public" data-toggle="tooltip" data-placement="auto"
-                                        title='Can be viewed and downloaded by anyone.' type="submit"
-                                        {% if cm.raccess.public %}
-                                            class="btn btn-default active"
-                                        {% else %}
-                                            class="btn btn-default"
-                                        {% endif %}
-                                        >Public
-                                </button>
+                <div class="btn-group" role="group">
+                    {# -------- PUBLIC -------- #}
+                    <form class="pull-left"
+                              action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
+                              method="POST">
+                            {% csrf_token %}
+                            <input name="t" type="hidden" value="make_public"/>
+                            <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
+                            <button {% if not cm.can_be_public_or_discoverable or cm.raccess.public %} disabled {% endif %}
+                                    id="btn-public" data-toggle="tooltip" data-placement="auto"
+                                    title='Can be viewed and downloaded by anyone.' type="submit"
+                                    {% if cm.raccess.public %}
+                                        class="btn btn-default active"
+                                    {% else %}
+                                        class="btn btn-default"
+                                    {% endif %}
+                                    >Public
+                            </button>
+                    </form>
+                    {# -------- DISCOVERABLE -------- #}
+                    <form class="pull-left"
+                              action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
+                              method="POST">
+                            <input name="t" type="hidden" value="make_discoverable"/>
+                            <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
+                            {% csrf_token %}
+                            <button {% if not cm.can_be_public_or_discoverable %} disabled {% endif %}
+                                    id="btn-discoverable" data-toggle="tooltip" data-placement="auto"
+                                    title='Metadata is public but data is protected.' type="submit"
+                                    {% if cm.raccess.discoverable and not cm.raccess.public %}
+                                        class="btn btn-default active"
+                                    {% else %}
+                                        class="btn btn-default"
+                                    {% endif %}
+                                    >Discoverable
+                            </button>
                         </form>
-                        {# -------- DISCOVERABLE -------- #}
-                        <form class="pull-left"
-                                  action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
-                                  method="POST">
-                                <input name="t" type="hidden" value="make_discoverable"/>
-                                <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
-                                {% csrf_token %}
-                                <button {% if not cm.can_be_public_or_discoverable %} disabled {% endif %}
-                                        id="btn-discoverable" data-toggle="tooltip" data-placement="auto"
-                                        title='Metadata is public but data is protected.' type="submit"
-                                        {% if cm.raccess.discoverable and not cm.raccess.public %}
-                                            class="btn btn-default active"
-                                        {% else %}
-                                            class="btn btn-default"
-                                        {% endif %}
-                                        >Discoverable
-                                </button>
-                            </form>
-                        {# -------- PRIVATE -------- #}
-                        <form class="pull-left"
-                                  action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
-                                  method="POST">
-                                <input name="t" type="hidden" value="make_private"/>
-                                <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
-                                {% csrf_token %}
-                                <button {% if not cm.raccess.public and not cm.raccess.discoverable %} disabled {% endif %}
-                                        id="btn-private" data-toggle="tooltip" data-placement="auto"
-                                        title='Can be viewed and downloaded only by designated users or research groups.' type="submit"
-                                        {% if not cm.raccess.public and not cm.raccess.discoverable %}
-                                            class="btn btn-default active"
-                                        {% else %}
-                                            class="btn btn-default"
-                                        {% endif %}
-                                        >Private
-                                </button>
+                    {# -------- PRIVATE -------- #}
+                    <form class="pull-left"
+                              action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
+                              method="POST">
+                            <input name="t" type="hidden" value="make_private"/>
+                            <input name="resource-mode" type="hidden" value="{{ resource_mode }}">
+                            {% csrf_token %}
+                            <button {% if not cm.raccess.public and not cm.raccess.discoverable %} disabled {% endif %}
+                                    id="btn-private" data-toggle="tooltip" data-placement="auto"
+                                    title='Can be viewed and downloaded only by designated users or research groups.' type="submit"
+                                    {% if not cm.raccess.public and not cm.raccess.discoverable %}
+                                        class="btn btn-default active"
+                                    {% else %}
+                                        class="btn btn-default"
+                                    {% endif %}
+                                    >Private
+                            </button>
+                    </form>
+                </div>
+
+                {% if is_owner_user and cm.resource_type == "NetcdfResource" and not cm.raccess.public %}
+                    <div class="pull-left label-public">Note that making the resource public may take a little extra time to update
+                            Hyrax server in order to provide OPeNDAP service for this resource. </div>
+                {% endif %}
+
+                {% if is_owner_user %}
+                    <div id="shareable-container" class="height-fix">
+                        {#   Shareable flag    #}
+                        <form class="pull-left" action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
+                              method="POST">
+                            {% csrf_token %}
+
+                            <input name="t" type="hidden" {% if cm.raccess.shareable %}value="make_not_shareable"
+                                   {% else %}value="make_shareable"{% endif %}/>
+
+                            <br>
+                            <div class="input-group" data-toggle="tooltip" title="When checked, users other than owners may grant access to the resource.">
+                              <span class="input-group-addon">
+                                <input id="btn-shareable" type="checkbox"
+                                              {% if cm.raccess.shareable %}checked{% endif %}>
+                              </span>
+                              <span class="form-control">Shareable</span>
+                            </div><!-- /input-group -->
                         </form>
                     </div>
-
-                    {% if is_owner_user and cm.resource_type == "NetcdfResource" and not cm.raccess.public %}
-                        <div class="pull-left label-public">Note that making the resource public may take a little extra time to update
-                                Hyrax server in order to provide OPeNDAP service for this resource. </div>
-                    {% endif %}
-
-                    {% if is_owner_user %}
-                        <div id="shareable-container" class="height-fix">
-                            {#   Shareable flag    #}
-                            <form class="pull-left" action="/hsapi/_internal/{{ cm.short_id }}/set-resource-flag/"
-                                  method="POST">
-                                {% csrf_token %}
-
-                                <input name="t" type="hidden" {% if cm.raccess.shareable %}value="make_not_shareable"
-                                       {% else %}value="make_shareable"{% endif %}/>
-
-                                <br>
-                                <div class="input-group" data-toggle="tooltip" title="When checked, users other than owners may grant access to the resource.">
-                                  <span class="input-group-addon">
-                                    <input id="btn-shareable" type="checkbox"
-                                                  {% if cm.raccess.shareable %}checked{% endif %}>
-                                  </span>
-                                  <span class="form-control">Shareable</span>
-                                </div><!-- /input-group -->
-                            </form>
-                        </div>
-                        <br>
+                    <br>
+                {% endif %}
+            {% else %}
+                <ul class="list-group">
+                {% if cm.raccess.published %}
+                    <li class="list-group-item">
+                    <div>
+                        <img src="{{ STATIC_URL }}img/published.png" alt="Published Resource"/>
+                        <span>&nbsp;Published</span>
+                    </div>
+                        </li>
+                {% elif cm.raccess.public %}
+                    <li class="list-group-item">
+                    <div>
+                        <img src="{{ STATIC_URL }}img/public.png" alt="Public Resource"/>
+                        <span>&nbsp;Public</span>
+                    </div>
+                    </li>
+                {% elif cm.raccess.discoverable %}
+                    <li class="list-group-item">
+                    <div>
+                        <img src="{{ STATIC_URL }}img/discoverable.png" alt="Discoverable Resource"/>
+                        <span>&nbsp;Discoverable</span>
+                    </div>
+                        </li>
+                {% else %}
+                    <li class="list-group-item">
+                    <div>
+                        <img src="{{ STATIC_URL }}img/private.png" alt="Private Resource"/>
+                        <span>&nbsp;Private</span>
+                    </div>
+                    </li>
+                {% endif %}
+                {% if cm.raccess.published %}
+                    {% if "pending" in cm.doi or "failure" in cm.doi %}
+                        <li class="list-group-item">
+                            <div>
+                                <small class="text-muted">Note that the DOI will not be available until it has been
+                                    registered and activated.
+                                </small>
+                            </div>
+                        </li>
                     {% endif %}
                 {% else %}
-                    <ul class="list-group">
-                    {% if cm.raccess.published %}
-                        <li class="list-group-item">
+                    <li class="list-group-item">
+                    {% if cm.raccess.shareable %}
                         <div>
-                            <img src="{{ STATIC_URL }}img/published.png" alt="Published Resource"/>
-                            <span>&nbsp;Published</span>
+                            <img src="{{ STATIC_URL }}img/shareable.png" alt="Sharable Resource"/>
+                            <span>&nbsp;Shareable</span>
                         </div>
-                            </li>
-                    {% elif cm.raccess.public %}
-                        <li class="list-group-item">
-                        <div>
-                            <img src="{{ STATIC_URL }}img/public.png" alt="Public Resource"/>
-                            <span>&nbsp;Public</span>
-                        </div>
-                        </li>
-                    {% elif cm.raccess.discoverable %}
-                        <li class="list-group-item">
-                        <div>
-                            <img src="{{ STATIC_URL }}img/discoverable.png" alt="Discoverable Resource"/>
-                            <span>&nbsp;Discoverable</span>
-                        </div>
-                            </li>
                     {% else %}
-                        <li class="list-group-item">
                         <div>
-                            <img src="{{ STATIC_URL }}img/private.png" alt="Private Resource"/>
-                            <span>&nbsp;Private</span>
+                            <img src="{{ STATIC_URL }}img/non-shareable.png" alt="Non Sharable Resource"/>
+                            <span>&nbsp;Not Shareable</span>
                         </div>
-                        </li>
                     {% endif %}
-                    {% if cm.raccess.published %}
-                        {% if "pending" in cm.doi or "failure" in cm.doi %}
-                            <li class="list-group-item">
-                                <div>
-                                    <small class="text-muted">Note that the DOI will not be available until it has been
-                                        registered and activated.
-                                    </small>
-                                </div>
-                            </li>
-                        {% endif %}
-                    {% else %}
-                        <li class="list-group-item">
-                        {% if cm.raccess.shareable %}
-                            <div>
-                                <img src="{{ STATIC_URL }}img/shareable.png" alt="Sharable Resource"/>
-                                <span>&nbsp;Shareable</span>
-                            </div>
-                        {% else %}
-                            <div>
-                                <img src="{{ STATIC_URL }}img/non-shareable.png" alt="Non Sharable Resource"/>
-                                <span>&nbsp;Not Shareable</span>
-                            </div>
-                        {% endif %}
-                        </li>
-                    {% endif %}
-                    </ul>
+                    </li>
                 {% endif %}
+                </ul>
+            {% endif %}
             <div id="user-permission-msg">
                 {% if is_owner_user %}
                     <div class="alert alert-info" role="alert"><i class="fa fa-lock" aria-hidden="true"></i> You are the owner of this resource.</div>

--- a/theme/templates/resource-landing-page/modals.html
+++ b/theme/templates/resource-landing-page/modals.html
@@ -2143,7 +2143,9 @@
                             <input readonly id="txtFileURL" type="text" class="form-control click-select-all">
                             <span class="input-group-btn">
                                 <button class="btn btn-default clipboard-copy" data-target="txtFileURL"
-                                        type="button">Copy</button>
+                                        type="button">
+                                    <i class="fa fa-clipboard" aria-hidden="true"></i> Copy
+                                </button>
                             </span>
                         </div>
                     </fieldset>

--- a/theme/templates/resource-landing-page/top-right-buttons.html
+++ b/theme/templates/resource-landing-page/top-right-buttons.html
@@ -61,7 +61,7 @@
                             <a id="new-version" data-toggle="modal" data-target="#new-version-resource-dialog">
                                 <span data-toggle="tooltip" data-placement="auto"
                                       title="Create a new version of this resource"
-                                      class="glyphicon glyphicon-plus-sign icon-button icon-blue"></span>
+                                      class="fa fa-clone icon-button icon-blue"></span>
                             </a>
                         {% endif %}
                     </form>
@@ -72,13 +72,14 @@
                             <a disabled>
                                 <span data-toggle="tooltip" data-placement="auto"
                                       title="You cannot copy because the license for this resource does not permit copying"
-                                      class="glyphicon glyphicon-import icon-button text-muted"></span>
+                                      class="fa fa-copy icon-button text-muted"></span>
                             </a>
                         {% else %}
                             <a id="copy-resource" data-toggle="modal" data-target="#copy-resource-dialog">
                                 <span data-toggle="tooltip" data-placement="auto"
                                       title="Copy this resource"
-                                      class="glyphicon glyphicon-import icon-button icon-blue"></span>
+                                      class="fa fa-copy icon-button icon-blue">
+                                </span>
                             </a>
                         {% endif %}
                     {% endif %}

--- a/theme/tests/test_functional.py
+++ b/theme/tests/test_functional.py
@@ -109,7 +109,7 @@ class FunctionalTestsCases(object):
         title = self.driver.find_element_by_xpath("//h2[@id='resource-title']").text
         self.assertEqual(title, RESOURCE_TITLE)
         citation = self.driver.find_element_by_xpath("//div[@id='citation-text']")
-        citation_text = citation.get_attribute('text')
+        citation_text = citation.text
         import re
         m = re.search('HydroShare, http://www.hydroshare.org/resource/(.*)$', citation_text)
         shortkey = m.groups(0)[0]

--- a/theme/tests/test_functional.py
+++ b/theme/tests/test_functional.py
@@ -108,8 +108,8 @@ class FunctionalTestsCases(object):
         # check results
         title = self.driver.find_element_by_xpath("//h2[@id='resource-title']").text
         self.assertEqual(title, RESOURCE_TITLE)
-        citation = self.driver.find_element_by_xpath("//input[@id='citation-text']")
-        citation_text = citation.get_attribute('value')
+        citation = self.driver.find_element_by_xpath("//div[@id='citation-text']")
+        citation_text = citation.get_attribute('text')
         import re
         m = re.search('HydroShare, http://www.hydroshare.org/resource/(.*)$', citation_text)
         shortkey = m.groups(0)[0]


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2448568/24114358/851b3c22-0d65-11e7-9c7f-30faca7696eb.png)

- The full citation is now displayed. The container resizes appropriately.
- URL is again clickable

Also:
- Updated 'Copy Resource' and 'Create New Resource Version' button icons
![image](https://cloud.githubusercontent.com/assets/2448568/24114425/c9809362-0d65-11e7-8a94-521809c4141a.png)


