### PR TITLE
[#1966] Widget for selecting coordinates

### DIFF
--- a/hs_app_timeseries/forms.py
+++ b/hs_app_timeseries/forms.py
@@ -21,6 +21,7 @@ class SiteFormHelper(BaseFormHelper):
         # the order in which the model fields are listed for the FieldSet is the order these
         # fields will be displayed
         field_width = 'form-control input-sm'
+        field_map_coordinates = 'form-control input-sm'
         common_layout = Layout(
                             Field('selected_series_id', css_class=field_width, type="hidden"),
                             Field('available_sites', css_class=field_width, type="hidden"),
@@ -44,12 +45,12 @@ class SiteFormHelper(BaseFormHelper):
                                   title="A controlled vocabulary term that describes the type of "
                                         "data collection site (e.g., 'Stream').\n"
                                         "Select 'Other...' to specify a new site type term."),
-                            Field('latitude', css_class=field_width,
+                            Field('latitude', css_class=field_map_coordinates,
                                   title="The latitude coordinate of the site location using the "
-                                        "WGS84 datum (e.g., 43.1111)."),
-                            Field('longitude', css_class=field_width,
+                                        "WGS84 datum (e.g., 43.1111).", data_map_item="latitude"),
+                            Field('longitude', css_class=field_map_coordinates,
                                   title="The longitude coordinate of the site location using the "
-                                        "WGS84 datum (e.g., -111.2334)."),
+                                        "WGS84 datum (e.g., -111.2334).", data_map_item="longitude"),
                      )
         layout = _set_form_helper_layout(common_layout=common_layout, element_name="site",
                                          is_show_element_code_selection=show_site_code_selection,
@@ -789,7 +790,7 @@ UTCOffSetLayout = HTML("""
 
 TimeSeriesMetaDataLayout = HTML("""
 <div class="form-group col-sm-6 col-xs-12 time-series-forms">
-     <div id="site">
+     <div id="site" class="hs-coordinates-picker" data-coordinates-type="point">
          {% load crispy_forms_tags %}
          {% crispy site_form %}
          <hr style="border:0">

--- a/hs_app_timeseries/forms.py
+++ b/hs_app_timeseries/forms.py
@@ -21,7 +21,6 @@ class SiteFormHelper(BaseFormHelper):
         # the order in which the model fields are listed for the FieldSet is the order these
         # fields will be displayed
         field_width = 'form-control input-sm'
-        field_map_coordinates = 'form-control input-sm'
         common_layout = Layout(
                             Field('selected_series_id', css_class=field_width, type="hidden"),
                             Field('available_sites', css_class=field_width, type="hidden"),
@@ -45,10 +44,10 @@ class SiteFormHelper(BaseFormHelper):
                                   title="A controlled vocabulary term that describes the type of "
                                         "data collection site (e.g., 'Stream').\n"
                                         "Select 'Other...' to specify a new site type term."),
-                            Field('latitude', css_class=field_map_coordinates,
+                            Field('latitude', css_class=field_width,
                                   title="The latitude coordinate of the site location using the "
                                         "WGS84 datum (e.g., 43.1111).", data_map_item="latitude"),
-                            Field('longitude', css_class=field_map_coordinates,
+                            Field('longitude', css_class=field_width,
                                   title="The longitude coordinate of the site location using the "
                                         "WGS84 datum (e.g., -111.2334).", data_map_item="longitude"),
                      )

--- a/hs_app_timeseries/forms.py
+++ b/hs_app_timeseries/forms.py
@@ -46,10 +46,12 @@ class SiteFormHelper(BaseFormHelper):
                                         "Select 'Other...' to specify a new site type term."),
                             Field('latitude', css_class=field_width,
                                   title="The latitude coordinate of the site location using the "
-                                        "WGS84 datum (e.g., 43.1111).", data_map_item="latitude"),
+                                        "WGS84 datum (e.g., 43.1111).",
+                                  data_map_item="latitude"),
                             Field('longitude', css_class=field_width,
                                   title="The longitude coordinate of the site location using the "
-                                        "WGS84 datum (e.g., -111.2334).", data_map_item="longitude"),
+                                        "WGS84 datum (e.g., -111.2334).",
+                                  data_map_item="longitude"),
                      )
         layout = _set_form_helper_layout(common_layout=common_layout, element_name="site",
                                          is_show_element_code_selection=show_site_code_selection,

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -1141,6 +1141,7 @@
 
                 {%  block modal %}
                     {% include "resource-landing-page/modals.html" %}
+                    {% include "resource-landing-page/coordinates_picker.html" %}
                 {%  endblock %}
             </div>
         </div>

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -69,6 +69,18 @@
                 {% include "resource-landing-page/citation.html" with resource_mode="view" %}
             {% endif %}
 
+            <div id="test-dynamic" data-coordinates-type="point">
+                <input data-map-item="latitude">
+                <input data-map-item="longitude">
+            </div>
+
+            <div id="test-dynamic-2" data-coordinates-type="rectangle">
+                <input data-map-item="northlimit">
+                <input data-map-item="eastlimit">
+                <input data-map-item="southlimit">
+                <input data-map-item="westlimit">
+            </div>
+
             {# ======= Coverage ======= #}
             {% if spatial_coverage.north or spatial_coverage.northlimit or temporal_coverage or metadata_form %}
                 {% include "resource-landing-page/coverage.html" %}

--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -69,18 +69,6 @@
                 {% include "resource-landing-page/citation.html" with resource_mode="view" %}
             {% endif %}
 
-            <div id="test-dynamic" data-coordinates-type="point">
-                <input data-map-item="latitude">
-                <input data-map-item="longitude">
-            </div>
-
-            <div id="test-dynamic-2" data-coordinates-type="rectangle">
-                <input data-map-item="northlimit">
-                <input data-map-item="eastlimit">
-                <input data-map-item="southlimit">
-                <input data-map-item="westlimit">
-            </div>
-
             {# ======= Coverage ======= #}
             {% if spatial_coverage.north or spatial_coverage.northlimit or temporal_coverage or metadata_form %}
                 {% include "resource-landing-page/coverage.html" %}

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1010,10 +1010,6 @@ span.remove{
     top: 0;
 }
 
-.form-control{
-    margin-bottom:8px;
-}
-
 .no-padding{
     padding:0;
 }
@@ -1145,8 +1141,8 @@ span.remove {
 	margin: 1px;
 }
 
-.form-control{
-    margin-bottom:8px;
+.form-control, .controls .input-group .form-control {
+	margin-bottom: 8px;
 }
 
 .no-padding{
@@ -4521,4 +4517,18 @@ div#fb-file-operations-controls {
 
 .ui-widget-overlay {
 	z-index: 1031 !important;
+}
+
+/*Coordinates picker styling*/
+#picker-map-container {
+	height: 300px;
+	margin: 0 1px;
+}
+
+#coordinates-picker-modal .modal-footer {
+	margin-top: 0;
+}
+
+.btn-choose-coordinates {
+	vertical-align: top;
 }

--- a/theme/static/js/coordinates-picker.js
+++ b/theme/static/js/coordinates-picker.js
@@ -1,0 +1,162 @@
+/**
+ * Created by Mauriel on 3/28/2017.
+ */
+
+$(document).ready(function () {
+    var coordinatesPicker;
+    var allOverlays = [];
+    var drawingManager;
+    var currentInstance;   // Keeps track of the instance to work with
+
+    $('#coordinates-picker-modal').on('shown.bs.modal', function () {
+        google.maps.event.trigger(coordinatesPicker, 'resize');
+    });
+
+    // Initialize Map
+    coordinatesPicker = new google.maps.Map(document.getElementById('picker-map-container'), {
+        zoom: 3,
+        streetViewControl: false,
+        center: {lat: 41.850033, lng: -87.6500523}, // Default center
+        mapTypeControl: true,
+        mapTypeControlOptions: {
+            style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
+            mapTypeIds: [
+                google.maps.MapTypeId.ROADMAP,
+                google.maps.MapTypeId.SATELLITE
+            ],
+            position: google.maps.ControlPosition.TOP_RIGHT
+        }
+    });
+
+    drawingManager = new google.maps.drawing.DrawingManager({
+        drawingControl: true,
+        drawingControlOptions: {
+            position: google.maps.ControlPosition.TOP_CENTER,
+        },
+        rectangleOptions: {
+            editable: true,
+            draggable: true
+        }
+    });
+
+    drawingManager.setMap(coordinatesPicker);
+
+    // When a rectangle is drawn
+    google.maps.event.addListener(drawingManager, 'rectanglecomplete', function (rectangle) {
+        var coordinates = (rectangle.getBounds());
+        processDrawing(coordinates, "rectangle");
+
+        // When this rectangle is modified
+        rectangle.addListener('bounds_changed', function () {
+            var coordinates = (rectangle.getBounds());
+            processDrawing(coordinates, "rectangle");
+        });
+    });
+
+    // When a point is selected
+    google.maps.event.addListener(drawingManager, 'markercomplete', function (marker) {
+        var coordinates = (marker.getPosition());
+            processDrawing(coordinates, "marker");
+    });
+
+    google.maps.event.addListener(drawingManager, 'overlaycomplete', function (e) {
+        allOverlays.push(e);
+    });
+
+    function processDrawing(coordinates, shape) {
+        // Delete previous drawings
+        if (allOverlays.length > 1) {
+            for (var i = 1; i < allOverlays.length; i++) {
+                allOverlays[i - 1].overlay.setMap(null);
+            }
+            allOverlays.shift();
+        }
+
+        if (shape == "rectangle") {
+            var bounds = {
+                north: parseFloat(coordinates.getNorthEast().lat()),
+                south: parseFloat(coordinates.getSouthWest().lat()),
+                east: parseFloat(coordinates.getNorthEast().lng()),
+                west: parseFloat(coordinates.getSouthWest().lng())
+            };
+
+            $("#btn-confirm-coordinates").unbind("click");
+            $("#btn-confirm-coordinates").click(function () {
+                currentInstance.find("input[data-map-item='northlimit']").val(bounds.north.toFixed(4));
+                currentInstance.find("input[data-map-item='eastlimit']").val(bounds.east.toFixed(4));
+                currentInstance.find("input[data-map-item='southlimit']").val(bounds.south.toFixed(4));
+                currentInstance.find("input[data-map-item='westlimit']").val(bounds.west.toFixed(4));
+                $('#coordinates-picker-modal').modal('hide')
+            });
+        }
+        else {
+            $("#btn-confirm-coordinates").unbind("click");
+            $("#btn-confirm-coordinates").click(function () {
+                currentInstance.find("input[data-map-item='longitude']").val(coordinates.lng().toFixed(4));
+                currentInstance.find("input[data-map-item='latitude']").val(coordinates.lat().toFixed(4));
+                $('#coordinates-picker-modal').modal('hide')
+            });
+        }
+    }
+
+    $(".hs-coordinates-picker").each(function() {
+        const instance = $(this);
+        var items = instance.find("input[data-map-item]");
+
+        items.each(function () {
+            var item = $(this);
+            // Wrap the element and append a button next to it to trigger the map modal
+            // The button adapts to the size of the input (bootstrap classes: input-sm and input-lg)
+            if (item.hasClass("input-sm")) {
+                item.wrap('<div class="input-group input-group-sm"></div>');
+            }
+            else if (item.hasClass("input-sm")) {
+                item.wrap('<div class="input-group input-group-lg"></div>');
+            }
+            else {
+                item.wrap('<div class="input-group"></div>');
+            }
+
+            item.parent().append('<span class="input-group-btn btn-choose-coordinates" title="Choose coordinates">' +
+                                        '<span class="btn btn-default" type="button">' +
+                                        '<i class="fa fa-map-marker" aria-hidden="true"></i>' +
+                                        '</span>' +
+                                    '</span>')
+        });
+
+        // Map trigger event handler
+        $(this).find(".btn-choose-coordinates").click(function () {
+            currentInstance = instance;
+            var type = currentInstance.attr("data-coordinates-type");
+
+            // Set the type of controls
+            if (type == "point") {
+                drawingManager.drawingControlOptions.drawingModes = [
+                    google.maps.drawing.OverlayType.MARKER
+                ];
+                drawingManager.setMap(coordinatesPicker);
+            }
+            else if (type == "rectangle") {
+                drawingManager.drawingControlOptions.drawingModes = [
+                    google.maps.drawing.OverlayType.RECTANGLE
+                ];
+                drawingManager.setMap(coordinatesPicker);
+            }
+
+            // Delete previous drawings
+            for (var i = 0; i < allOverlays.length; i++) {
+                allOverlays[i].overlay.setMap(null);
+            }
+
+            allOverlays = [];
+
+            // Set default behavior. It is overridden once coordinates are selected.
+            $("#btn-confirm-coordinates").unbind("click");
+            $("#btn-confirm-coordinates").click(function () {
+                $('#coordinates-picker-modal').modal('hide')
+            });
+
+            $("#coordinates-picker-modal").modal("show");
+        });
+    })
+});

--- a/theme/static/js/coordinates-picker.js
+++ b/theme/static/js/coordinates-picker.js
@@ -24,7 +24,7 @@ var drawingManager;
             if (item.hasClass("input-sm")) {
                 item.wrap('<div class="input-group input-group-sm"></div>');
             }
-            else if (item.hasClass("input-sm")) {
+            else if (item.hasClass("input-lg")) {
                 item.wrap('<div class="input-group input-group-lg"></div>');
             }
             else {

--- a/theme/templates/resource-landing-page/coordinates_picker.html
+++ b/theme/templates/resource-landing-page/coordinates_picker.html
@@ -1,0 +1,24 @@
+<div class="modal fade" id="coordinates-picker-modal" tabindex="-1" role="dialog" aria-labelledby="chooseCoordinates"
+     aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <span class="modal-title" id="chooseCoordinates">
+                    <i class="fa fa-map-marker" aria-hidden="true"></i>&nbsp;
+                    Choose coordinates
+                </span>
+
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+                <div id="picker-map-container"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="button" id="btn-confirm-coordinates" class="btn btn-primary">Confirm</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript" src="{{ STATIC_URL }}js/coordinates-picker.js"></script>


### PR DESCRIPTION
## Usage

### Include the HTML in your template:
`{% include "resource-landing-page/coordinates_picker.html" %}`

### Have a container with all the input fields. 

This container should have:
- The class `"hs-coordinates-picker"` if the elements are to be instantiated on page load. Otherwise see below for how to instantiate dynamically.
- The attribute `"data-coordinates-type"` which can be `"point"` or `"rectangle"`
- The input elements contained within (no matter how nested).

The input elements should have:
- The attribute `"data-map-item"` which can be:
-- for a point: `"longitude"` and `"latitude"`
-- for a rectangle: `"northlimit"`,` "eastlimit"`, `"southlimit"` and `"westlimit"`

### Examples
Elements can be instantiated when the page loads. The script will search for the elements with the class "hs-coordinates-picker" and initiate them. Example:
```
<div class="hs-coordinates-picker" data-coordinates-type="point">
   ...
   <input data-map-item="latitude">
   <input data-map-item="longitude">
   ...
</div>
```

The script will run at page load, find the inputs with the specifications above and append the widget to them. It can be used in multiple places in the same page.

Elements can also be instantiated dynamically. Example:
```
<div id="myCoordinates" data-coordinates-type="point">
   ...
   <input data-map-item="latitude">
   <input data-map-item="longitude">
   ...
</div>

<script>
   $(document).ready(function() {
       $("#myCoordinates").coordinatesPicker();
   });
</script>
```

## Screenshots
_The buttons attached to the input elements_
![image](https://cloud.githubusercontent.com/assets/2448568/24431166/9fe4354a-13d7-11e7-883e-a024a73a4358.png)

_The map modal_
![image](https://cloud.githubusercontent.com/assets/2448568/24431199/cf17a478-13d7-11e7-9db3-64e7a3b19cf5.png)