### PR TITLE
[#1978][Hotfix] Fix for message displacing buttons

### DIFF
--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -169,7 +169,7 @@
                 </div>
 
                 {% if is_owner_user and cm.resource_type == "NetcdfResource" and not cm.raccess.public %}
-                    <div class="pull-left label-public">Note that making the resource public may take a little extra time to update
+                    <div class="label-public">Note that making the resource public may take a little extra time to update
                             Hyrax server in order to provide OPeNDAP service for this resource. </div>
                 {% endif %}
 


### PR DESCRIPTION
Message moved to the bottom:
![image](https://cloud.githubusercontent.com/assets/2448568/24617483/4063387c-1851-11e7-9664-77958dc9cc77.png)
