### PR TITLE
1999 resource file api bugs

### DIFF
--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -423,21 +423,21 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id, set_to_private=False):
     # Also, bags and similar attached files are not copied.
     istorage = src_res.get_irods_storage()
 
-    # This makes an exact copy of all physical files. 
+    # This makes an exact copy of all physical files.
     src_files = os.path.join(src_res.root_path, 'data')
     dest_files = os.path.join(tgt_res.root_path, 'data')
     istorage.copyFiles(src_files, dest_files)
 
     for avu_name in avu_list:
         value = istorage.getAVU(src_res.root_path, avu_name)
-        if avu_name == 'isPublic' 
+        if avu_name == 'isPublic':
             if set_to_private:
                 istorage.setAVU(tgt_res.root_path, avu_name, 'False')
-            else: 
+            else:
                 istorage.setAVU(tgt_res.root_path, avu_name, value)
-        else: 
+        else:
             istorage.setAVU(tgt_res.root_path, avu_name, value)
-        
+
     # link copied resource files to Django resource model
     files = src_res.files.all()
 

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -29,6 +29,7 @@ from hs_core.hydroshare.hs_bagit import create_bag_files
 
 from django_irods.icommands import SessionException
 from django_irods.storage import IrodsStorage
+from pprint import pprint
 
 
 logger = logging.getLogger(__name__)
@@ -425,7 +426,8 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id, set_to_private=False):
 
     # This makes an exact copy of all physical files.
     src_files = os.path.join(src_res.root_path, 'data')
-    dest_files = os.path.join(tgt_res.root_path, 'data')
+    # This has to be one segment short of the source because it is a target directory. 
+    dest_files = tgt_res.root_path
     istorage.copyFiles(src_files, dest_files)
 
     src_coll = src_res.root_path

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -427,9 +427,9 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id, set_to_private=False):
     src_files = os.path.join(src_res.root_path, 'data')
     dest_files = os.path.join(tgt_res.root_path, 'data')
     istorage.copyFiles(src_files, dest_files)
-    
+
     src_coll = src_res.root_path
-    tgt_coll = tgt_res.root_path 
+    tgt_coll = tgt_res.root_path
     for avu_name in avu_list:
         value = istorage.getAVU(src_coll, avu_name)
         if avu_name == 'isPublic':

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -427,16 +427,18 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id, set_to_private=False):
     src_files = os.path.join(src_res.root_path, 'data')
     dest_files = os.path.join(tgt_res.root_path, 'data')
     istorage.copyFiles(src_files, dest_files)
-
+    
+    src_coll = src_res.root_path
+    tgt_coll = tgt_res.root_path 
     for avu_name in avu_list:
-        value = istorage.getAVU(src_res.root_path, avu_name)
+        value = istorage.getAVU(src_coll, avu_name)
         if avu_name == 'isPublic':
             if set_to_private:
-                istorage.setAVU(tgt_res.root_path, avu_name, 'False')
+                istorage.setAVU(tgt_coll, avu_name, 'False')
             else:
-                istorage.setAVU(tgt_res.root_path, avu_name, value)
+                istorage.setAVU(tgt_coll, avu_name, value)
         else:
-            istorage.setAVU(tgt_res.root_path, avu_name, value)
+            istorage.setAVU(tgt_coll, avu_name, value)
 
     # link copied resource files to Django resource model
     files = src_res.files.all()

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -422,27 +422,21 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id, set_to_private=False):
     # This makes the assumption that the destination is in the same exact zone.
     # Also, bags and similar attached files are not copied.
     istorage = src_res.get_irods_storage()
-    src_coll = os.path.join(src_res.root_path, 'data')
-    dest_coll = os.path.join(tgt_res.root_path, 'data')
+
     # This makes an exact copy of all physical files. 
-    # TODO: This is in error for bags 
-    # However, the evidence is that the metadata_dirty flag should be set to True 
-    # so that the bag will be regenerated, because inherently the copy is a 
-    # different resource and has a different resource id!
-    istorage.copyFiles(src_coll, dest_coll)
+    src_files = os.path.join(src_res.root_path, 'data')
+    dest_files = os.path.join(tgt_res.root_path, 'data')
+    istorage.copyFiles(src_files, dest_files)
 
     for avu_name in avu_list:
-        value = istorage.getAVU(src_coll, avu_name)
+        value = istorage.getAVU(src_res.root_path, avu_name)
         if avu_name == 'isPublic' 
             if set_to_private:
-                istorage.setAVU(dest_coll, avu_name, 'False')
+                istorage.setAVU(tgt_res.root_path, avu_name, 'False')
             else: 
-                istorage.setAVU(dest_coll, avu_name, value)
-        elif avu_name == 'metadata_dirty':
-            # force bag to be recreated
-            istorage.setAVU(dest_coll, avu_name, 'False')
+                istorage.setAVU(tgt_res.root_path, avu_name, value)
         else: 
-            istorage.setAVU(dest_coll, avu_name, value)
+            istorage.setAVU(tgt_res.root_path, avu_name, value)
         
     # link copied resource files to Django resource model
     files = src_res.files.all()
@@ -453,12 +447,8 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id, set_to_private=False):
     for src_logical_file in src_logical_files:
         map_logical_files[src_logical_file] = src_logical_file.get_copy()
 
-    # TODO: This is now in error because we already copied the file to the resource. 
-    # TODO: We need to create the resource file with a pointer to the existing storage.
-    # TODO: Or, we need to allow this copy to suffice rather than the above copy. 
     for n, f in enumerate(files):
         folder, base = os.path.split(f.short_path)  # strips object information.
-        # this form of ResourceFile.create creates a reference to an existing file in iRODS
         new_resource_file = ResourceFile.create(tgt_res, base, folder=folder)
 
         # if the original file is part of a logical file, then

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -29,7 +29,6 @@ from hs_core.hydroshare.hs_bagit import create_bag_files
 
 from django_irods.icommands import SessionException
 from django_irods.storage import IrodsStorage
-from pprint import pprint
 
 
 logger = logging.getLogger(__name__)
@@ -426,7 +425,7 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id, set_to_private=False):
 
     # This makes an exact copy of all physical files.
     src_files = os.path.join(src_res.root_path, 'data')
-    # This has to be one segment short of the source because it is a target directory. 
+    # This has to be one segment short of the source because it is a target directory.
     dest_files = tgt_res.root_path
     istorage.copyFiles(src_files, dest_files)
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1942,7 +1942,7 @@ class ResourceFile(models.Model):
         else:  # if file is not an open file, then it's a basename (string)
             if file is None and source is not None:
                 if __debug__:
-                    assert(isinstance(source, baseString))
+                    assert(isinstance(source, basestring))
                 # source is a path to an iRODS file to be copied here.
                 root, newfile = os.path.split(source)  # take file from source path
                 # newfile is where it should be copied to.

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1948,28 +1948,25 @@ class ResourceFile(models.Model):
                 # newfile is where it should be copied to.
                 target = get_resource_file_path(resource, newfile, folder=folder)
                 istorage = resource.get_irods_storage()
-                if __debug__:
-                    if not istorage.exists(source):
-                        raise ValidationError("ResourceFile.create: source {} of copy not found"
-                                              .format(source))
+                if not istorage.exists(source):
+                    raise ValidationError("ResourceFile.create: source {} of copy not found"
+                                          .format(source))
                 if not move:
                     istorage.copyFiles(source, target)
                 else:
                     istorage.moveFile(source, target)
-                if __debug__:
-                    if not istorage.exists(target):
-                        raise ValidationError("ResourceFile.create: copy to target {} failed"
-                                              .format(target))
-                    if move and istorage.exists(source):
-                        raise ValidationError("ResourceFile.create: move did not work")
+                if not istorage.exists(target):
+                    raise ValidationError("ResourceFile.create: copy to target {} failed"
+                                          .format(target))
+                if move and istorage.exists(source):
+                    raise ValidationError("ResourceFile.create: move did not work")
             elif file is not None and source is None:
                 # file points to an existing iRODS file
                 target = get_resource_file_path(resource, file, folder=folder)
                 istorage = resource.get_irods_storage()
-                if __debug__:
-                    if not istorage.exists(target):
-                        raise ValidationError("ResourceFile.create: target {} does not exist"
-                                              .format(target))
+                if not istorage.exists(target):
+                    raise ValidationError("ResourceFile.create: target {} does not exist"
+                                          .format(target))
             else:
                 raise ValidationError(
                     "ResourceFile.create: exactly one of source or file must be specified")

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1894,9 +1894,9 @@ class ResourceFile(models.Model):
         Federation must be initialized first at the resource level.
 
         :param resource: resource that contains the file.
-        :param file: a File or a string.
+        :param file: a File or a iRODS path to an existing file already copied.
         :param folder: the folder in which to store the file.
-        :param source: an iRODS path from which to copy the file.
+        :param source: an iRODS path in the same zone from which to copy the file.
         :param move: if True, move the file rather than copying.
 
         There are two main usages to this constructor:
@@ -1914,7 +1914,8 @@ class ResourceFile(models.Model):
         In this case, source is a full iRODS pathname of the place from which to copy or move
         the file. The default is to copy the file and leave a copy in place.
 
-        A third form is less common and presumes that the file already exists in iRODS:
+        A third form is less common and presumes that the file already exists in iRODS
+        in the proper place:
 
         * pointing to an existing file:
 
@@ -1940,14 +1941,22 @@ class ResourceFile(models.Model):
 
         else:  # if file is not an open file, then it's a basename (string)
             if file is None and source is not None:
-                root, file = os.path.split(source)  # take from source path
-            target = get_resource_file_path(resource, file, folder=folder)
-            if source is not None:
+                # source is a path to an iRODS file to be copied here.
+                root, newfile = os.path.split(source)  # take file from source path
+                # newfile is where it should be copied to.
+                target = get_resource_file_path(resource, newfile, folder=folder)
                 istorage = resource.get_irods_storage()
                 if not move:
                     istorage.copyFiles(source, target)
                 else:
                     istorage.moveFile(source, target)
+            elif file is not None and source is None:
+                # file points to an existing iRODS file
+                target = get_resource_file_path(resource, file, folder=folder)
+            else:
+                raise ValidationError(
+                    "ResourceFile.create: exactly one of source or file must be specified")
+
             # we've copied or moved if necessary; now set the paths
             if resource.resource_federation_path:
                 kwargs['resource_file'] = None

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1950,9 +1950,16 @@ class ResourceFile(models.Model):
                     istorage.copyFiles(source, target)
                 else:
                     istorage.moveFile(source, target)
+                if not istorage.exists(target):
+                    raise ValidationError("ResourceFile.create: copy to target {} failed"
+                                          .format(target))
             elif file is not None and source is None:
                 # file points to an existing iRODS file
                 target = get_resource_file_path(resource, file, folder=folder)
+                istorage = resource.get_irods_storage()
+                if not istorage.exists(target):
+                    raise ValidationError("ResourceFile.create: target {} does not exist"
+                                          .format(target))
             else:
                 raise ValidationError(
                     "ResourceFile.create: exactly one of source or file must be specified")


### PR DESCRIPTION
@hyi @dtarb This is a preliminary PR to correct problems described by @pkdash in issue #1999. 
The main problem so far is that the iRODS attributes are being attached to the wrong level of the resource during a copy. This affects both copy and version for all resource types, not just composite resource. 
It also seems to mess up the creation of an appropriate bag for the resource.

This is work in progress. What I've fixed so far is definitely wrong and needs to be fixed, but I have not yet fully investigated the scope of this problem. There may be other errors. 
