### PR TITLE
HOTFIX-Set flag to regenerate metadata xml on bulk metadata update

### DIFF
--- a/hs_collection_resource/tests/test_collection.py
+++ b/hs_collection_resource/tests/test_collection.py
@@ -741,7 +741,7 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
         metadata_dict = [{'coverage': {'type': 'period', 'value':
                          {'name': 'Name for period coverage',
                           'start': '1/1/2016', 'end': '12/31/2016'}}}, ]
-        update_science_metadata(pk=self.resGen1.short_id, metadata=metadata_dict)
+        update_science_metadata(pk=self.resGen1.short_id, metadata=metadata_dict, user=self.user1)
         self.assertEqual(self.resGen1.metadata.coverages.count(), 1)
         # calculate overall coverages
         _update_collection_coverages(self.resCollection)
@@ -758,7 +758,8 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
         metadata_dict = [{'coverage': {'type': 'point', 'value':
                          {'name': 'Name for point coverage', 'east': '-20',
                           'north': '10', 'units': 'decimal deg'}}}, ]
-        update_science_metadata(pk=self.resGeoFeature.short_id, metadata=metadata_dict)
+        update_science_metadata(pk=self.resGeoFeature.short_id, metadata=metadata_dict,
+                                user=self.user1)
         self.assertEqual(self.resGeoFeature.metadata.coverages.count(), 1)
         # calculate overall coverages
         _update_collection_coverages(self.resCollection)
@@ -785,7 +786,7 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
                          {'coverage': {'type': 'point', 'value':
                           {'name': 'Name for point coverage', 'east': '25',
                            'north': '-35', 'units': 'decimal deg'}}}]
-        update_science_metadata(pk=self.resGen2.short_id, metadata=metadata_dict)
+        update_science_metadata(pk=self.resGen2.short_id, metadata=metadata_dict, user=self.user1)
         self.assertEqual(self.resGen2.metadata.coverages.count(), 2)
         self.resCollection.resources.add(self.resGen2)
         self.assertEqual(self.resCollection.resources.count(), 3)

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -637,7 +637,7 @@ def add_resource_files(pk, *files, **kwargs):
     return ret
 
 
-def update_science_metadata(pk, metadata):
+def update_science_metadata(pk, metadata, user):
     """
     Updates science metadata for a resource
 
@@ -646,6 +646,7 @@ def update_science_metadata(pk, metadata):
         updated.
         metadata: a list of dictionary items containing data for each metadata element that needs to
         be updated
+        user: user who is updating metadata
         example metadata format:
         [
             {'title': {'value': 'Updated Resource Title'}},
@@ -678,6 +679,7 @@ def update_science_metadata(pk, metadata):
 
     resource = utils.get_resource_by_shortkey(pk)
     resource.metadata.update(metadata)
+    utils.resource_modified(resource, user, overwrite_bag=False)
 
 
 def delete_resource(pk):

--- a/hs_core/tests/api/native/test_update_metadata.py
+++ b/hs_core/tests/api/native/test_update_metadata.py
@@ -11,7 +11,7 @@ class TestUpdateMetadata(MockIRODSTestCaseMixin, TestCase):
     def setUp(self):
         super(TestUpdateMetadata, self).setUp()
         group, _ = Group.objects.get_or_create(name='Hydroshare Author')
-        user = hydroshare.create_account(
+        self.user = hydroshare.create_account(
             'shaun@gmail.com',
             username='shaunjl',
             first_name='shaun',
@@ -19,7 +19,7 @@ class TestUpdateMetadata(MockIRODSTestCaseMixin, TestCase):
             superuser=False,
             )
 
-        self.res = hydroshare.create_resource('GenericResource', user, 'Test Resource')
+        self.res = hydroshare.create_resource('GenericResource', self.user, 'Test Resource')
 
     def test_update_science_metadata(self):
         # add these new metadata elements
@@ -52,7 +52,8 @@ class TestUpdateMetadata(MockIRODSTestCaseMixin, TestCase):
             {'subject': {'value': 'sub-2'}},
         ]
 
-        hydroshare.update_science_metadata(pk=self.res.short_id, metadata=metadata_dict)
+        hydroshare.update_science_metadata(pk=self.res.short_id, metadata=metadata_dict,
+                                           user=self.user)
 
         # check that the title element got updated
         self.assertEqual(self.res.metadata.title.value, 'Updated Resource Title', msg='Resource title did not match')
@@ -169,7 +170,8 @@ class TestUpdateMetadata(MockIRODSTestCaseMixin, TestCase):
         self.assertEqual(self.res.metadata.coverages.all().count(), 0, msg="Number of coverages not equal to 0.")
 
         # now add the 2 coverage elements by updating metadata
-        hydroshare.update_science_metadata(pk=self.res.short_id, metadata=metadata_dict)
+        hydroshare.update_science_metadata(pk=self.res.short_id, metadata=metadata_dict,
+                                           user=self.user)
 
         # there should be now 2 coverage elements after the update
         self.assertEqual(self.res.metadata.coverages.all().count(), 2, msg="Number of coverages not equal to 2.")

--- a/hs_core/views/resource_metadata_rest_api.py
+++ b/hs_core/views/resource_metadata_rest_api.py
@@ -230,7 +230,7 @@ class MetadataElementsRetrieveUpdate(generics.RetrieveUpdateDestroyAPIView):
                 for subject in put_data.pop('subjects'):
                     metadata.append({"subject": {"value": subject['value']}})
 
-            hydroshare.update_science_metadata(pk=pk, metadata=metadata)
+            hydroshare.update_science_metadata(pk=pk, metadata=metadata, user=request.user)
         except Exception as ex:
             error_msg = {
                 'resource': "Resource metadata update failed: %s, %s"


### PR DESCRIPTION
This hotfix needs to be applied to master. Once I get +1 I will ask @mjstealey to do this merge.