### PR TITLE
2031 Django-iRODS integrity checker

### DIFF
--- a/hs_core/management/commands/check_irods_files.py
+++ b/hs_core/management/commands/check_irods_files.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+"""
+Check synchronization between iRODS and Django
+
+This checks that:
+
+1. every ResourceFile corresponds to an iRODS file
+2. every iRODS file in {short_id}/data/contents corresponds to a ResourceFile
+
+* By default, prints errors on stdout.
+* Optional argument --log instead logs output to system log.
+"""
+
+from django.core.management.base import BaseCommand
+from hs_core.models import BaseResource
+
+
+class Command(BaseCommand):
+    help = "Check synchronization between iRODS and Django."
+
+    def add_arguments(self, parser):
+
+        # a list of resource id's, or none to check all resources
+        parser.add_argument('resource_ids', nargs='*', type=str)
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--log',
+            action='store_true',  # True for presence, False for absence
+            dest='log',           # value is options['log']
+            help='log errors to system log',
+        )
+
+    def handle(self, *args, **options):
+        if len(options['resource_ids']) > 0:  # an array of resource short_id to check.
+            for rid in options['resource_ids']:
+                try:
+                    resource = BaseResource.objects.get(short_id=rid)
+                except BaseResource.DoesNotExist:
+                    msg = "Resource with id {} not found".format(rid)
+                    print(msg)
+
+                print("LOOKING FOR ERRORS FOR RESOURCE {}".format(rid))
+                resource.check_irods_files(stop_on_error=False,
+                                           echo_errors=not options['log'],
+                                           log_errors=options['log'],
+                                           return_errors=False)
+
+        else:  # check all resources
+            print("LOOKING FOR ERRORS FOR ALL RESOURCES")
+            for r in BaseResource.objects.all():
+                r.check_irods_files(stop_on_error=False,
+                                    echo_errors=not options['log'],  # Don't both log and echo
+                                    log_errors=options['log'],
+                                    return_errors=False)

--- a/hs_core/management/commands/check_irods_files.py
+++ b/hs_core/management/commands/check_irods_files.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
                 try:
                     resource = BaseResource.objects.get(short_id=rid)
                 except BaseResource.DoesNotExist:
-                    msg = "Resource with id {} not found".format(rid)
+                    msg = "Resource with id {} not found in Django Resources".format(rid)
                     print(msg)
 
                 print("LOOKING FOR ERRORS FOR RESOURCE {}".format(rid))

--- a/hs_core/management/commands/check_irods_files.py
+++ b/hs_core/management/commands/check_irods_files.py
@@ -69,6 +69,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if options['unreferenced']:
+            print("LOOKING FOR IRODS RESOURCES NOT IN DJANGO")
             check_for_dangling_irods(echo_errors=not options['log'],
                                      log_errors=options['log'],
                                      return_errors=False)
@@ -81,14 +82,14 @@ class Command(BaseCommand):
                     msg = "Resource with id {} not found in Django Resources".format(rid)
                     print(msg)
 
-                print("LOOKING FOR ERRORS FOR RESOURCE {}".format(rid))
+                print("LOOKING FOR FILE ERRORS FOR RESOURCE {}".format(rid))
                 resource.check_irods_files(stop_on_error=False,
                                            echo_errors=not options['log'],
                                            log_errors=options['log'],
                                            return_errors=False)
 
         else:  # check all resources
-            print("LOOKING FOR ERRORS FOR ALL RESOURCES")
+            print("LOOKING FOR FILE ERRORS FOR ALL RESOURCES")
             for r in BaseResource.objects.all():
                 r.check_irods_files(stop_on_error=False,
                                     echo_errors=not options['log'],  # Don't both log and echo

--- a/hs_core/management/commands/check_relations.py
+++ b/hs_core/management/commands/check_relations.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+"""
+Check relations
+
+This checks that every relation to a resource refers to an existing resource
+
+* By default, prints errors on stdout.
+* Optional argument --log instead logs output to system log.
+"""
+
+from django.core.management.base import BaseCommand
+from hs_core.models import BaseResource
+from hs_core.hydroshare.utils import get_resource_by_shortkey
+
+import logging
+
+
+class Command(BaseCommand):
+    help = "Check for dangling relationships among resources."
+
+    def add_arguments(self, parser):
+
+        # a list of resource id's, or none to check all resources
+        parser.add_argument('resource_ids', nargs='*', type=str)
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--log',
+            action='store_true',  # True for presence, False for absence
+            dest='log',           # value is options['log']
+            help='log errors to system log',
+        )
+
+    def handle(self, *args, **options):
+        if len(options['resource_ids']) > 0:  # an array of resource short_id to check.
+            for rid in options['resource_ids']:
+                try:
+                    resource = BaseResource.objects.get(short_id=rid)
+                except BaseResource.DoesNotExist:
+                    msg = "Resource with id {} not found in Django Resources".format(rid)
+                    print(msg)
+
+                print("LOOKING FOR RELATION ERRORS FOR RESOURCE {}".format(rid))
+                resource.check_relations(stop_on_error=False,
+                                         echo_errors=not options['log'],
+                                         log_errors=options['log'],
+                                         return_errors=False)
+
+        else:  # check all resources
+            print("LOOKING FOR RELATION ERRORS FOR ALL RESOURCES")
+            for r in BaseResource.objects.all():
+                r.check_relations(stop_on_error=False,
+                                  echo_errors=not options['log'],  # Don't both log and echo
+                                  log_errors=options['log'],
+                                  return_errors=False)

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1785,6 +1785,15 @@ class AbstractResource(ResourcePermissionsMixin):
         errors = []
         ecount = 0
 
+        # report federation paths for debugging
+        if self.is_federated:
+            msg = "federation path for {} is {}".format(self.short_id,
+                                                        self.resource_federation_path)
+            if echo_errors:
+                print(msg)
+            if log_errors:
+                logger.info(msg)
+
         # skip federated resources if not configured to handle these
         if self.is_federated and not settings.REMOTE_USE_IRODS:
             msg = "check_irods_files: skipping check of federated resource {}"\
@@ -1819,6 +1828,27 @@ class AbstractResource(ResourcePermissionsMixin):
                                                            return_errors=return_errors)
             errors.extend(error2)
             ecount += ecount2
+
+            # Step 3: does the resource contain required file elements?
+            meta = os.path.join(self.root_path, 'data', 'resourcemetadata.xml')
+            if not istorage.exists(meta):
+                msg = "metadata file {} does not exist".format(meta)
+                if echo_errors:
+                    print(msg)
+                if log_errors:
+                    logger.error(msg)
+                if return_errors:
+                    errors.append(msg)
+
+            rmap = os.path.join(self.root_path, 'data', 'resourcemap.xml')
+            if not istorage.exists(rmap):
+                msg = "map file {} does not exist".format(rmap)
+                if echo_errors:
+                    print(msg)
+                if log_errors:
+                    logger.error(msg)
+                if return_errors:
+                    errors.append(msg)
 
             # finally, check whether the public flag agrees with ours
             django_public = self.raccess.public

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1797,10 +1797,6 @@ class AbstractResource(ResourcePermissionsMixin):
         """ ls a directory and check files there for conformance with django """
         errors = []
         istorage = self.get_irods_storage()
-        if len(dir) > len(self.file_path):
-            folder = dir[len(self.file_path)+1:]
-        else:
-            folder = None
         try:
 
             listing = istorage.listdir(dir)

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1847,9 +1847,9 @@ class AbstractResource(ResourcePermissionsMixin):
                         if stop_on_error:
                             raise ValidationError(msg)
 
-            except SessionException:
-                msg = "check_irods_files: resource {} has no 'isPublic' attribute"\
-                    .format(self.short_id)
+            except SessionException as ex:
+                msg = "cannot read isPublic attribute of {}: {}"\
+                    .format(self.short_id, ex.stderr)
                 ecount += 1
                 if log_errors:
                     logger.error(msg)

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -250,3 +250,14 @@ def create_bag_by_irods(resource_id):
     else:
         logger.error('Resource does not exist.')
         return False
+
+
+@shared_task
+def check_irods_files():
+    """
+    Check every resource for iRODS file problems.
+
+    This logs DEBUG messages for every problem it finds
+    """
+    for r in BaseResource.objects.all():
+        r.check_irods_sync()

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -257,7 +257,8 @@ def check_irods_files():
     """
     Check every resource for iRODS file problems.
 
-    This logs DEBUG messages for every problem it finds
+    This logs ERROR messages for every problem it finds
     """
     for r in BaseResource.objects.all():
-        r.check_irods_files()
+        r.check_irods_files(log_errors=True, echo_errors=False, 
+                            stop_on_error=False, return_errors=False)

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -260,5 +260,5 @@ def check_irods_files():
     This logs ERROR messages for every problem it finds
     """
     for r in BaseResource.objects.all():
-        r.check_irods_files(log_errors=True, echo_errors=False, 
+        r.check_irods_files(log_errors=True, echo_errors=False,
                             stop_on_error=False, return_errors=False)

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -260,4 +260,4 @@ def check_irods_files():
     This logs DEBUG messages for every problem it finds
     """
     for r in BaseResource.objects.all():
-        r.check_irods_sync()
+        r.check_irods_files()

--- a/hs_core/tests/api/native/test_check_files.py
+++ b/hs_core/tests/api/native/test_check_files.py
@@ -46,10 +46,6 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         super(TestResourceFileAPI, self).tearDown()
         self.test_file_1.close()
         os.remove(self.test_file_1.name)
-        # self.test_file_2.close()
-        # os.remove(self.test_file_2.name)
-        # self.test_file_3.close()
-        # os.remove(self.test_file_3.name)
 
     def test_unfederated_root_path_setting(self):
         """ an unfederated file in the root folder has the proper state after state changes """

--- a/hs_core/tests/api/native/test_check_files.py
+++ b/hs_core/tests/api/native/test_check_files.py
@@ -9,7 +9,6 @@ from hs_core.testing import MockIRODSTestCaseMixin, TestCaseCommonUtilities
 
 from hs_core.models import ResourceFile, get_path
 
-from pprint import pprint
 
 class TestResourceFileAPI(MockIRODSTestCaseMixin,
                           TestCaseCommonUtilities, TransactionTestCase):
@@ -66,7 +65,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         # should succeed without errors
         self.res.check_irods_sync(raise_exceptions=True)
 
-        #resource should has only one file at this point
+        # resource should has only one file at this point
         self.assertEqual(self.res.files.all().count(), 1,
                          msg="resource file count didn't match")
 

--- a/hs_core/tests/api/native/test_check_files.py
+++ b/hs_core/tests/api/native/test_check_files.py
@@ -57,13 +57,13 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         self.assertEqual(self.res.files.all().count(), 0,
                          msg="resource file count didn't match")
 
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # add one file to the resource
         hydroshare.add_resource_files(self.res.short_id, self.test_file_1)
 
         # should succeed without errors
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # resource should has only one file at this point
         self.assertEqual(self.res.files.all().count(), 1,
@@ -109,7 +109,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
 
         # should raise exception
         with self.assertRaises(ValidationError):
-            self.res.check_irods_sync(raise_exceptions=True)
+            self.res.check_irods_files(stop_on_error=True)
 
         # TODO: how to eliminate this kind of error
         # dumbpath = 'x' + shortpath
@@ -127,13 +127,13 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         ResourceFile.create_folder(self.res, 'foo')
 
         # should succeed without errors
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # add one file to the resource
         hydroshare.add_resource_files(self.res.short_id, self.test_file_1, folder='foo')
 
         # should succeed without errors
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # resource should has only one file at this point
         self.assertEqual(self.res.files.all().count(), 1,
@@ -180,7 +180,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
 
         # should raise exception
         with self.assertRaises(ValidationError):
-            self.res.check_irods_sync(raise_exceptions=True)
+            self.res.check_irods_files(stop_on_error=True)
 
         # TODO: how to eliminate this particular error.
         # dumbpath = 'x' + shortpath
@@ -199,13 +199,13 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
                          msg="resource file count didn't match")
 
         # should succeed without errors
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # add one file to the resource
         hydroshare.add_resource_files(self.res.short_id, self.test_file_1)
 
         # should succeed without errors
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # resource should has only one file at this point
         self.assertEqual(self.res.files.all().count(), 1,
@@ -285,13 +285,13 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         ResourceFile.create_folder(self.res, 'foo')
 
         # should succeed without errors
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # add one file to the resource
         hydroshare.add_resource_files(self.res.short_id, self.test_file_1, folder='foo')
 
         # should succeed without errors
-        self.res.check_irods_sync(raise_exceptions=True)
+        self.res.check_irods_files(stop_on_error=True)
 
         # resource should has only one file at this point
         self.assertEqual(self.res.files.all().count(), 1,
@@ -359,7 +359,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
 
         # should raise exception
         with self.assertRaises(ValidationError):
-            self.res.check_irods_sync(raise_exceptions=True)
+            self.res.check_irods_files(stop_on_error=True)
 
         # delete resources to clean up
         hydroshare.delete_resource(self.res.short_id)

--- a/hs_core/tests/api/native/test_check_files.py
+++ b/hs_core/tests/api/native/test_check_files.py
@@ -198,7 +198,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         self.assertTrue(errors[0].endswith(
              'data/contents/fuzz.txt does not exist in iRODS'))
         self.assertTrue(errors[1].endswith(
-            'data/contents/file1.txt in iRODs does not exist in Django'))
+            'data/contents/foo/file1.txt in iRODs does not exist in Django'))
         self.assertTrue(errors[2].endswith(
             "type is GenericResource, title is 'My Test Resource'"))
 
@@ -387,7 +387,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         self.assertTrue(errors[0].endswith(
              'data/contents/fuzz.txt does not exist in iRODS'))
         self.assertTrue(errors[1].endswith(
-            'data/contents/file1.txt in iRODs does not exist in Django'))
+            'data/contents/foo/file1.txt in iRODs does not exist in Django'))
         self.assertTrue(errors[2].endswith(
             "type is GenericResource, title is 'My Test Resource'"))
 

--- a/hs_core/tests/api/native/test_check_files.py
+++ b/hs_core/tests/api/native/test_check_files.py
@@ -1,0 +1,366 @@
+import os
+
+from django.test import TransactionTestCase
+from django.contrib.auth.models import Group
+from django.core.exceptions import ValidationError
+
+from hs_core import hydroshare
+from hs_core.testing import MockIRODSTestCaseMixin, TestCaseCommonUtilities
+
+from hs_core.models import ResourceFile, get_path
+
+from pprint import pprint
+
+class TestResourceFileAPI(MockIRODSTestCaseMixin,
+                          TestCaseCommonUtilities, TransactionTestCase):
+    def setUp(self):
+        super(TestResourceFileAPI, self).setUp()
+        self.hydroshare_author_group, _ = Group.objects.get_or_create(name='Hydroshare Author')
+        # create a user to be used for creating the resource
+        self.user = hydroshare.create_account(
+            'creator@usu.edu',
+            username='creator',
+            first_name='Creator_FirstName',
+            last_name='Creator_LastName',
+            superuser=False,
+            groups=[]
+        )
+
+        self.res = hydroshare.create_resource(
+            'GenericResource',
+            self.user,
+            'My Test Resource'
+        )
+
+        # create a file
+        self.test_file_name1 = 'file1.txt'
+        self.file_name_list = [self.test_file_name1, ]
+
+        # put predictable contents into these
+        test_file = open(self.test_file_name1, 'w')
+        test_file.write("Test text file in file1.txt")
+        test_file.close()
+
+        self.test_file_1 = open(self.test_file_name1, 'r')
+
+    def tearDown(self):
+        super(TestResourceFileAPI, self).tearDown()
+        self.test_file_1.close()
+        os.remove(self.test_file_1.name)
+        # self.test_file_2.close()
+        # os.remove(self.test_file_2.name)
+        # self.test_file_3.close()
+        # os.remove(self.test_file_3.name)
+
+    def test_unfederated_root_path_setting(self):
+        """ an unfederated file in the root folder has the proper state after state changes """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        # add one file to the resource
+        hydroshare.add_resource_files(self.res.short_id, self.test_file_1)
+
+        # should succeed without errors
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        #resource should has only one file at this point
+        self.assertEqual(self.res.files.all().count(), 1,
+                         msg="resource file count didn't match")
+
+        # get the handle of the file created above
+        resfile = self.res.files.all()[0]
+
+        # determine where that file should live
+        shortpath = os.path.join(self.res.short_id, "data", "contents", "file1.txt")
+
+        self.assertEqual(resfile.file_folder, None)
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        self.assertTrue(resfile.path_is_acceptable(shortpath))
+
+        # non-existent files should raise error
+        otherpath = os.path.join(self.res.short_id, "data", "contents", "file2.txt")
+        with self.assertRaises(ValidationError):
+            resfile.path_is_acceptable(otherpath)
+
+        # try setting to an unqualified name; should qualify it
+        resfile.set_storage_path("file1.txt")
+        # should match computed path
+        self.assertEqual(resfile.file_folder, None)
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to what it is already
+        resfile.set_storage_path(shortpath)
+        # should match computed path
+        self.assertEqual(resfile.file_folder, None)
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to a good path to a non-existent object
+        with self.assertRaises(ValidationError):
+            resfile.set_storage_path(otherpath)
+        # should not change
+        self.assertEqual(resfile.file_folder, None)
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to intentionally corrupt it
+        resfile.set_short_path("fuzz.txt")
+
+        # should raise exception
+        with self.assertRaises(ValidationError):
+            self.res.check_irods_sync(raise_exceptions=True)
+
+        # TODO: how to eliminate this kind of error
+        # dumbpath = 'x' + shortpath
+        # dumbpath = self.res.short_id + "file1.txt"
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)
+
+    def test_unfederated_folder_path_setting(self):
+        """ an unfederated file in a subfolder has the proper state after state changes """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        ResourceFile.create_folder(self.res, 'foo')
+
+        # should succeed without errors
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        # add one file to the resource
+        hydroshare.add_resource_files(self.res.short_id, self.test_file_1, folder='foo')
+
+        # should succeed without errors
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        # resource should has only one file at this point
+        self.assertEqual(self.res.files.all().count(), 1,
+                         msg="resource file count didn't match")
+
+        # get the handle of the file created above
+        resfile = self.res.files.all()[0]
+
+        # determine where that file should live
+        shortpath = os.path.join(self.res.short_id, "data",
+                                 "contents", "foo", "file1.txt")
+
+        self.assertEqual(resfile.file_folder, "foo")
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        self.assertTrue(resfile.path_is_acceptable(shortpath))
+
+        # non-existent files should raise error
+        otherpath = os.path.join(self.res.short_id, "data", "contents", "foo", "file2.txt")
+        with self.assertRaises(ValidationError):
+            resfile.path_is_acceptable(otherpath)
+
+        # try setting to an unqualified name; should qualify it
+        resfile.set_storage_path("foo/file1.txt")
+        # should match computed path
+        self.assertEqual(resfile.file_folder, "foo")
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to what it is already
+        resfile.set_storage_path(shortpath)
+        # should match computed path
+        self.assertEqual(resfile.file_folder, "foo")
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to a good path to a non-existent object
+        with self.assertRaises(ValidationError):
+            resfile.set_storage_path(otherpath)
+        # should not change
+        self.assertEqual(resfile.file_folder, "foo")
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to intentionally corrupt it
+        resfile.set_short_path("fuzz.txt")
+
+        # should raise exception
+        with self.assertRaises(ValidationError):
+            self.res.check_irods_sync(raise_exceptions=True)
+
+        # TODO: how to eliminate this particular error.
+        # dumbpath = 'x' + shortpath
+        # dumbpath = self.res.short_id + "file1.txt"
+
+        # clean up after folder test
+        # ResourceFile.remove_folder(self.res, 'foo', self.user)
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)
+
+    def test_federated_root_path_logic(self):
+        """ a federated file path in the root folder has the proper state after state changes """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        # should succeed without errors
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        # add one file to the resource
+        hydroshare.add_resource_files(self.res.short_id, self.test_file_1)
+
+        # should succeed without errors
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        # resource should has only one file at this point
+        self.assertEqual(self.res.files.all().count(), 1,
+                         msg="resource file count didn't match")
+
+        # get the handle of the file created above
+        resfile = self.res.files.all()[0]
+
+        # cheat: set a fake federated path to test path logic
+        oldfedpath = self.res.resource_federation_path
+        oldpath = resfile.storage_path
+
+        # intentionally break path logic by setting an unused federation path
+        fedpath = "/myzone/home/myuser"
+        self.res.resource_federation_path = fedpath
+        self.res.save()
+        # must load changes into resfile from self.res before setting storage path
+        resfile.content_object.refresh_from_db()
+        resfile.set_storage_path('file1.txt', test_exists=False)
+
+        self.assertEqual(self.res.resource_federation_path, fedpath)
+        self.assertEqual(resfile.storage_path, get_path(resfile, 'file1.txt'))
+
+        # determine where that file should live; THIS IS FAKE
+        shortpath = os.path.join(fedpath, self.res.short_id, "data",
+                                 "contents", "file1.txt")
+
+        # intentionally break the resource file path
+        resfile.set_storage_path(shortpath, test_exists=False)
+        self.assertEqual(shortpath, resfile.storage_path)
+
+        self.assertEqual(resfile.file_folder, None)
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        self.assertTrue(resfile.path_is_acceptable(shortpath, test_exists=False))
+
+        otherpath = os.path.join(fedpath, self.res.short_id, "data", "contents", "file2.txt")
+        resfile.path_is_acceptable(otherpath, test_exists=False)
+
+        # non-existent files should raise error
+        # This won't work because federation path is fake
+        # with self.assertRaises(ValidationError):
+        #     resfile.path_is_acceptable(otherpath, test_exists=True)
+
+        # try setting to an unqualified name; should qualify it
+        resfile.set_storage_path("file1.txt", test_exists=False)
+        # should match computed path
+        self.assertEqual(resfile.file_folder, None)
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to what it is already
+        resfile.set_storage_path(shortpath, test_exists=False)
+        # should match computed path
+        self.assertEqual(resfile.file_folder, None)
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to a good path to a non-existent object
+        resfile.set_storage_path(otherpath, test_exists=False)
+
+        # conclusion: strip off federation path
+        self.res.resource_federation_path = oldfedpath
+        self.res.save()
+        # must load changes into resfile from self.res before setting storage path
+        resfile.content_object.refresh_from_db()
+        resfile.set_storage_path(oldpath, test_exists=False)
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)
+
+    def test_federated_folder_path_logic(self):
+        """ a federated file in a subfolder has the proper state after state changes """
+
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        ResourceFile.create_folder(self.res, 'foo')
+
+        # should succeed without errors
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        # add one file to the resource
+        hydroshare.add_resource_files(self.res.short_id, self.test_file_1, folder='foo')
+
+        # should succeed without errors
+        self.res.check_irods_sync(raise_exceptions=True)
+
+        # resource should has only one file at this point
+        self.assertEqual(self.res.files.all().count(), 1,
+                         msg="resource file count didn't match")
+
+        # get the handle of the file created above
+        resfile = self.res.files.all()[0]
+
+        self.assertEqual(resfile.resource_file.name, os.path.join(self.res.short_id,
+                                                                  "data", "contents",
+                                                                  "foo", "file1.txt"))
+        self.assertEqual(resfile.file_folder, "foo")
+
+        # cheat: set a fake federated path to test path logic
+        fedpath = "/myzone/home/myuser"
+        self.res.resource_federation_path = fedpath
+        self.res.save()
+        resfile.content_object.refresh_from_db()
+        resfile.set_storage_path('foo/file1.txt', test_exists=False)
+
+        # determine where that file should live
+        shortpath = os.path.join(fedpath, self.res.short_id, "data",
+                                 "contents", "foo", "file1.txt")
+
+        self.assertEqual(shortpath, resfile.storage_path)
+
+        # this should result in an exact path
+        resfile.set_storage_path(shortpath, test_exists=False)
+
+        self.assertEqual(resfile.file_folder, "foo")
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        self.assertTrue(resfile.path_is_acceptable(shortpath, test_exists=False))
+
+        # non-existent files should raise error
+        otherpath = os.path.join(fedpath, self.res.short_id, "data", "contents", "foo", "file2.txt")
+        resfile.path_is_acceptable(otherpath, test_exists=False)
+        # This won't work because federation path is fake.
+        # with self.assertRaises(ValidationError):
+        #     resfile.path_is_acceptable(otherpath, test_exists=True)
+
+        # try setting to an unqualified name; should qualify it
+        resfile.set_storage_path("foo/file1.txt", test_exists=False)
+        # should match computed path
+        self.assertEqual(resfile.file_folder, "foo")
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to what it is already
+        resfile.set_storage_path(shortpath, test_exists=False)
+        # should match computed path
+        self.assertEqual(resfile.file_folder, "foo")
+        self.assertEqual(resfile.storage_path, shortpath)
+
+        # now try to change that path to a good path to a non-existent object
+        resfile.set_storage_path(otherpath, test_exists=False)
+
+        # conclusion: unfederate the resource
+        self.res.resource_federation_path = ""
+        self.res.save()
+        resfile.content_object.refresh_from_db()
+        resfile.set_storage_path("foo/file1.txt", test_exists=False)
+
+        # now try to intentionally corrupt it
+        resfile.set_short_path("fuzz.txt")
+
+        # should raise exception
+        with self.assertRaises(ValidationError):
+            self.res.check_irods_sync(raise_exceptions=True)
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)

--- a/hs_core/tests/api/native/test_check_files.py
+++ b/hs_core/tests/api/native/test_check_files.py
@@ -111,6 +111,16 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         with self.assertRaises(ValidationError):
             self.res.check_irods_files(stop_on_error=True)
 
+        # now don't raise exception and read error
+        errors, ecount = self.res.check_irods_files(return_errors=True, log_errors=False)
+
+        self.assertTrue(errors[0].endswith(
+             'data/contents/fuzz.txt does not exist in iRODS'))
+        self.assertTrue(errors[1].endswith(
+            'data/contents/file1.txt in iRODs does not exist in Django'))
+        self.assertTrue(errors[2].endswith(
+            "type is GenericResource, title is 'My Test Resource'"))
+
         # TODO: how to eliminate this kind of error
         # dumbpath = 'x' + shortpath
         # dumbpath = self.res.short_id + "file1.txt"
@@ -181,6 +191,16 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         # should raise exception
         with self.assertRaises(ValidationError):
             self.res.check_irods_files(stop_on_error=True)
+
+        # now don't raise exception and read error
+        errors, ecount = self.res.check_irods_files(return_errors=True, log_errors=False)
+
+        self.assertTrue(errors[0].endswith(
+             'data/contents/fuzz.txt does not exist in iRODS'))
+        self.assertTrue(errors[1].endswith(
+            'data/contents/file1.txt in iRODs does not exist in Django'))
+        self.assertTrue(errors[2].endswith(
+            "type is GenericResource, title is 'My Test Resource'"))
 
         # TODO: how to eliminate this particular error.
         # dumbpath = 'x' + shortpath
@@ -360,6 +380,16 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
         # should raise exception
         with self.assertRaises(ValidationError):
             self.res.check_irods_files(stop_on_error=True)
+
+        # now don't raise exception and read error
+        errors, ecount = self.res.check_irods_files(return_errors=True, log_errors=False)
+
+        self.assertTrue(errors[0].endswith(
+             'data/contents/fuzz.txt does not exist in iRODS'))
+        self.assertTrue(errors[1].endswith(
+            'data/contents/file1.txt in iRODs does not exist in Django'))
+        self.assertTrue(errors[2].endswith(
+            "type is GenericResource, title is 'My Test Resource'"))
 
         # delete resources to clean up
         hydroshare.delete_resource(self.res.short_id)


### PR DESCRIPTION
@pkdash @hyi @mjstealey 
Here is the first version of the integrity checker. If you call:
```resource.check_irods_files()```
for a specific resource, then integrity will be checked and the system log will report errors.

If you instead call:
```resource.check_irods_files(stop_on_error=True)```
for a resource, it will raise an exception and stop on first error with ValidationError

See `hs_core/tests/api/native/test_check_files.py` for examples. 
