### PR TITLE
[#2063][Hotfix] Spatial reference - string wrap fix

### DIFF
--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1045,6 +1045,11 @@ table.info-table {
 	padding-bottom: 8px;
 }
 
+.custom-table td {
+	word-break: break-all;
+	word-wrap: break-word;
+}
+
 #txt-title {
 	font-size: 27px;
 	height: auto;


### PR DESCRIPTION
Fix for text overflow in Spatial Reference table of File Metadata

![image](https://cloud.githubusercontent.com/assets/2448568/25568004/c7313078-2db6-11e7-9642-097f47e9e2b6.png)
