### PR TITLE
2071 [hotfix] fix isPublic

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -139,11 +139,15 @@ def update_resource_file(pk, filename, f):
     for rf in ResourceFile.objects.filter(object_id=resource.id):
         if rf.short_path == filename:
             if rf.resource_file:
+                # TODO: should use delete_resource_file
                 rf.resource_file.delete()
+                # TODO: should use add_file_to_resource
                 rf.resource_file = File(f) if not isinstance(f, UploadedFile) else f
                 rf.save()
             if rf.fed_resource_file:
+                # TODO: should use delete_resource_file
                 rf.fed_resource_file.delete()
+                # TODO: should use add_file_to_resource
                 rf.fed_resource_file = File(f) if not isinstance(f, UploadedFile) else f
                 rf.save()
             return rf
@@ -681,9 +685,14 @@ def update_science_metadata(pk, metadata):
 
     Returns:
     """
-
     resource = utils.get_resource_by_shortkey(pk)
     resource.metadata.update(metadata)
+
+    # set to private if metadata has become non-compliant
+    resource.update_public_and_discoverable()  # set to False if necessary
+
+    # TODO: This is a bit of a lie since the user initiating this is not the creator
+    utils.resource_modified(resource, resource.creator, overwrite_bag=False)
 
 
 def delete_resource(pk):

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -857,7 +857,7 @@ def delete_resource_file(pk, filename_or_id, user, delete_logical_file=True):
             signals.post_delete_file_from_resource.send(sender=res_cls, resource=resource)
 
             # set to private if necessary -- AFTER post_delete_file handling
-            resource.update_public_and_discoverable()  # set to False if necessary 
+            resource.update_public_and_discoverable()  # set to False if necessary
 
             # generate bag
             utils.resource_modified(resource, user, overwrite_bag=False)

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1474,12 +1474,12 @@ class AbstractResource(ResourcePermissionsMixin):
     @property
     def has_required_metadata(self):
         """ return True only if all required metadata is present for publication. """
-        if self.metadata is None or not self.metadata.has_all_required_elements(): 
+        if self.metadata is None or not self.metadata.has_all_required_elements():
             return False
-        for f in self.logical_files: 
-            if not f.metadata.has_all_required_elements(): 
+        for f in self.logical_files:
+            if not f.metadata.has_all_required_elements():
                 return False
-        return True 
+        return True
 
     @property
     def can_be_public_or_discoverable(self):
@@ -1555,13 +1555,13 @@ class AbstractResource(ResourcePermissionsMixin):
 
         This sets the public flag (self.raccess.public) for a resource based
         upon application logic. It is part of AbstractResource because its result depends
-        upon resource state, and not just access control. 
+        upon resource state, and not just access control.
 
         * This flag can only be set to True if the resource passes basic validations
           `has_required_metata` and `has_required_content_files`
         * setting `public` to `True` also sets `discoverable` to `True`
         * setting `public` to `False` does not change `discoverable`
-        * setting `public` to either also modifies the AVU isPublic for the resource. 
+        * setting `public` to either also modifies the AVU isPublic for the resource.
 
         Thus, the setting public=True, discoverable=False is disallowed.
 
@@ -1599,51 +1599,50 @@ class AbstractResource(ResourcePermissionsMixin):
 
             # public changed state: set isPublic metadata AVU accordingly
             if value != old_value:
-                res_coll = self.root_path
                 self.setAVU("isPublic", self.raccess.public)
 
-                # TODO: why does this only run when something becomes public? 
-                # TODO: Should it be run when a NetcdfResource becomes private? 
+                # TODO: why does this only run when something becomes public?
+                # TODO: Should it be run when a NetcdfResource becomes private?
                 # run script to update hyrax input files when private netCDF resource changes state
                 if value and settings.RUN_HYRAX_UPDATE and self.resource_type == 'NetcdfResource':
                     run_script_to_update_hyrax_input_files(self.short_id)
 
-    def update_public_and_discoverable(self): 
+    def update_public_and_discoverable(self):
         """ update the settings of the public and discoverable flags for changes in metadata """
-        if self.raccess.discoverable and not self.can_be_public_or_discoverable: 
+        if self.raccess.discoverable and not self.can_be_public_or_discoverable:
             self.set_discoverable(False)  # also sets Public
 
-    def setAVU(self, attribute, value): 
-        """ 
-        set an AVU at the resource level 
-        
-        This avoids mistakes in setting AVUs by assuring that the appropriate root path
-        is alway used. 
+    def setAVU(self, attribute, value):
         """
-        if isinstance(value, boolean): 
-            value = str(value).lower()  # normalize boolean values to strings  
+        set an AVU at the resource level
+
+        This avoids mistakes in setting AVUs by assuring that the appropriate root path
+        is alway used.
+        """
+        if isinstance(value, bool):
+            value = str(value).lower()  # normalize boolean values to strings
         istorage = self.get_irods_storage()
         root_path = self.root_path
-        istorage.setAVU(root_path, attribute, value) 
+        istorage.setAVU(root_path, attribute, value)
 
-    def getAVU(self, attribute) 
+    def getAVU(self, attribute):
         """
         get an AVU for a resource
 
         This avoids mistakes in getting AVUs by assuring that the appropriate root path
-        is alway used. 
+        is alway used.
         """
         istorage = self.get_irods_storage()
         root_path = self.root_path
-        value = istorage.getAVU(root_path, attribute) 
-        if attribute == 'isPublic': 
-            if value.lower() == 'true': 
+        value = istorage.getAVU(root_path, attribute)
+        if attribute == 'isPublic':
+            if value.lower() == 'true':
                 return True
-            else: 
+            else:
                 return False
-        else: 
+        else:
             return value
-        
+
     # TODO: Why isn't this a regular method? Why does it need to be a class method?
     # It would seem to me that one only creates a bag after a resource has been created,
     # so that this would be an instance method....

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1471,7 +1471,7 @@ class AbstractResource(ResourcePermissionsMixin):
 
     @property
     def has_required_metadata(self):
-        """ return True only if all required metadata is present for publication. """
+        """ return True only if all required metadata is present. """
         if self.metadata is None or not self.metadata.has_all_required_elements():
             return False
         for f in self.logical_files:
@@ -1524,7 +1524,7 @@ class AbstractResource(ResourcePermissionsMixin):
         # check that there is sufficient resource content
         has_metadata = self.has_required_metadata
         has_files = self.has_required_content_files
-        if value and not (has_metadata or has_files):
+        if value and not (has_metadata and has_files):
 
             if not has_metadata and not has_files:
                 msg = "Resource does not have sufficient metadata and content files to be " + \
@@ -1578,7 +1578,7 @@ class AbstractResource(ResourcePermissionsMixin):
         # check that there is sufficient resource content
         has_metadata = self.has_required_metadata
         has_files = self.has_required_content_files
-        if value and (not has_metadata or not has_files):
+        if value and not (has_metadata and has_files):
 
             if not has_metadata and not has_files:
                 msg = "Resource does not have sufficient metadata and content files to be public"

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -34,8 +34,6 @@ from mezzanine.pages.managers import PageManager
 
 from dominate.tags import div, legend, table, tbody, tr, th, td, h4
 
-from hs_core.views.utils import run_script_to_update_hyrax_input_files
-
 
 class GroupOwnership(models.Model):
     group = models.ForeignKey(Group)
@@ -1568,6 +1566,9 @@ class AbstractResource(ResourcePermissionsMixin):
         If `user` is None, access control is not checked.  This happens when a resource has been
         invalidated outside of the control of a specific user. In this case, user can be None
         """
+        # avoid import loop
+        from hs_core.views.utils import run_script_to_update_hyrax_input_files
+
         # access control is separate from validation logic
         if user is not None and not user.uaccess.can_change_resource_flags(self):
             raise ValidationError("You don't have permission to change resource sharing status")

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1491,8 +1491,8 @@ class AbstractResource(ResourcePermissionsMixin):
 
         and False otherwise
         """
-        has_files = self.has_required_content_files()
-        has_metadata = self.has_required_metadata()
+        has_files = self.has_required_content_files
+        has_metadata = self.has_required_metadata
         return has_files and has_metadata
 
     def set_discoverable(self, value, user=None):
@@ -1522,8 +1522,8 @@ class AbstractResource(ResourcePermissionsMixin):
             raise ValidationError("You don't have permission to change resource sharing status")
 
         # check that there is sufficient resource content
-        has_metadata = self.has_required_metadata()
-        has_files = self.has_required_content_files(),
+        has_metadata = self.has_required_metadata
+        has_files = self.has_required_content_files
         if value and not (has_metadata or has_files):
 
             if not has_metadata and not has_files:
@@ -1576,8 +1576,8 @@ class AbstractResource(ResourcePermissionsMixin):
         old_value = self.raccess.public  # is this a change?
 
         # check that there is sufficient resource content
-        has_metadata = self.has_required_metadata()
-        has_files = self.has_required_content_files(),
+        has_metadata = self.has_required_metadata
+        has_files = self.has_required_content_files
         if value and (not has_metadata or not has_files):
 
             if not has_metadata and not has_files:

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -126,9 +126,9 @@ def add_zip_file_contents_to_resource(pk, zip_file_path):
                 i, num_files)
             resource.save()
 
-        # This might make the resource unsuitable for public consumption 
+        # This might make the resource unsuitable for public consumption
         resource.update_public_and_discoverable()
-        # TODO: this is a bit of a lie because a different user requested the bag overwrite 
+        # TODO: this is a bit of a lie because a different user requested the bag overwrite
         utils.resource_modified(resource, resource.creator, overwrite_bag=False)
 
         # Call success callback
@@ -196,14 +196,14 @@ def create_bag_by_irods(resource_id):
             def_res=settings.HS_IRODS_LOCAL_ZONE_DEF_RES)
         bag_full_name = os.path.join(res.resource_federation_path, bag_full_name)
         bagit_files = [
-                '{fed_path}/{res_id}/bagit.txt'.format(fed_path=res.resource_federation_path,
-                                                       res_id=resource_id),
-                '{fed_path}/{res_id}/manifest-md5.txt'.format(
-                    fed_path=res.resource_federation_path, res_id=resource_id),
-                '{fed_path}/{res_id}/tagmanifest-md5.txt'.format(
-                    fed_path=res.resource_federation_path, res_id=resource_id),
-                '{fed_path}/bags/{res_id}.zip'.format(fed_path=res.resource_federation_path,
-                                                      res_id=resource_id)
+            '{fed_path}/{res_id}/bagit.txt'.format(fed_path=res.resource_federation_path,
+                                                   res_id=resource_id),
+            '{fed_path}/{res_id}/manifest-md5.txt'.format(
+                fed_path=res.resource_federation_path, res_id=resource_id),
+            '{fed_path}/{res_id}/tagmanifest-md5.txt'.format(
+                fed_path=res.resource_federation_path, res_id=resource_id),
+            '{fed_path}/bags/{res_id}.zip'.format(fed_path=res.resource_federation_path,
+                                                  res_id=resource_id)
         ]
     else:
         is_exist = istorage.exists(resource_id)
@@ -216,10 +216,10 @@ def create_bag_by_irods(resource_id):
         bagit_input_resource = "*DESTRESC='{def_res}'".format(
             def_res=settings.IRODS_DEFAULT_RESOURCE)
         bagit_files = [
-                '{res_id}/bagit.txt'.format(res_id=resource_id),
-                '{res_id}/manifest-md5.txt'.format(res_id=resource_id),
-                '{res_id}/tagmanifest-md5.txt'.format(res_id=resource_id),
-                'bags/{res_id}.zip'.format(res_id=resource_id)
+            '{res_id}/bagit.txt'.format(res_id=resource_id),
+            '{res_id}/manifest-md5.txt'.format(res_id=resource_id),
+            '{res_id}/tagmanifest-md5.txt'.format(res_id=resource_id),
+            'bags/{res_id}.zip'.format(res_id=resource_id)
         ]
 
     # only proceed when the resource is not deleted potentially by another request

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -126,6 +126,11 @@ def add_zip_file_contents_to_resource(pk, zip_file_path):
                 i, num_files)
             resource.save()
 
+        # This might make the resource unsuitable for public consumption 
+        resource.update_public_and_discoverable()
+        # TODO: this is a bit of a lie because a different user requested the bag overwrite 
+        utils.resource_modified(resource, resource.creator, overwrite_bag=False)
+
         # Call success callback
         resource.file_unpack_message = None
         resource.file_unpack_status = 'Done'

--- a/hs_core/tests/api/native/test_set_public.py
+++ b/hs_core/tests/api/native/test_set_public.py
@@ -1,0 +1,138 @@
+
+import os
+import tempfile
+import zipfile
+import shutil
+from dateutil import parser
+from unittest import TestCase
+import datetime as dtime
+
+from django.contrib.auth.models import Group, User
+from django.utils import timezone
+
+from hs_core.hydroshare import resource, get_resource_by_shortkey
+from hs_core.tests.api.utils import MyTemporaryUploadedFile
+from hs_core.models import GenericResource
+from hs_core.testing import MockIRODSTestCaseMixin
+from hs_core import hydroshare
+from hs_core.hydroshare.utils import QuotaException, resource_pre_create_actions
+
+
+class TestCreateResource(MockIRODSTestCaseMixin, TestCase):
+    def setUp(self):
+        super(TestCreateResource, self).setUp()
+
+        self.tmp_dir = tempfile.mkdtemp()
+        self.hs_group, _ = Group.objects.get_or_create(name='Hydroshare Author')
+        # create a user
+        self.user = hydroshare.create_account(
+            'test_user@email.com',
+            username='mytestuser',
+            first_name='some_first_name',
+            last_name='some_last_name',
+            superuser=False,
+            groups=[self.hs_group]
+        )
+        # create files
+        file_one = os.path.join(self.tmp_dir,"test1.txt") 
+
+        open(file_one, "w").close()
+
+        # open files for read and upload
+        self.file_one = open(file_one, "r")
+
+        self.res = resource.create_resource(
+            'GenericResource',
+            self.user,
+            'My Test Resource',
+            files=(self.file_one,)
+            )
+
+    def tearDown(self):
+        super(TestCreateResource, self).tearDown()
+
+        shutil.rmtree(self.tmp_dir)
+
+        self.res.delete()
+        self.user.uaccess.delete()
+        self.user.delete()
+        self.hs_group.delete()
+
+        User.objects.all().delete()
+        Group.objects.all().delete()
+        GenericResource.objects.all().delete()
+        self.file_one.close()
+        os.remove(self.file_one.name)
+
+    def test_resource_setAVU_and_getAVU(self):
+        """ test that setAVU and getAVU work predictably """
+        self.res.setAVU("foo", "bar")
+        self.assertEqual(self.res.getAVU("foo"), "bar")
+        self.res.setAVU("foo", "cat") 
+        self.assertEqual(self.res.getAVU("foo"), "cat")
+
+    def test_set_public_and_set_discoverable(self):
+        """ test that resource.set_public and resource.set_discoverable work properly. """
+
+        # default resource was constructed to be publishable 
+        self.assertTrue(self.res.can_be_public_or_discoverable) 
+        self.assertFalse(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+        self.res.set_public(False) 
+        self.assertFalse(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+        self.res.set_discoverable(True) 
+        self.assertTrue(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+        self.res.set_discoverable(False) 
+        self.assertFalse(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.res.set_public(True) 
+        self.assertTrue(self.res.raccess.discoverable) 
+        self.assertTrue(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'true') 
+        self.res.set_discoverable(False) 
+        self.assertFalse(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+        
+        # now try some things that won't work 
+        # first make the resource unacceptable to be discoverable
+        self.res.metadata.title.value = ''
+        self.res.metadata.title.save()
+        self.assertFalse(self.res.can_be_public_or_discoverable) 
+        with self.assertRaises(ValidationError):
+            self.res.set_public(True) 
+        self.assertFalse(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+        with self.assertRaises(ValidationError):
+            self.res.set_discoverable(True) 
+
+    def test_update_public_and_discoverable(self):
+        """ test that resource.update_public_and_discoverable works properly. """
+
+        self.assertTrue(self.res.can_be_public_or_discoverable) 
+        self.res.update_public_and_discoverable()
+        self.assertFalse(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+
+        # intentionally and greviously violate constraints
+        self.res.raccess.discoverable = True
+        self.res.raccess.public = True
+        self.res.raccess.save()
+        self.res.setAVU('isPublic', True) 
+
+        # There's a problem now 
+        self.assertFalse(self.res.can_be_public_or_discoverable) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'true') 
+
+        # update should correct the problem
+        self.res.update_public_and_discoverable()
+        self.assertFalse(self.res.raccess.discoverable) 
+        self.assertFalse(self.res.raccess.public) 
+        self.assertEqual(self.res.getAVU('isPublic'), 'false') 

--- a/hs_core/tests/api/native/test_set_public.py
+++ b/hs_core/tests/api/native/test_set_public.py
@@ -1,21 +1,16 @@
 
 import os
 import tempfile
-import zipfile
 import shutil
-from dateutil import parser
 from unittest import TestCase
-import datetime as dtime
 
 from django.contrib.auth.models import Group, User
-from django.utils import timezone
+from django.core.exceptions import ValidationError
 
-from hs_core.hydroshare import resource, get_resource_by_shortkey
-from hs_core.tests.api.utils import MyTemporaryUploadedFile
+from hs_core.hydroshare import resource
 from hs_core.models import GenericResource
 from hs_core.testing import MockIRODSTestCaseMixin
 from hs_core import hydroshare
-from hs_core.hydroshare.utils import QuotaException, resource_pre_create_actions
 
 
 class TestCreateResource(MockIRODSTestCaseMixin, TestCase):
@@ -34,7 +29,7 @@ class TestCreateResource(MockIRODSTestCaseMixin, TestCase):
             groups=[self.hs_group]
         )
         # create files
-        file_one = os.path.join(self.tmp_dir,"test1.txt") 
+        file_one = os.path.join(self.tmp_dir, "test1.txt")
 
         open(file_one, "w").close()
 
@@ -68,71 +63,71 @@ class TestCreateResource(MockIRODSTestCaseMixin, TestCase):
         """ test that setAVU and getAVU work predictably """
         self.res.setAVU("foo", "bar")
         self.assertEqual(self.res.getAVU("foo"), "bar")
-        self.res.setAVU("foo", "cat") 
+        self.res.setAVU("foo", "cat")
         self.assertEqual(self.res.getAVU("foo"), "cat")
 
     def test_set_public_and_set_discoverable(self):
         """ test that resource.set_public and resource.set_discoverable work properly. """
 
-        # default resource was constructed to be publishable 
-        self.assertTrue(self.res.can_be_public_or_discoverable) 
-        self.assertFalse(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
-        self.res.set_public(False) 
-        self.assertFalse(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
-        self.res.set_discoverable(True) 
-        self.assertTrue(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
-        self.res.set_discoverable(False) 
-        self.assertFalse(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.res.set_public(True) 
-        self.assertTrue(self.res.raccess.discoverable) 
-        self.assertTrue(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'true') 
-        self.res.set_discoverable(False) 
-        self.assertFalse(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
-        
-        # now try some things that won't work 
+        # default resource was constructed to be publishable
+        self.assertTrue(self.res.can_be_public_or_discoverable)
+        self.assertFalse(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'false')
+        self.res.set_public(False)
+        self.assertFalse(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'false')
+        self.res.set_discoverable(True)
+        self.assertTrue(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'false')
+        self.res.set_discoverable(False)
+        self.assertFalse(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.res.set_public(True)
+        self.assertTrue(self.res.raccess.discoverable)
+        self.assertTrue(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'true')
+        self.res.set_discoverable(False)
+        self.assertFalse(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'false')
+
+        # now try some things that won't work
         # first make the resource unacceptable to be discoverable
         self.res.metadata.title.value = ''
         self.res.metadata.title.save()
-        self.assertFalse(self.res.can_be_public_or_discoverable) 
+        self.assertFalse(self.res.can_be_public_or_discoverable)
         with self.assertRaises(ValidationError):
-            self.res.set_public(True) 
-        self.assertFalse(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+            self.res.set_public(True)
+        self.assertFalse(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'false')
         with self.assertRaises(ValidationError):
-            self.res.set_discoverable(True) 
+            self.res.set_discoverable(True)
 
     def test_update_public_and_discoverable(self):
         """ test that resource.update_public_and_discoverable works properly. """
 
-        self.assertTrue(self.res.can_be_public_or_discoverable) 
+        self.assertTrue(self.res.can_be_public_or_discoverable)
         self.res.update_public_and_discoverable()
-        self.assertFalse(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+        self.assertFalse(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'false')
 
         # intentionally and greviously violate constraints
         self.res.raccess.discoverable = True
         self.res.raccess.public = True
         self.res.raccess.save()
-        self.res.setAVU('isPublic', True) 
+        self.res.setAVU('isPublic', True)
 
-        # There's a problem now 
-        self.assertFalse(self.res.can_be_public_or_discoverable) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'true') 
+        # There's a problem now
+        self.assertFalse(self.res.can_be_public_or_discoverable)
+        self.assertEqual(self.res.getAVU('isPublic'), 'true')
 
         # update should correct the problem
         self.res.update_public_and_discoverable()
-        self.assertFalse(self.res.raccess.discoverable) 
-        self.assertFalse(self.res.raccess.public) 
-        self.assertEqual(self.res.getAVU('isPublic'), 'false') 
+        self.assertFalse(self.res.raccess.discoverable)
+        self.assertFalse(self.res.raccess.public)
+        self.assertEqual(self.res.getAVU('isPublic'), 'false')

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -407,7 +407,7 @@ def update_metadata_element(request, shortkey, element_name, element_id, *args, 
                     # some database error occurred
                     err_msg = err_msg.format(element_name, exp.message)
                     request.session['validation_error'] = err_msg
-                # TODO: it's brittle to embed validation logic at this level. 
+                # TODO: it's brittle to embed validation logic at this level.
                 if element_name == 'title':
                     res.update_public_and_discoverable()
                 if is_update_success:
@@ -478,7 +478,7 @@ def delete_metadata_element(request, shortkey, element_name, element_id, *args, 
 
 def delete_file(request, shortkey, f, *args, **kwargs):
     res, _, user = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
-    hydroshare.delete_resource_file(shortkey, f, user)
+    hydroshare.delete_resource_file(shortkey, f, user)  # calls resource_modified
     request.session['resource-mode'] = 'edit'
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
@@ -491,12 +491,12 @@ def delete_multiple_files(request, shortkey, *args, **kwargs):
     for f_id in f_id_list:
         f_id = f_id.strip()
         try:
-            hydroshare.delete_resource_file(shortkey, f_id, user)
+            hydroshare.delete_resource_file(shortkey, f_id, user)  # calls resource_modified
         except ObjectDoesNotExist as ex:
             # Since some specific resource types such as feature resource type delete all other
             # dependent content files together when one file is deleted, we make this specific
             # ObjectDoesNotExist exception as legitimate in deplete_multiple_files() without
-            # raising this specific exceptoin
+            # raising this specific exception
             logger.debug(ex.message)
             continue
     request.session['resource-mode'] = 'edit'
@@ -1560,7 +1560,7 @@ def _unshare_resource_with_users(request, requesting_user, users_to_unshare_with
 
 def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_value):
     """
-    Set flags 'public', 'discoverable', shareable'
+    Set flags 'public', 'discoverable', 'shareable'
 
     This routine generates appropriate messages for the REST API and thus differs from
     AbstractResource.set_public, set_discoverable, which raise exceptions.

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -470,6 +470,7 @@ def file_download_url_mapper(request, shortkey):
 def delete_metadata_element(request, shortkey, element_name, element_id, *args, **kwargs):
     res, _, _ = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
     res.metadata.delete_element(element_name, element_id)
+    res.update_public_and_discoverable()
     resource_modified(res, request.user, overwrite_bag=False)
     request.session['resource-mode'] = 'edit'
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
@@ -676,7 +677,7 @@ def set_resource_flag(request, shortkey, *args, **kwargs):
     if t == 'make_public':
         _set_resource_sharing_status(request, user, res, flag_to_set='public', flag_value=True)
     elif t == 'make_private' or t == 'make_not_discoverable':
-        _set_resource_sharing_status(request, user, res, flag_to_set='public', flag_value=False)
+        _set_resource_sharing_status(request, user, res, flag_to_set='discoverable', flag_value=False)
     elif t == 'make_discoverable':
         _set_resource_sharing_status(request, user, res, flag_to_set='discoverable', flag_value=True)
     elif t == 'make_not_shareable':

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -273,7 +273,7 @@ def add_metadata_element(request, shortkey, element_name, *args, **kwargs):
         # seems the user wants to delete all keywords - no need for pre-check in signal handler
         res.metadata.subjects.all().delete()
         is_add_success = True
-        res.update_public_and_discoverable()  # set to private if necessary now 
+        res.update_public_and_discoverable()  # set to private if necessary now
         resource_modified(res, request.user, overwrite_bag=False)
     else:
         handler_response = pre_metadata_element_create.send(sender=sender_resource,
@@ -323,7 +323,7 @@ def add_metadata_element(request, shortkey, element_name, *args, **kwargs):
                     err_msg = err_msg.format(element_name, response['errors'])
 
     # TODO: This is curious, because it seems to allow something to have insufficient metadata
-    # TODO: and remain discoverable. Is this an error? 
+    # TODO: and remain discoverable. Is this an error?
     if request.is_ajax():
         if is_add_success:
             res_public_status = 'public' if res.raccess.public else 'not public'
@@ -416,7 +416,7 @@ def update_metadata_element(request, shortkey, element_name, element_id, *args, 
                 err_msg = err_msg.format(element_name, response['errors'])
 
     # TODO: This is curious, because it seems to allow something to have insufficient metadata
-    # TODO: and remain discoverable. Is this an error? 
+    # TODO: and remain discoverable. Is this an error?
     if request.is_ajax():
         if is_update_success:
             res_public_status = 'public' if res.raccess.public else 'not public'
@@ -1619,13 +1619,13 @@ def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_valu
 
     elif flag_to_set == 'discoverable':
         try:
-            resource.set_discoverable(flag_value, user=session.user)  # checks access control
+            resource.set_discoverable(flag_value, user)  # checks access control
         except ValidationError as v:
             messages.error(request, v.message)
 
     elif flag_to_set == 'public':
         try:
-            resource.set_public(flag_value, user=session.user)  # checks access control
+            resource.set_public(flag_value, user)  # checks access control
         except ValidationError as v:
             messages.error(request, v.message)
 

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -32,20 +32,27 @@ from mezzanine.utils.email import subject_template, send_mail_template
 import autocomplete_light
 from inplaceeditform.commons import get_dict_from_obj, apply_filters
 from inplaceeditform.views import _get_http_response, _get_adaptor
+from django_irods.storage import IrodsStorage
 from django_irods.icommands import SessionException
 
 from hs_core import hydroshare
 from hs_core.hydroshare.utils import get_resource_by_shortkey, resource_modified, resolve_request
-from .utils import authorize, upload_from_irods, ACTION_TO_AUTHORIZE, \
+from .utils import authorize, upload_from_irods, ACTION_TO_AUTHORIZE, run_script_to_update_hyrax_input_files, \
     get_my_resources_list, send_action_to_take_email, get_coverage_data_dict
 from hs_core.models import GenericResource, resource_processor, CoreMetaData, Subject
 from hs_core.hydroshare.resource import METADATA_STATUS_SUFFICIENT, METADATA_STATUS_INSUFFICIENT
 
+from . import resource_rest_api
+from . import resource_metadata_rest_api
+from . import user_rest_api
+from . import resource_folder_hierarchy
+
+from . import resource_access_api
+from . import resource_folder_rest_api
+
 from hs_core.hydroshare import utils
 
-from hs_core.signals import pre_metadata_element_create,  pre_metadata_element_update, \
-    post_metadata_element_update, post_delete_resource
-
+from hs_core.signals import *
 from hs_access_control.models import PrivilegeCodes, GroupMembershipRequest, GroupResourcePrivilege
 
 from hs_collection_resource.models import CollectionDeletedResource
@@ -68,7 +75,7 @@ def verify(request, *args, **kwargs):
     u = User.objects.get(pk=pk)
     if u.email == email:
         if not u.is_active:
-            u.is_active = True
+            u.is_active=True
             u.save()
             u.groups.add(Group.objects.get(name="Hydroshare Author"))
         from django.contrib.auth import login
@@ -160,8 +167,7 @@ def add_files_to_resource(request, shortkey, *args, **kwargs):
 
 
 def _get_resource_sender(element_name, resource):
-    core_metadata_element_names = [el_name.lower() for el_name in
-                                   CoreMetaData.get_supported_element_names()]
+    core_metadata_element_names = [el_name.lower() for el_name in CoreMetaData.get_supported_element_names()]
 
     if element_name in core_metadata_element_names:
         sender_resource = GenericResource().__class__
@@ -175,9 +181,7 @@ def get_supported_file_types_for_resource_type(request, resource_type, *args, **
     resource_cls = hydroshare.check_resource_type(resource_type)
     if request.is_ajax:
         # TODO: use try catch
-        ajax_response_data = {
-            'file_types': json.dumps(resource_cls.get_supported_upload_file_types())
-        }
+        ajax_response_data = {'file_types': json.dumps(resource_cls.get_supported_upload_file_types())}
         return HttpResponse(json.dumps(ajax_response_data))
     else:
         return HttpResponseRedirect(request.META['HTTP_REFERER'])
@@ -234,7 +238,6 @@ def update_key_value_metadata(request, shortkey, *args, **kwargs):
 
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
-
 @api_view(['POST'])
 def update_key_value_metadata_public(request, pk):
     res, _, _ = authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
@@ -246,7 +249,7 @@ def update_key_value_metadata_public(request, pk):
 
     try:
         res.save()
-    except Error:
+    except Error as ex:
         is_update_success = False
 
     if is_update_success:
@@ -273,7 +276,7 @@ def add_metadata_element(request, shortkey, element_name, *args, **kwargs):
         # seems the user wants to delete all keywords - no need for pre-check in signal handler
         res.metadata.subjects.all().delete()
         is_add_success = True
-        res.update_public_and_discoverable()  # set to private if necessary now
+        res.update_public_and_discoverable()
         resource_modified(res, request.user, overwrite_bag=False)
     else:
         handler_response = pre_metadata_element_create.send(sender=sender_resource,
@@ -322,8 +325,6 @@ def add_metadata_element(request, shortkey, element_name, *args, **kwargs):
                 elif "errors" in response:
                     err_msg = err_msg.format(element_name, response['errors'])
 
-    # TODO: This is curious, because it seems to allow something to have insufficient metadata
-    # TODO: and remain discoverable. Is this an error?
     if request.is_ajax():
         if is_add_success:
             res_public_status = 'public' if res.raccess.public else 'not public'
@@ -406,17 +407,14 @@ def update_metadata_element(request, shortkey, element_name, element_id, *args, 
                     # some database error occurred
                     err_msg = err_msg.format(element_name, exp.message)
                     request.session['validation_error'] = err_msg
+                # TODO: it's brittle to embed validation logic at this level. 
                 if element_name == 'title':
-                    # TODO: why only for title?
                     res.update_public_and_discoverable()
-
                 if is_update_success:
                     resource_modified(res, request.user, overwrite_bag=False)
             elif "errors" in response:
                 err_msg = err_msg.format(element_name, response['errors'])
 
-    # TODO: This is curious, because it seems to allow something to have insufficient metadata
-    # TODO: and remain discoverable. Is this an error?
     if request.is_ajax():
         if is_update_success:
             res_public_status = 'public' if res.raccess.public else 'not public'
@@ -462,8 +460,7 @@ def update_metadata_element(request, shortkey, element_name, element_id, *args, 
 def file_download_url_mapper(request, shortkey):
     """ maps the file URIs in resourcemap document to django_irods download view function"""
 
-    resource, _, _ = authorize(request, shortkey,
-                               needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
+    resource, _, _ = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
     istorage = resource.get_irods_storage()
     irods_file_path = '/'.join(request.path.split('/')[2:-1])
     file_download_url = istorage.url(irods_file_path)
@@ -506,8 +503,7 @@ def delete_multiple_files(request, shortkey, *args, **kwargs):
 
 
 def delete_resource(request, shortkey, *args, **kwargs):
-    res, _, user = authorize(request, shortkey,
-                             needed_permission=ACTION_TO_AUTHORIZE.DELETE_RESOURCE)
+    res, _, user = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.DELETE_RESOURCE)
 
     res_title = res.metadata.title
     res_id = shortkey
@@ -530,13 +526,13 @@ def delete_resource(request, shortkey, *args, **kwargs):
     # create a CollectionDeletedResource object which can then be used to list collection deleted
     # resources on collection resource landing page
     for collection_res in resource_related_collections:
-        o = CollectionDeletedResource.objects.create(
-            resource_title=res_title,
-            deleted_by=user,
-            resource_id=res_id,
-            resource_type=res_type,
-            collection=collection_res
-        )
+        o=CollectionDeletedResource.objects.create(
+             resource_title=res_title,
+             deleted_by=user,
+             resource_id=res_id,
+             resource_type=res_type,
+             collection=collection_res
+             )
         o.resource_owners.add(*owners_list)
 
     post_delete_resource.send(sender=type(res), request=request, user=user,
@@ -551,15 +547,12 @@ def delete_resource(request, shortkey, *args, **kwargs):
 
 def rep_res_bag_to_irods_user_zone(request, shortkey, *args, **kwargs):
     '''
-    This function needs to be called via AJAX. The function replicates resource bag to
-    iRODS user zone on users.hydroshare.org which is federated with hydroshare zone
-    under the iRODS user account corresponding to a HydroShare user. This function
-    should only be called or exposed to be called from web interface when a
-    corresponding iRODS user account on hydroshare user Zone exists. The purpose of
-    this function is to allow HydroShare resource bag that a HydroShare user has access
-    to be copied to HydroShare user's iRODS space in HydroShare user zone so that users
-    can do analysis or computations on the resource
-
+    This function needs to be called via AJAX. The function replicates resource bag to iRODS user zone on users.hydroshare.org
+    which is federated with hydroshare zone under the iRODS user account corresponding to a HydroShare user. This function
+    should only be called or exposed to be called from web interface when a corresponding iRODS user account on hydroshare
+    user Zone exists. The purpose of this function is to allow HydroShare resource bag that a HydroShare user has access
+    to be copied to HydroShare user's iRODS space in HydroShare user zone so that users can do analysis or computations on
+    the resource
     Args:
         request: an AJAX request
         shortkey: UUID of the resource to be copied to the login user's iRODS user space
@@ -567,28 +560,23 @@ def rep_res_bag_to_irods_user_zone(request, shortkey, *args, **kwargs):
     Returns:
         JSON list that indicates status of resource replication, i.e., success or error
     '''
-    res, authorized, user = authorize(request, shortkey,
-                                      needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE,
-                                      raises_exception=False)
+    res, authorized, user = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE, raises_exception=False)
     if not authorized:
         return HttpResponse(
-            json.dumps({"error": "You are not authorized to replicate this resource."}),
-            content_type="application/json"
+        json.dumps({"error": "You are not authorized to replicate this resource."}),
+        content_type="application/json"
         )
 
     try:
         utils.replicate_resource_bag_to_user_zone(user, shortkey)
         return HttpResponse(
-            json.dumps({
-                "success":
-                "This resource bag zip file has been successfully copied to your iRODS user zone."
-            }),
-            content_type="application/json"
+            json.dumps({"success": "This resource bag zip file has been successfully copied to your iRODS user zone."}),
+            content_type = "application/json"
         )
     except SessionException as ex:
         return HttpResponse(
-            json.dumps({"error": ex.stderr}),
-            content_type="application/json"
+        json.dumps({"error": ex.stderr}),
+        content_type="application/json"
         )
 
 
@@ -628,7 +616,7 @@ def create_new_version_resource(request, shortkey, *args, **kwargs):
             res.locked_time = None
             res.save()
         else:
-            # cannot create new version for resource since the resource is locked by another user
+            # cannot create new version for this resource since the resource is locked by another user
             request.session['resource_creation_error'] = 'Failed to create a new version for ' \
                                                          'this resource since another user is ' \
                                                          'creating a new version for this ' \
@@ -637,8 +625,8 @@ def create_new_version_resource(request, shortkey, *args, **kwargs):
 
     new_resource = None
     try:
-        # lock the resource to prevent concurrent new version creation since only one new
-        # version for an obsoleted resource is allowed
+        # lock the resource to prevent concurrent new version creation since only one new version for an
+        # obsoleted resource is allowed
         res.locked_time = datetime.datetime.now(pytz.utc)
         res.save()
         new_resource = hydroshare.create_empty_resource(shortkey, user)
@@ -670,8 +658,7 @@ def create_new_version_resource_public(request, pk):
 
 def publish(request, shortkey, *args, **kwargs):
     # only resource owners are allowed to change resource flags (e.g published)
-    res, _, _ = authorize(request, shortkey,
-                          needed_permission=ACTION_TO_AUTHORIZE.SET_RESOURCE_FLAG)
+    res, _, _ = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.SET_RESOURCE_FLAG)
 
     try:
         hydroshare.publish_resource(request.user, shortkey)
@@ -684,20 +671,18 @@ def publish(request, shortkey, *args, **kwargs):
 
 def set_resource_flag(request, shortkey, *args, **kwargs):
     # only resource owners are allowed to change resource flags
-    res, _, user = authorize(request, shortkey,
-                             needed_permission=ACTION_TO_AUTHORIZE.SET_RESOURCE_FLAG)
+    res, _, user = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.SET_RESOURCE_FLAG)
     t = resolve_request(request).get('t', None)
     if t == 'make_public':
         _set_resource_sharing_status(request, user, res, flag_to_set='public', flag_value=True)
     elif t == 'make_private' or t == 'make_not_discoverable':
         _set_resource_sharing_status(request, user, res, flag_to_set='public', flag_value=False)
     elif t == 'make_discoverable':
-        _set_resource_sharing_status(request, user, res, flag_to_set='discoverable',
-                                     flag_value=True)
+        _set_resource_sharing_status(request, user, res, flag_to_set='discoverable', flag_value=True)
     elif t == 'make_not_shareable':
         _set_resource_sharing_status(request, user, res, flag_to_set='shareable', flag_value=False)
     elif t == 'make_shareable':
-        _set_resource_sharing_status(request, user, res, flag_to_set='shareable', flag_value=True)
+       _set_resource_sharing_status(request, user, res, flag_to_set='shareable', flag_value=True)
 
     if request.META.get('HTTP_REFERER', None):
         request.session['resource-mode'] = request.POST.get('resource-mode', 'view')
@@ -718,7 +703,6 @@ def set_resource_flag_public(request, pk):
             return HttpResponse(message, status=400)
     return response
 
-
 def share_resource_with_user(request, shortkey, privilege, user_id, *args, **kwargs):
     """this view function is expected to be called by ajax"""
     return _share_resource(request, shortkey, privilege, user_id, user_or_group='user')
@@ -736,10 +720,9 @@ def _share_resource(request, shortkey, privilege, user_or_group_id, user_or_grou
     :param shortkey: id of the resource to share with
     :param privilege: access privilege need for the resource
     :param user_or_group_id: id of the user or group with whom the resource to be shared
-    :param user_or_group: indicates if the resource to be shared with a user or group.
-        A value of 'user' will share the resource with a user whose id is provided
-        with the parameter 'user_or_group_id'.  Any other value for this parameter assumes
-        resource to be shared with a group.
+    :param user_or_group: indicates if the resource to be shared with a user or group. A value of 'user' will share
+                          the resource with a user whose id is provided with the parameter 'user_or_group_id'.
+                          Any other value for this parameter assumes resource to be shared with a group.
     :return:
     """
 
@@ -800,8 +783,7 @@ def _share_resource(request, shortkey, privilege, user_or_group_id, user_or_grou
             picture_url = user_to_share_with.userprofile.picture.url
 
         ajax_response_data = {'status': status, 'name': user_to_share_with.get_full_name(),
-                              'username': user_to_share_with.username,
-                              'privilege_granted': privilege,
+                              'username': user_to_share_with.username, 'privilege_granted': privilege,
                               'current_user_privilege': current_user_privilege,
                               'profile_pic': picture_url, 'is_current_user': is_current_user,
                               'error_msg': err_message}
@@ -935,25 +917,24 @@ def save_ajax(request):
         if form.is_valid():
             adaptor.save(value_edit_with_filter)
             return _get_http_response({'errors': False,
-                                       'value': adaptor.render_value_edit()})
-        messages = []  # The error is for another field that you are editing
+                                        'value': adaptor.render_value_edit()})
+        messages = [] # The error is for another field that you are editing
         for field_name_error, errors_field in form.errors.items():
             for error in errors_field:
                 messages.append("%s: %s" % (field_name_error, unicode(error)))
         message_i18n = ','.join(messages)
         return _get_http_response({'errors': message_i18n})
-    except ValidationError as error:  # The error is for a field that you are editing
+    except ValidationError as error: # The error is for a field that you are editing
         message_i18n = ', '.join([u"%s" % m for m in error.messages])
         return _get_http_response({'errors': message_i18n})
 
 
 def verify_account(request, *args, **kwargs):
     context = {
-        'username': request.GET['username'],
-        'email': request.GET['email']
-    }
-    return render_to_response('pages/verify-account.html', context,
-                              context_instance=RequestContext(request))
+            'username' : request.GET['username'],
+            'email' : request.GET['email']
+        }
+    return render_to_response('pages/verify-account.html', context, context_instance=RequestContext(request))
 
 
 @processor_for('resend-verification-email')
@@ -971,11 +952,12 @@ go to http://{domain}/verify/{token}/ and verify your account.
             token=token
         ))
 
-        context = {'is_email_sent': True}
-        return render_to_response('pages/verify-account.html', context,
-                                  context_instance=RequestContext(request))
+        context = {
+            'is_email_sent' : True
+        }
+        return render_to_response('pages/verify-account.html', context, context_instance=RequestContext(request))
     except:
-        pass  # TODO: should log this instead of ignoring it.
+        pass # FIXME should log this instead of ignoring it.
 
 
 class FilterForm(forms.Form):
@@ -1046,7 +1028,6 @@ class GroupUpdateForm(GroupForm):
         privacy_level = frm_data['privacy_level']
         self._set_privacy_level(group_to_update, privacy_level)
 
-
 @processor_for('my-resources')
 @login_required
 def my_resources(request, page):
@@ -1067,8 +1048,7 @@ def add_generic_context(request, page):
                                       widget=autocomplete_light.ChoiceWidget("UserAutocomplete"))
 
     class AddGroupForm(forms.Form):
-        group = forms.ModelChoiceField(Group.objects.filter(gaccess__active=True)
-                                       .exclude(name='Hydroshare Author').all(),
+        group = forms.ModelChoiceField(Group.objects.filter(gaccess__active=True).exclude(name='Hydroshare Author').all(),
                                        widget=autocomplete_light.ChoiceWidget("GroupAutocomplete"))
 
     return {
@@ -1083,8 +1063,7 @@ def add_generic_context(request, page):
 
 @login_required
 def create_resource_select_resource_type(request, *args, **kwargs):
-    return render_to_response('pages/create-resource.html',
-                              context_instance=RequestContext(request))
+    return render_to_response('pages/create-resource.html', context_instance=RequestContext(request))
 
 
 @login_required
@@ -1144,16 +1123,16 @@ def create_resource(request, *args, **kwargs):
         return JsonResponse(ajax_response_data)
 
     resource = hydroshare.create_resource(
-        resource_type=request.POST['resource-type'],
-        owner=request.user,
-        title=res_title,
-        metadata=metadata,
-        files=resource_files,
-        source_names=source_names,
-        # TODO: should probably be resource_federation_path like it is set to.
-        fed_res_path=fed_res_path[0] if len(fed_res_path) == 1 else '',
-        move=(fed_copy_or_move == 'move'),
-        content=res_title
+            resource_type=request.POST['resource-type'],
+            owner=request.user,
+            title=res_title,
+            metadata=metadata,
+            files=resource_files,
+            source_names=source_names,
+            # TODO: should probably be resource_federation_path like it is set to.
+            fed_res_path=fed_res_path[0] if len(fed_res_path) == 1 else '',
+            move=(fed_copy_or_move == 'move'),
+            content=res_title
     )
 
     try:
@@ -1210,19 +1189,16 @@ def update_user_group(request, group_id, *args, **kwargs):
                 messages.success(request, "Group update was successful.")
             except IntegrityError as ex:
                 if group_form.cleaned_data['name'] in ex.message:
-                    message = "Group name '{}' already exists".format(
-                        group_form.cleaned_data['name'])
+                    message = "Group name '{}' already exists".format(group_form.cleaned_data['name'])
                     messages.error(request, "Group update errors: {}.".format(message))
                 else:
                     messages.error(request, "Group update errors:{}.".format(ex.message))
         else:
             messages.error(request, "Group update errors:{}.".format(group_form.errors.as_json))
     else:
-        messages.error(request,
-                       "Group update errors: You don't have permission to update this group")
+        messages.error(request, "Group update errors: You don't have permission to update this group")
 
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
-
 
 @login_required
 def delete_user_group(request, group_id, *args, **kwargs):
@@ -1250,7 +1226,6 @@ def restore_user_group(request, group_id, *args, **kwargs):
 
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
-
 @login_required
 def share_group_with_user(request, group_id, user_id, privilege, *args, **kwargs):
     requesting_user = request.user
@@ -1268,9 +1243,7 @@ def share_group_with_user(request, group_id, user_id, privilege, *args, **kwargs
     if access_privilege != PrivilegeCodes.NONE:
         if requesting_user.uaccess.can_share_group(group_to_share, access_privilege):
             try:
-                requesting_user.uaccess.share_group_with_user(group_to_share,
-                                                              user_to_share_with,
-                                                              access_privilege)
+                requesting_user.uaccess.share_group_with_user(group_to_share, user_to_share_with, access_privilege)
                 messages.success(request, "User successfully added to the group")
             except PermissionDenied as ex:
                 messages.error(request, ex.message)
@@ -1315,12 +1288,12 @@ def unshare_group_with_user(request, group_id, user_id, *args, **kwargs):
 @login_required
 def make_group_membership_request(request, group_id, user_id=None, *args, **kwargs):
     """
-    Allows either an owner of the group to invite a user to join a group or a user
-    to make a request to join a group
+    Allows either an owner of the group to invite a user to join a group or a user to make a request
+    to join a group
     :param request: the user who is making the request
     :param group_id: ID of the group for which the join request/invitation to me made
-    :param user_id: needed only when an owner is inviting a user to join a group.
-    This is the id of the user the owner is inviting
+    :param user_id: needed only when an owner is inviting a user to join a group. This is the id of the user the owner
+                    is inviting
     :return:
     """
     requesting_user = request.user
@@ -1362,41 +1335,35 @@ def make_group_membership_request(request, group_id, user_id=None, *args, **kwar
 
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
-
 def group_membership(request, uidb36, token, membership_request_id, **kwargs):
     """
     View for the link in the verification email that was sent to a user
     when they request/invite to join a group.
-    User is logged in and the request to join a group is accepted. Then the user is
-    redirected to the group profile page of the group for which the membership got accepted.
+    User is logged in and the request to join a group is accepted. Then the user is redirected to the group
+    profile page of the group for which the membership got accepted.
 
     :param uidb36: ID of the user to whom the email was sent (part of the link in the email)
     :param token: token that was part of the link in the email
-    :param membership_request_id: ID of the GroupMembershipRequest object (part of the link
-        in the email)
+    :param membership_request_id: ID of the GroupMembershipRequest object (part of the link in the email)
     """
     membership_request = GroupMembershipRequest.objects.filter(id=membership_request_id).first()
     if membership_request is not None:
         if membership_request.group_to_join.gaccess.active:
             user = authenticate(uidb36=uidb36, token=token, is_active=True)
             if user is not None:
-                user.uaccess.act_on_group_membership_request(membership_request,
-                                                             accept_request=True)
+                user.uaccess.act_on_group_membership_request(membership_request, accept_request=True)
                 auth_login(request, user)
                 # send email to notify membership acceptance
                 _send_email_on_group_membership_acceptance(membership_request)
                 if membership_request.invitation_to is not None:
-                    message = "You just joined the group '{}'"\
-                        .format(membership_request.group_to_join.name)
+                    message = "You just joined the group '{}'".format(membership_request.group_to_join.name)
                 else:
-                    message = "User '{}' just joined the group '{}'"\
-                        .format(membership_request.request_from.first_name,
-                                membership_request.group_to_join.name)
+                    message = "User '{}' just joined the group '{}'".format(membership_request.request_from.first_name,
+                                                                            membership_request.group_to_join.name)
 
                 messages.info(request, message)
                 # redirect to group profile page
-                return HttpResponseRedirect('/group/{}/'
-                                            .format(membership_request.group_to_join.id))
+                return HttpResponseRedirect('/group/{}/'.format(membership_request.group_to_join.id))
             else:
                 messages.error(request, "The link you clicked is no longer valid.")
                 return redirect("/")
@@ -1413,11 +1380,10 @@ def act_on_group_membership_request(request, membership_request_id, action, *arg
     """
     Take action (accept or decline) on group membership request
 
-    :param request: requesting user is either owner of the group taking action on a
-        request from a user or a user taking action on a invitation to join a group from
-        a group owner
-    :param membership_request_id: id of the membership request object
-        (an instance of GroupMembershipRequest) to act on
+    :param request: requesting user is either owner of the group taking action on a request from a user
+                    or a user taking action on a invitation to join a group from a group owner
+    :param membership_request_id: id of the membership request object (an instance of GroupMembershipRequest)
+                                  to act on
     :param action: need to have a value of either 'accept' or 'decline'
     :return:
     """
@@ -1432,8 +1398,7 @@ def act_on_group_membership_request(request, membership_request_id, action, *arg
     else:
         if membership_request.group_to_join.gaccess.active:
             try:
-                user_acting.uaccess.act_on_group_membership_request(membership_request,
-                                                                    accept_request)
+                user_acting.uaccess.act_on_group_membership_request(membership_request, accept_request)
                 if accept_request:
                     message = 'Membership request accepted'
                     messages.success(request, message)
@@ -1457,7 +1422,7 @@ def get_file(request, *args, **kwargs):
     name = kwargs['name']
     session = RodsSession("./", "/usr/bin")
     session.runCmd("iinit")
-    session.runCmd('iget', [name, 'tempfile.' + name])
+    session.runCmd('iget', [ name, 'tempfile.' + name ])
     return HttpResponse(open(name), content_type='x-binary/octet-stream')
 
 
@@ -1482,15 +1447,13 @@ def get_user_or_group_data(request, user_or_group_id, is_group, *args, **kwargs)
         user = utils.user_from_id(user_or_group_id)
 
         if user.userprofile.middle_name:
-            user_name = "{} {} {}".format(user.first_name, user.userprofile.middle_name,
-                                          user.last_name)
+            user_name = "{} {} {}".format(user.first_name, user.userprofile.middle_name, user.last_name)
         else:
             user_name = "{} {}".format(user.first_name, user.last_name)
 
         user_data['name'] = user_name
         user_data['email'] = user.email
-        user_data['url'] = '{domain}/user/{uid}/'.format(domain=utils.current_site_url(),
-                                                         uid=user.pk)
+        user_data['url'] = '{domain}/user/{uid}/'.format(domain=utils.current_site_url(), uid=user.pk)
         if user.userprofile.phone_1:
             user_data['phone'] = user.userprofile.phone_1
         elif user.userprofile.phone_2:
@@ -1508,8 +1471,7 @@ def get_user_or_group_data(request, user_or_group_id, is_group, *args, **kwargs)
                 address = user.userprofile.country
 
         user_data['address'] = address
-        user_data['organization'] = user.userprofile.organization \
-            if user.userprofile.organization else ''
+        user_data['organization'] = user.userprofile.organization if user.userprofile.organization else ''
         user_data['website'] = user.userprofile.website if user.userprofile.website else ''
     else:
         group = utils.group_from_id(user_or_group_id)
@@ -1537,8 +1499,7 @@ def _send_email_on_group_membership_acceptance(membership_request):
         <p>Thank you</p>
         <p>The HydroShare Team</p>
         """.format(membership_request.request_from.first_name,
-                   membership_request.invitation_to.first_name,
-                   membership_request.group_to_join.name)
+                   membership_request.invitation_to.first_name, membership_request.group_to_join.name)
     else:
         # group owner accepted user request
         # here wre are sending email to the user whose request to join got accepted
@@ -1546,8 +1507,7 @@ def _send_email_on_group_membership_acceptance(membership_request):
         <p>Your request to join the group '{}' has been accepted.</p>
         <p>Thank you</p>
         <p>The HydroShare Team</p>
-        """.format(membership_request.request_from.first_name,
-                   membership_request.group_to_join.name)
+        """.format(membership_request.request_from.first_name, membership_request.group_to_join.name)
 
     send_mail(subject="HydroShare group membership",
               message=email_msg,
@@ -1559,16 +1519,14 @@ def _send_email_on_group_membership_acceptance(membership_request):
 def _share_resource_with_user(request, frm, resource, requesting_user, privilege):
     if frm.is_valid():
         try:
-            requesting_user.uaccess.share_resource_with_user(resource, frm.cleaned_data['user'],
-                                                             privilege)
+            requesting_user.uaccess.share_resource_with_user(resource, frm.cleaned_data['user'], privilege)
         except PermissionDenied as exp:
             messages.error(request, exp.message)
     else:
         messages.error(request, frm.errors.as_json())
 
 
-def _unshare_resource_with_users(request, requesting_user, users_to_unshare_with, resource,
-                                 privilege):
+def _unshare_resource_with_users(request, requesting_user, users_to_unshare_with, resource, privilege):
     users_to_keep = User.objects.in_bulk(users_to_unshare_with).values()
     owners = set(resource.raccess.owners.all())
     editors = set(resource.raccess.edit_users.all()) - owners
@@ -1634,6 +1592,19 @@ def _set_resource_sharing_status(request, user, resource, flag_to_set, flag_valu
                        "unrecognized resource flag {}".format(flag_to_set))
 
 
+def _get_message_for_setting_resource_flag(has_files, has_metadata, resource_flag):
+    msg = ''
+    if not has_metadata and not has_files:
+        msg = "Resource does not have sufficient required metadata and content files to be {flag}".format(
+              flag=resource_flag)
+    elif not has_metadata:
+        msg = "Resource does not have sufficient required metadata to be {flag}".format(flag=resource_flag)
+    elif not has_files:
+        msg = "Resource does not have required content files to be {flag}".format(flag=resource_flag)
+
+    return msg
+
+
 class MyGroupsView(TemplateView):
     template_name = 'pages/my-groups.html'
 
@@ -1665,8 +1636,7 @@ class MyGroupsView(TemplateView):
 
 
 class AddUserForm(forms.Form):
-        user = forms.ModelChoiceField(User.objects.all(),
-                                      widget=autocomplete_light.ChoiceWidget("UserAutocomplete"))
+        user = forms.ModelChoiceField(User.objects.all(), widget=autocomplete_light.ChoiceWidget("UserAutocomplete"))
 
 
 class GroupView(TemplateView):
@@ -1684,10 +1654,8 @@ class GroupView(TemplateView):
         u.is_group_editor = g in u.uaccess.edit_groups
         u.is_group_viewer = g in u.uaccess.view_groups
 
-        g.join_request_waiting_owner_action = \
-            g.gaccess.group_membership_requests.filter(request_from=u).exists()
-        g.join_request_waiting_user_action = \
-            g.gaccess.group_membership_requests.filter(invitation_to=u).exists()
+        g.join_request_waiting_owner_action = g.gaccess.group_membership_requests.filter(request_from=u).exists()
+        g.join_request_waiting_user_action = g.gaccess.group_membership_requests.filter(invitation_to=u).exists()
         g.join_request = g.gaccess.group_membership_requests.filter(invitation_to=u).first()
 
         group_resources = []
@@ -1723,18 +1691,13 @@ class CollaborateView(TemplateView):
         # for each group set group dynamic attributes
         for g in groups:
             g.is_user_member = u in g.gaccess.members
-            g.join_request_waiting_owner_action = \
-                g.gaccess.group_membership_requests.filter(request_from=u).exists()
-            g.join_request_waiting_user_action = \
-                g.gaccess.group_membership_requests.filter(invitation_to=u).exists()
+            g.join_request_waiting_owner_action = g.gaccess.group_membership_requests.filter(request_from=u).exists()
+            g.join_request_waiting_user_action = g.gaccess.group_membership_requests.filter(invitation_to=u).exists()
             g.join_request = None
             if g.join_request_waiting_owner_action or g.join_request_waiting_user_action:
-                g.join_request = \
-                    g.gaccess.group_membership_requests.filter(request_from=u).first() or \
-                    g.gaccess.group_membership_requests.filter(invitation_to=u).first()
+                g.join_request = g.gaccess.group_membership_requests.filter(request_from=u).first() or \
+                                 g.gaccess.group_membership_requests.filter(invitation_to=u).first()
         return {
             'profile_user': u,
             'groups': groups,
         }
-
-# flake8 __init__.py

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -618,7 +618,7 @@ class AccessRulesUpdate(APIView):
         res = get_resource_by_shortkey(pk)
         try:
             res.set_public(validated_request_data['public'], request.user)
-        except ValidationError as ex:
+        except ValidationError:
             return Response(data={'resource_id': pk}, status=status.HTTP_403_FORBIDDEN)
 
         return Response(data={'resource_id': pk}, status=status.HTTP_200_OK)

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -616,8 +616,10 @@ class AccessRulesUpdate(APIView):
 
         validated_request_data = access_rules_validator.validated_data
         res = get_resource_by_shortkey(pk)
-        res.raccess.public = validated_request_data['public']
-        res.raccess.save()
+        try:
+            res.set_public(validated_request_data['public'], request.user)
+        except ValidationError as ex:
+            return Response(data={'resource_id': pk}, status=status.HTTP_403_FORBIDDEN)
 
         return Response(data={'resource_id': pk}, status=status.HTTP_200_OK)
 

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -634,6 +634,8 @@ def zip_folder(user, res_id, input_coll_path, output_zip_fname, bool_remove_orig
         # remove empty folder in iRODS
         istorage.delete(res_coll_input)
 
+    # TODO: should check can_be_public_or_discoverable here
+
     hydroshare.utils.resource_modified(resource, user, overwrite_bag=False)
     return output_zip_fname, output_zip_size
 
@@ -667,6 +669,8 @@ def unzip_file(user, res_id, zip_with_rel_path, bool_remove_original):
 
     if bool_remove_original:
         delete_resource_file(res_id, zip_fname, user)
+
+    # TODO: should check can_be_public_or_discoverable here
 
     hydroshare.utils.resource_modified(resource, user, overwrite_bag=False)
 
@@ -714,11 +718,7 @@ def remove_folder(user, res_id, folder_path):
 
     remove_irods_folder_in_django(resource, istorage, coll_path, user)
 
-    if resource.raccess.public or resource.raccess.discoverable:
-        if not resource.can_be_public_or_discoverable:
-            resource.raccess.public = False
-            resource.raccess.discoverable = False
-            resource.raccess.save()
+    resource.update_public_and_discoverable()  # make private if required 
 
     hydroshare.utils.resource_modified(resource, user, overwrite_bag=False)
 
@@ -786,6 +786,8 @@ def move_or_rename_file_or_folder(user, res_id, src_path, tgt_path, validate_mov
     istorage.moveFile(src_full_path, tgt_full_path)
 
     rename_irods_file_or_folder_in_django(resource, src_full_path, tgt_full_path)
+
+    # TODO: should check can_be_public_or_discoverable here
 
     hydroshare.utils.resource_modified(resource, user, overwrite_bag=False)
 

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -25,7 +25,7 @@ from mezzanine.conf import settings
 from hs_core import hydroshare
 from hs_core.hydroshare import check_resource_type, delete_resource_file
 from hs_core.models import AbstractMetaDataElement, BaseResource, GenericResource, Relation, \
-                           ResourceFile, get_user
+    ResourceFile, get_user
 from hs_core.signals import pre_metadata_element_create, post_delete_file_from_resource
 from hs_core.hydroshare.utils import get_file_mime_type
 from django_irods.storage import IrodsStorage
@@ -718,7 +718,7 @@ def remove_folder(user, res_id, folder_path):
 
     remove_irods_folder_in_django(resource, istorage, coll_path, user)
 
-    resource.update_public_and_discoverable()  # make private if required 
+    resource.update_public_and_discoverable()  # make private if required
 
     hydroshare.utils.resource_modified(resource, user, overwrite_bag=False)
 

--- a/hs_file_types/models/netcdf.py
+++ b/hs_file_types/models/netcdf.py
@@ -485,10 +485,7 @@ class NetCDFLogicalFile(AbstractLogicalFile):
                             logical_file.metadata.create_element(k, **v)
                     log.info("NetCDF file type - metadata was saved to DB")
                     # set resource to private if logical file is missing required metadata
-                    if not logical_file.metadata.has_all_required_elements():
-                        resource.raccess.public = False
-                        resource.raccess.discoverable = False
-                        resource.raccess.save()
+                    resource.update_public_and_discoverable()
             else:
                 err_msg = "Not a valid NetCDF file. File type file validation failed."
                 log.error(err_msg)

--- a/hs_file_types/models/raster.py
+++ b/hs_file_types/models/raster.py
@@ -346,10 +346,7 @@ class GeoRasterLogicalFile(AbstractLogicalFile):
                         logical_file.metadata.create_element(k, **v)
                     log.info("Geo raster file type - metadata was saved to DB")
                     # set resource to private if logical file is missing required metadata
-                    if not logical_file.metadata.has_all_required_elements():
-                        resource.raccess.public = False
-                        resource.raccess.discoverable = False
-                        resource.raccess.save()
+                    resource.update_public_and_discoverable()
             else:
                 err_msg = "Geo raster file type file validation failed.{}".format(
                     ' '.join(error_info))

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,6 @@ exclude=
   hs_core/views/autocomplete.py,
   hs_core/views/discovery_json_view.py,
   hs_core/views/discovery_view.py,
-  hs_core/views/__init__.py,
   hs_core/views/pagination.py,
   hs_core/views/resource_api.py,
   hs_core/views/user_rest_api.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ exclude=
   hs_core/views/autocomplete.py,
   hs_core/views/discovery_json_view.py,
   hs_core/views/discovery_view.py,
+  hs_core/views/__init__.py,
   hs_core/views/pagination.py,
   hs_core/views/resource_api.py,
   hs_core/views/user_rest_api.py,


### PR DESCRIPTION
New routines: 
* `resource.set_public(value, user)`: sets the public flag and potentially the discoverable flag. 
* `resource.set_discoverable(value, user)`: sets the discoverable flag and potentially the public flag. 
* `resource.update_public_and_discoverable()`: sets discoverable/private to False if metadata constraints are now violated. 
* `resource.setAVU('isPublic', True)`: automatically locates resource root and converts Boolean to string. 
* `resource.getAVU('isPublic')`: returns the value of the AVU, automatically locating the resource root. 

These are used as follows: 
* `resource.set_public` and `resource.set_discoverable` are called when the user requests a setting via the UI or REST API.  This includes when publishing data. 
* `resource.update_public_and_discoverable` are called when metadata and/or files are modified that might potentially violate restrictions on public resources. 

This fixes several issues with the `isPublic` AVU: 
1. `isPublic` tracks `resource.raccess.public` every time it's changed. 
2. New routine `resource.update_public_and_discoverable` downgrades access when metadata is incomplete. 
3. Metadata checks now include logical file metadata completeness. 
4. `set_public` and `set_discoverable` enforce logical rules public -> discoverable and not discoverable -> not public 

I am still debugging but nearing the end of testing so I think I should request review. 