### PR TITLE
[#1924] hotfix for checking the creator name

### DIFF
--- a/hs_file_types/models/netcdf.py
+++ b/hs_file_types/models/netcdf.py
@@ -935,7 +935,8 @@ def netcdf_file_update(instance, nc_res_file, txt_res_file, user):
 
             creator = instance.metadata.creators.all().filter(order=1).first()
             if creator:
-                nc_dataset.creator_name = creator.name
+                nc_dataset.creator_name = creator.name if creator.name else creator.organization
+
                 if creator.email:
                     nc_dataset.creator_email = creator.email
                 if creator.description or creator.homepage:


### PR DESCRIPTION
This is to make sure that when a creator is an organization, the organization name will be added in the netCDF file.