### PR TITLE
[HOTFIX] File type metadata form display issues

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1232,16 +1232,16 @@ class Coverage(AbstractMetaDataElement):
                             td(self.value['east'])
             else:
                 legend('Temporal Coverage')
+                start_date = parser.parse(self.value['start'])
+                end_date = parser.parse(self.value['end'])
                 with table(cls='custom-table'):
                     with tbody():
                         with tr():
                             get_th('Start Date')
-                            td(self.value['start'], id='temporal_start_date',
-                               data_date=self.value['start'])
+                            td(start_date.strftime('%m/%d/%Y'))
                         with tr():
                             get_th('End Date')
-                            td(self.value['end'], id='temporal_end_date',
-                               data_date=self.value['end'])
+                            td(end_date.strftime('%m/%d/%Y'))
 
         return root_div.render(pretty=pretty)
 

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -457,9 +457,6 @@ function showFileTypeMetadata(){
          $(".file-browser-container, #fb-files-container").css("cursor", "auto");
          $("#btn-add-keyword-filetype").click(onAddKeywordFileType);
 
-         $("#temporal_start_date").formatDate();
-         $("#temporal_end_date").formatDate();
-
          $("#txt-keyword-filetype").keypress(function (e) {
              e.which = e.which || e.keyCode;
              if (e.which == 13) {


### PR DESCRIPTION
Fixed it by removing use of formatDate() for file type temporal data.