### PR TITLE
2095 [hotfix] resource debugging page

### DIFF
--- a/hs_core/debug_urls.py
+++ b/hs_core/debug_urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import patterns, url
+from hs_core import views
+
+urlpatterns = patterns(
+    '',
+    # Resource Debugging: print consistency problems in a resource
+    url(r'^resource/(?P<shortkey>[0-9a-f-]+)/debug/$',
+        views.debug_resource_view.debug_resource,
+        name='debug_resource'),
+)

--- a/hs_core/templates/debug/debug_resource.html
+++ b/hs_core/templates/debug/debug_resource.html
@@ -29,18 +29,21 @@
 </ul>
 </ul>
 
+<h2>Resource flags</h2> 
 <table border='1'>
 <tbody> 
-<tr><th colspan='2'>Resource Flags</th></tr> 
-<tr><td>public</td><td>{{ raccess.public }}</td></tr>
-<tr><td>discoverable</td><td>{{ raccess.discoverable }}</td></tr>
-<tr><td>immutable</td><td>{{ raccess.immutable }}</td></tr>
+<tr><th colspan='2'>Resource Flags</th><th colspan='2'>iRODs AVUs</th></tr> 
+<tr><td>resource_type</td><td>{{ resource.resource_type }}</td>
+    <td>resourceType</td><td>{{ type_AVU }}</td></tr>
+<tr><td>public</td><td>{{ raccess.public }}</td>
+    <td>isPublic</td><td>{{ public_AVU }}</td></tr>
+<tr><th colspan='2'>Resource Flags</th>
+    <th colspan='2'>iRODs AVUs</th></tr> 
+<tr><td>discoverable</td><td>{{ raccess.discoverable }}</td>
+    <td>bag_modified</td><td>{{ modified_AVU }}</td></tr>
+<tr><td>immutable</td><td>{{ raccess.immutable }}</td>
+    <td>quotaUserName</td><td>{{ quota_AVU }}</td></tr>
 <tr><td>published</td><td>{{ raccess.published }}</td></tr>
-<tr><th colspan='2'>Resource AVUs</th></tr> 
-<tr><td>isPublic</td><td>{{ public_AVU }}</td></tr>
-<tr><td>bag_modified</td><td>{{ modified_AVU }}</td></tr>
-<tr><td>quotaUserName</td><td>{{ quota_AVU }}</td></tr>
-<tr><td>resourceType</td><td>{{ type_AVU }}</td></tr>
 </tbody> 
 </table>
 

--- a/hs_core/templates/debug/debug_resource.html
+++ b/hs_core/templates/debug/debug_resource.html
@@ -1,0 +1,56 @@
+<h1>Debugging information for resource <a href='/resource/{{ shortkey}}/'>{{ shortkey }}</a></h1>
+
+<ul>
+<li> Title: <b>{{ resource.metadata.title.value }}</b> </li>
+<li> Creator:
+{% if creator.first_name %}
+    <a href='/user/{{ creator.pk }}/'
+        target="_blank">{{ creator.first_name }} {{ creator.last_name }}
+                        ({{ creator.username }}) </a>
+{% else %}
+    <a href='/user/{{ creator.pk }}/' target="_blank">{{ creator.username }}</a>
+{% endif %}
+</li>
+<li> Owners:
+<ul>
+{% for owner in owners %}
+    <li> 
+    {% if owner.first_name %}
+        <a href='/user/{{ owner.pk }}/'
+            target="_blank">{{ owner.first_name }} {{ owner.last_name }}
+                            ({{ owner.username }}) </a>
+    {% else %}
+        <a href='/user/{{ owner.pk }}/' target="_blank">{{ owner.username }}</a>
+    {% endif %}
+    </li> 
+{% endfor %}
+
+</li>
+</ul>
+</ul>
+
+<table border='1'>
+<tbody> 
+<tr><th colspan='2'>Resource Flags</th></tr> 
+<tr><td>public</td><td>{{ raccess.public }}</td></tr>
+<tr><td>discoverable</td><td>{{ raccess.discoverable }}</td></tr>
+<tr><td>immutable</td><td>{{ raccess.immutable }}</td></tr>
+<tr><td>published</td><td>{{ raccess.published }}</td></tr>
+<tr><th colspan='2'>Resource AVUs</th></tr> 
+<tr><td>isPublic</td><td>{{ public_AVU }}</td></tr>
+<tr><td>bag_modified</td><td>{{ modified_AVU }}</td></tr>
+<tr><td>quotaUserName</td><td>{{ quota_AVU }}</td></tr>
+<tr><td>resourceType</td><td>{{ type_AVU }}</td></tr>
+</tbody> 
+</table>
+
+{% if irods_issues %}
+    <h2>iRODs issues found</h2>
+    <ul>
+    {% for issue in irods_issues %}
+        <li><code>{{ issue }}</code></li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <h2>No irods issues found.</h2>
+{% endif %}

--- a/hs_core/urls.py
+++ b/hs_core/urls.py
@@ -109,11 +109,6 @@ urlpatterns = patterns('',
         views.resource_access_api.ResourceAccessUpdateDelete.as_view(),
         name='get_update_delete_resource_access'),
 
-    # Resource Debugging 
-    url(r'^resource/(?P<shortkey>[0-9a-f-]+)/debug/$',
-        views.debug_resource_view.debug_resource,
-        name='debug_resource'),
-
     # internal API
 
     url(r'^_internal/(?P<shortkey>[0-9a-f-]+)/add-files-to-resource/$',

--- a/hs_core/urls.py
+++ b/hs_core/urls.py
@@ -109,6 +109,11 @@ urlpatterns = patterns('',
         views.resource_access_api.ResourceAccessUpdateDelete.as_view(),
         name='get_update_delete_resource_access'),
 
+    # Resource Debugging 
+    url(r'^resource/(?P<shortkey>[0-9a-f-]+)/debug/$',
+        views.debug_resource_view.debug_resource,
+        name='debug_resource'),
+
     # internal API
 
     url(r'^_internal/(?P<shortkey>[0-9a-f-]+)/add-files-to-resource/$',

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -100,7 +100,7 @@ def change_quota_holder(request, shortkey):
 
     res = utils.get_resource_by_shortkey(shortkey)
     try:
-        res.raccess.set_quota_holder(request.user, new_holder_u)
+        res.set_quota_holder(request.user, new_holder_u)
 
         # send notification to the new quota holder
         context = {

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -49,6 +49,7 @@ from . import resource_folder_hierarchy
 
 from . import resource_access_api
 from . import resource_folder_rest_api
+from . import debug_resource_view
 
 from hs_core.hydroshare import utils
 

--- a/hs_core/views/debug_resource_view.py
+++ b/hs_core/views/debug_resource_view.py
@@ -13,9 +13,9 @@ def debug_resource(request, shortkey):
     template = loader.get_template('debug/debug_resource.html')
     context = {
         'shortkey': shortkey,
-        'creator': resource.creator, 
-        'resource': resource, 
-        'raccess': resource.raccess, 
+        'creator': resource.creator,
+        'resource': resource,
+        'raccess': resource.raccess,
         'owners': resource.raccess.owners,
         'editors': resource.raccess.get_users_with_explicit_access(PrivilegeCodes.CHANGE),
         'viewers': resource.raccess.get_users_with_explicit_access(PrivilegeCodes.VIEW),

--- a/hs_core/views/debug_resource_view.py
+++ b/hs_core/views/debug_resource_view.py
@@ -1,0 +1,29 @@
+from django.http import HttpResponse
+from django.template import loader
+from hs_core.views.utils import authorize, ACTION_TO_AUTHORIZE
+from hs_access_control.models import PrivilegeCodes
+
+
+def debug_resource(request, shortkey):
+    """ Debug view for resource depicts output of various integrity checking scripts """
+    resource, _, _ = authorize(request, shortkey,
+                               needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
+    irods_issues, irods_errors = resource.check_irods_files(log_errors=False, return_errors=True)
+
+    template = loader.get_template('debug/debug_resource.html')
+    context = {
+        'shortkey': shortkey,
+        'creator': resource.creator, 
+        'resource': resource, 
+        'raccess': resource.raccess, 
+        'owners': resource.raccess.owners,
+        'editors': resource.raccess.get_users_with_explicit_access(PrivilegeCodes.CHANGE),
+        'viewers': resource.raccess.get_users_with_explicit_access(PrivilegeCodes.VIEW),
+        'public_AVU': resource.getAVU('isPublic'),
+        'type_AVU': resource.getAVU('resourceType'),
+        'modified_AVU': resource.getAVU('bag_modified'),
+        'quota_AVU': resource.getAVU('quotaUserName'),
+        'irods_issues': irods_issues,
+        'irods_errors': irods_errors,
+    }
+    return HttpResponse(template.render(context, request))

--- a/hydroshare/urls.py
+++ b/hydroshare/urls.py
@@ -74,6 +74,7 @@ urlpatterns += patterns('',
     url('^hsapi/', include('hs_core.urls')),
     url('', include('hs_core.resourcemap_urls')),
     url('', include('hs_core.metadata_terms_urls')),
+    url('', include('hs_core.debug_urls')),
     url('^hsapi/', include('ref_ts.urls')),
     url('^irods/', include('irods_browser_app.urls')),
     url('^hs_metrics/', include('hs_metrics.urls')),
@@ -114,7 +115,7 @@ urlpatterns += patterns('',
     # one out.
 
     # url("^$", direct_to_template, {"template": "index.html"}, name="home"),
-    url(r"^tests/$", direct_to_template, {"template": "tests.html"}, name="tests"),
+    # QUNIT_TESTS_OFF
 
     # HOMEPAGE AS AN EDITABLE PAGE IN THE PAGE TREE
     # ---------------------------------------------


### PR DESCRIPTION
@dtarb @pkdash @mauriel133 @aphelionz @martinseul @hyi 
As mentioned in #2095, we need more insight into what is going on in the running system. This implements a simple debugging page for a resource. 

* with URL `/resource/{shortkey}/debug/`
* accessible to anyone with VIEW privilege
* not accessible via a link (must type URL manually). 

This page runs `check_irods_files` and prints the result. This will be very valuable in debugging synchronization errors. If at all possible I want to get this into 1.10.0. 

Please comment on access permission required and choice of URL. 

