### PR TITLE
Fix bag download problem

### DIFF
--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -175,7 +175,7 @@ def create_bag_by_irods(resource_id):
 
     metadata_dirty = istorage.getAVU(res.root_path, 'metadata_dirty')
     # if metadata has been changed, then regenerate metadata xml files
-    if metadata_dirty.lower() == "true":
+    if metadata_dirty is None or metadata_dirty.lower() == "true":
         try:
             create_bag_files(res)
         except Exception as ex:


### PR DESCRIPTION
@hyi @mjstealey @pkdash @aphelionz This fixes the issue with bag download crashing  #2111 

The reason for the error: 
1. Hong's scripts check for "true" in AVUs. 
2. Michael's setup scripts set iRODS AVUs to "True" instead. 
3. I used lower() to make the tests always work properly. (I originally modified the offending line of code) 
4. `metadata_dirty` for older resources is `None`, not `'True'`
5. Thus the task to generate a bag tries to do a `lower()` of `None`. 
I simply checked for `None` in that procedure.

Long term, we should also: 
1. Initialize bag_modified to 'true' --  and not 'True' -- in build script. 
2. add the `lower()` qualifiers and None test in `django_irods/views/`, which make the same mistake as was being made in `hs_core/tasks.py`. 

Will submit a related PR to repair (2) :  the `django_irods` issue. 
 

