### PR TITLE
Enhanced resource repair including NetCDF and isPublic AVU

### DIFF
--- a/hs_app_netCDF/templates/pages/netcdfresource.html
+++ b/hs_app_netCDF/templates/pages/netcdfresource.html
@@ -130,7 +130,7 @@
                     <div style="clear: both">
                         <br>
                         <legend>NetCDF Header Info</legend>
-                        <p>{{ f.short_path|slice:"33:" }}</p>
+                        <p>{{ f.short_path }}</p>
                         <div class="hs-doc-preview">
                             {% if f.size <= 5000000 %}
                                 <pre id="netcdf-header-info">{{ f.read }}</pre>

--- a/hs_app_netCDF/templates/pages/netcdfresource.html
+++ b/hs_app_netCDF/templates/pages/netcdfresource.html
@@ -114,7 +114,7 @@
 
     {# Add netcdf tool button  #}
 {#        {% for f in cm.files.all %}#}
-{#            {% if f.resource_file.name|slice:"-3:" == '.nc'%}#}
+{#            {% if f.short_path|slice:"-3:" == '.nc'%}#}
 {#                <td><a style="margin-left:15px" id="btn-netcdf-tools" type="button" class="btn btn-success" href="{% url "nc_tools:index" cm.short_id 'initial' %}">#}
 {#                    <span class="button-label"> NetCDF Tools</span>#}
 {#                </a></td>#}
@@ -126,14 +126,14 @@
     {% if cm.files.all %}
         {# tab body for ncdump #}
             {% for f in cm.files.all %}
-                {% if f.resource_file.name|slice:"-3:" == 'txt'%}
+                {% if f.short_path|slice:"-3:" == 'txt'%}
                     <div style="clear: both">
                         <br>
                         <legend>NetCDF Header Info</legend>
-                        <p>{{ f.resource_file.name|slice:"33:" }}</p>
+                        <p>{{ f.short_path|slice:"33:" }}</p>
                         <div class="hs-doc-preview">
-                            {% if f.resource_file.size <= 5000000 %}
-                                <pre id="netcdf-header-info">{{ f.resource_file.read}}</pre>
+                            {% if f.size <= 5000000 %}
+                                <pre id="netcdf-header-info">{{ f.read }}</pre>
                             {% else %}
                                 <pre id="netcdf-header-info" readonly rows="5">The size of the netCDF header information text file is too large for loading on the page.</pre>
                             {% endif %}

--- a/hs_core/management/commands/fix_broken_resources.py
+++ b/hs_core/management/commands/fix_broken_resources.py
@@ -3,7 +3,7 @@
 """
 Fix broken resources found in 1.10.0 migration.
 This script should be run only once.
-It performs resource-specific actions.
+It performs resource-specific actions:
 094da7d9400f493fb1e412df015e17a4 Delete files in iRODS that are not in Django (duplicates)
 aff4e6dfc09a4070ac15a6ec0741fd02 Delete files in Django that are not in Irods (failed upload)
 5e80dd7cbaf04a5e98d850609c7e534b Delete files in Django that are not in Irods (failed upload)
@@ -28,6 +28,7 @@ cdc6292fbee24dfd9810da7696a40dcf Delete unreferenced files on both sides.
 """
 
 from django.core.management.base import BaseCommand
+from django.conf import settings
 from hs_core.hydroshare.utils import get_resource_by_shortkey
 from hs_core.hydroshare.utils import resource_modified
 from hs_core.models import BaseResource
@@ -58,46 +59,6 @@ VACUUM = [
     'cdc6292fbee24dfd9810da7696a40dcf'
 ]
 
-# The AVUs should be fixed for these
-PUBLIC = [ 
-    '0359cab7d93f403ba6ee8726cff74f8a',
-    '040dfdc5e0684a40bd13c0259e971bb7',
-    '05a29e4ddffd42b88f482bd5be46e88d',
-    '0ae62cfb9f3347d29c8211564f8db515',
-    '0b7dcbc238c947239a6f949abec869db',
-    '0cb834d7635943e98d770e9df0c522fe',
-    '126bb28f05224636a8bc8b3d1bdad6b5',
-    '17c732b4ec924f54ba73aa77497d8354',
-    '1c14485cf5f445f99564c847bf7b9cf5',
-    '1d78964652034876b1c190647b21a77d',
-    '22c6c32608694cf38746cd665f255957',
-    '2443f9ff1217412f992b27f89942f87e',
-    '2ccee33680d64c138762ae8928810749',
-    '2d07c0d7695149f39c233bf3215ccd4a',
-    '310621bbccf24c958854632b2b26ad45',
-    '3118410c99bd4a86a91407e0a3d16e9a',
-    '31ee40f4726546f5ab9ca2e3a8e3d557',
-    '31f35199a2e548e29786182fbb3e2941',
-    '3202e694a05143f1a9ba30f8bc615cab',
-    '39127f7285d548e181a81ca5a789fb79',
-    '46c1b0f6c16c4ae1b71298cda7cfc0ab',
-    '500952f35e0b456f984835d306dfa4a3',
-    '53bab1bbcd544ad78e45443da7246fe4',
-    '57d8a925efbd4c33ac074297ade37ad8',
-    '6805aaed7a424d8f9971ac404ecd1da3',
-    '68fe2d39f40e4bf5bdfde6526259dc10',
-    '6a38890c0ce24c22badf89cb1da6be79',
-    '6db094fb5e5e4fae9a0bd047263d9ebc',
-    '6dbb0dfb8f3a498881e4de428cb1587c',
-    '7246f52a298848e4830249e8b626a904',
-    '7ccd6a6a8341443a9d9396ca4502ad22',
-    '85d16c91c20f450f8aecb460c8cfb947',
-    '877bf9ed9e66468cadddb229838a9ced',
-    '89125e9a3af544eab2479b7a974100ba',
-    '895cc2fc795f4a63ab35c291d39977dc',
-    '89e8df6d8b134238b30225df1a2cf454'
-]
-
 
 class Command(BaseCommand):
     help = "Check synchronization between iRODS and Django."
@@ -120,35 +81,42 @@ class Command(BaseCommand):
         print("REPAIR BROKEN NETCDF RESOURCES")
 
         for r in BaseResource.objects.filter(resource_type='NetcdfResource'):
-            istorage = r.get_irods_storage()
-            for f in r.files.all():
-                try:
-                    if f.short_path.endswith('.txt') and not istorage.exists(f.storage_path):
-                        print("found broken NetCDF resource {}".format(r.short_id))
-                        files = istorage.listdir(r.file_path)[1]
-                        for g in files:
-                            if g.endswith('.txt'):
-                                print("in {}, changing short path {} to {}"
-                                      .format(r.short_id, f.short_path, g))
-                                f.set_short_path(g)
-                                # Now check for file integrity afterward
-                                r.check_irods_files(echo_errors=True, log_errors=False,
-                                                    return_errors=False, clean_irods=False,
-                                                    clean_django=False, sync_ispublic=True)
-                                break
-                except SessionException:
-                    print("resource {} not found in iRODS".format(r.short_id))
+            if r.is_federated and not settings.REMOTE_USE_IRODS:
+                print("INFO: skipping repair of federated resource {} in unfederated mode"
+                      .format(r.short_id))
+            else:
+
+                istorage = r.get_irods_storage()
+                for f in r.files.all():
+                    try:
+                        if f.short_path.endswith('.txt') and not istorage.exists(f.storage_path):
+                            print("found broken NetCDF resource {}".format(r.short_id))
+                            files = istorage.listdir(r.file_path)[1]
+                            for g in files:
+                                if g.endswith('.txt'):
+                                    print("in {}, changing short path {} to {}"
+                                          .format(r.short_id, f.short_path, g))
+                                    f.set_short_path(g)
+                                    # Now check for file integrity afterward
+                                    r.check_irods_files(echo_errors=True, log_errors=False,
+                                                        return_errors=False, clean_irods=False,
+                                                        clean_django=False, sync_ispublic=True)
+                                    break
+                    except SessionException:
+                        print("resource {} ({}) not found in iRODS".format(r.short_id, r.root_path))
 
         print("REPAIR ISPUBLIC AVUS")
-        for r in BaseResource.objects.all(): 
-            try: 
-                pub = r.getAVU('isPublic')
-                if pub != r.raccess.public: 
-                    print("INFO: resource {}: isPublic is {}, r.raccess.public is {} (REPAIRING)"
-                          .format(r.short_id, pub, r.raccess.public))
-                    try: 
-                        r.setAVU('isPublic', r.raccess.public) 
-                    except SessionException: 
-                        print("ERROR: non-existent collection {}".format(r.short_id))
-            except SessionException: 
-                print("ERROR: non-existent collection {}".format(r.short_id))
+        for r in BaseResource.objects.all():
+            if r.is_federated and not settings.REMOTE_USE_IRODS:
+                print("INFO: skipping repair of federated resource {} in unfederated mode"
+                      .format(r.short_id))
+            else:
+                istorage = r.get_irods_storage()
+                if istorage.exists(r.root_path):
+                    pub = r.getAVU('isPublic')
+                    if pub != r.raccess.public:
+                        print("INFO: resource {}: isPublic is {}, public is {} (REPAIRING)"
+                              .format(r.short_id, pub, r.raccess.public))
+                        r.setAVU('isPublic', r.raccess.public)
+                else:
+                    print("ERROR: non-existent collection {} ({})".format(r.short_id, r.root_path))

--- a/hs_core/management/commands/fix_broken_resources.py
+++ b/hs_core/management/commands/fix_broken_resources.py
@@ -58,6 +58,46 @@ VACUUM = [
     'cdc6292fbee24dfd9810da7696a40dcf'
 ]
 
+# The AVUs should be fixed for these
+PUBLIC = [ 
+    '0359cab7d93f403ba6ee8726cff74f8a',
+    '040dfdc5e0684a40bd13c0259e971bb7',
+    '05a29e4ddffd42b88f482bd5be46e88d',
+    '0ae62cfb9f3347d29c8211564f8db515',
+    '0b7dcbc238c947239a6f949abec869db',
+    '0cb834d7635943e98d770e9df0c522fe',
+    '126bb28f05224636a8bc8b3d1bdad6b5',
+    '17c732b4ec924f54ba73aa77497d8354',
+    '1c14485cf5f445f99564c847bf7b9cf5',
+    '1d78964652034876b1c190647b21a77d',
+    '22c6c32608694cf38746cd665f255957',
+    '2443f9ff1217412f992b27f89942f87e',
+    '2ccee33680d64c138762ae8928810749',
+    '2d07c0d7695149f39c233bf3215ccd4a',
+    '310621bbccf24c958854632b2b26ad45',
+    '3118410c99bd4a86a91407e0a3d16e9a',
+    '31ee40f4726546f5ab9ca2e3a8e3d557',
+    '31f35199a2e548e29786182fbb3e2941',
+    '3202e694a05143f1a9ba30f8bc615cab',
+    '39127f7285d548e181a81ca5a789fb79',
+    '46c1b0f6c16c4ae1b71298cda7cfc0ab',
+    '500952f35e0b456f984835d306dfa4a3',
+    '53bab1bbcd544ad78e45443da7246fe4',
+    '57d8a925efbd4c33ac074297ade37ad8',
+    '6805aaed7a424d8f9971ac404ecd1da3',
+    '68fe2d39f40e4bf5bdfde6526259dc10',
+    '6a38890c0ce24c22badf89cb1da6be79',
+    '6db094fb5e5e4fae9a0bd047263d9ebc',
+    '6dbb0dfb8f3a498881e4de428cb1587c',
+    '7246f52a298848e4830249e8b626a904',
+    '7ccd6a6a8341443a9d9396ca4502ad22',
+    '85d16c91c20f450f8aecb460c8cfb947',
+    '877bf9ed9e66468cadddb229838a9ced',
+    '89125e9a3af544eab2479b7a974100ba',
+    '895cc2fc795f4a63ab35c291d39977dc',
+    '89e8df6d8b134238b30225df1a2cf454'
+]
+
 
 class Command(BaseCommand):
     help = "Check synchronization between iRODS and Django."
@@ -99,8 +139,8 @@ class Command(BaseCommand):
                 except SessionException:
                     print("resource {} not found in iRODS".format(r.short_id))
 
-        print("REPAIR ISPUBLIC AVUS AND CHECK ALL RESOURCES")
-        for r in BaseResource.objects.all():
-            r.check_irods_files(echo_errors=True, log_errors=False,
-                                return_errors=False, clean_irods=False,
-                                clean_django=False, sync_ispublic=True)
+        print("REPAIR ISPUBLIC AVUS")
+        for rid in PUBLIC:  # resources with unsynchronized AVUs
+            r = get_resource_by_shortkey(rid)
+            r.check_irods_files(echo_errors=True, log_errors=False, return_errors=False,
+                                clean_irods=False, clean_django=False, sync_ispublic=True)

--- a/hs_core/management/commands/fix_broken_resources.py
+++ b/hs_core/management/commands/fix_broken_resources.py
@@ -140,7 +140,15 @@ class Command(BaseCommand):
                     print("resource {} not found in iRODS".format(r.short_id))
 
         print("REPAIR ISPUBLIC AVUS")
-        for rid in PUBLIC:  # resources with unsynchronized AVUs
-            r = get_resource_by_shortkey(rid)
-            r.check_irods_files(echo_errors=True, log_errors=False, return_errors=False,
-                                clean_irods=False, clean_django=False, sync_ispublic=True)
+        for r in BaseResource.objects.all(): 
+            try: 
+                pub = r.getAVU('isPublic')
+                if pub != r.raccess.public: 
+                    print("INFO: resource {}: isPublic is {}, r.raccess.public is {} (REPAIRING)"
+                          .format(r.short_id, pub, r.raccess.public))
+                    try: 
+                        r.setAVU('isPublic', r.raccess.public) 
+                    except SessionException: 
+                        print("ERROR: non-existent collection {}".format(r.short_id))
+            except SessionException: 
+                print("ERROR: non-existent collection {}".format(r.short_id))

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2589,9 +2589,9 @@ class ResourceFile(models.Model):
     @property
     def read(self):
         if self.resource.is_federated:
-            return self.resource_file.read
-        else:
             return self.fed_resource_file.read
+        else:
+            return self.resource_file.read
 
     @property
     def storage_path(self):

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1666,7 +1666,7 @@ class AbstractResource(ResourcePermissionsMixin):
         root_path = self.root_path
         value = istorage.getAVU(root_path, attribute)
         if attribute == 'isPublic':
-            if value.lower() == 'true':
+            if value is not None and value.lower() == 'true':
                 return True
             else:
                 return False


### PR DESCRIPTION
The updated script `fix_broken_resources` repairs files as discussed on today's call, including the files discovered by the first check_irods_files run, NetCDF resources with erroneous header_info.txt, and isPublic flags. 

This script has been manually copied to beta.hydroshare.org and is running now. 
