### PR TITLE
2131 add users quota

### DIFF
--- a/theme/admin.py
+++ b/theme/admin.py
@@ -17,45 +17,32 @@ class IconBoxInline(TabularDynamicInlineAdmin):
 class HomePageAdmin(PageAdmin):
     inlines = (IconBoxInline,)
 
+
 class UserQuotaForm(forms.ModelForm):
     user = forms.ModelChoiceField(queryset=User.objects.all())
     class Meta:
         model = UserQuota
         fields = ['user', 'allocated_value', 'used_value', 'unit', 'zone']
-        exclude = []
 
-    def __init__(self, *args, **kwargs):
-        super(UserQuotaForm, self).__init__(*args, **kwargs)
-        if self.instance and self.instance.user_id:
-            # change a record, user foreign key cannot be changed
-            self.fields['user'].initial = self.instance.user
-            self.fields['user'].widget.attrs['readonly'] = True
-            self.fields['user'].widget.attrs['disabled'] = True
-
-    # def clean_user(self):
-    #     if self.instance.pk is None:
-    #         return self.instance.user
-    #     else:
-    #         return self.cleaned_data['user']
-    #
     def save(self, *args, **kwargs):
          instance = super(UserQuotaForm, self).save(commit=False)
-         self.cleaned_data['user'].save()
+         instance.user = self.cleaned_data['user']
          return instance
+
 
 class QuotaAdmin(admin.ModelAdmin):
     model = UserQuota
-    form = UserQuotaForm
-    # list_select_related = True
-    # list_editable = ('user',)
-    #readonly_fields = ('user',)
-    #add_fieldsets = (
-    #    (None, {
-    #        'classes': ('wide',),
-    #        'fields': ('user',)}),
-    #)
+
     list_display = ('user', 'allocated_value', 'used_value', 'unit', 'zone')
-    list_filter = ('zone',)
+    list_filter = ('zone', 'user__username', )
+
+    def get_form(self, request, obj=None, **kwargs):
+        # use a customized form class when adding a UserQuota object so that
+        # the foreign key user field is available for selection.
+        if obj is None:
+            return UserQuotaForm
+        else:
+            return super(QuotaAdmin, self).get_form(request, obj, **kwargs)
 
 
 admin.site.register(HomePage, HomePageAdmin)

--- a/theme/admin.py
+++ b/theme/admin.py
@@ -19,7 +19,8 @@ class HomePageAdmin(PageAdmin):
 
 
 class UserQuotaForm(forms.ModelForm):
-    user = forms.ModelChoiceField(queryset=User.objects.exclude(is_superuser=True))
+    user = forms.ModelChoiceField(
+        queryset=User.objects.exclude(is_superuser=True).exclude(is_active=False))
 
     class Meta:
         model = UserQuota

--- a/theme/admin.py
+++ b/theme/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
+from django import forms
+from django.contrib.auth.models import User
 
-from mezzanine.core.admin import TabularDynamicInlineAdmin, SingletonAdmin
+from mezzanine.core.admin import TabularDynamicInlineAdmin, SingletonAdmin, OwnableAdmin
 from mezzanine.pages.admin import PageAdmin
 
 from models import SiteConfiguration, HomePage, IconBox, UserQuota, QuotaMessage
@@ -15,13 +17,49 @@ class IconBoxInline(TabularDynamicInlineAdmin):
 class HomePageAdmin(PageAdmin):
     inlines = (IconBoxInline,)
 
+class UserQuotaForm(forms.ModelForm):
+    user = forms.ModelChoiceField(queryset=User.objects.all())
+    class Meta:
+        model = UserQuota
+        fields = ['user', 'allocated_value', 'used_value', 'unit', 'zone']
+        exclude = []
+
+    def __init__(self, *args, **kwargs):
+        super(UserQuotaForm, self).__init__(*args, **kwargs)
+        if self.instance and self.instance.user_id:
+            # change a record, user foreign key cannot be changed
+            self.fields['user'].initial = self.instance.user
+            self.fields['user'].widget.attrs['readonly'] = True
+            self.fields['user'].widget.attrs['disabled'] = True
+
+    # def clean_user(self):
+    #     if self.instance.pk is None:
+    #         return self.instance.user
+    #     else:
+    #         return self.cleaned_data['user']
+    #
+    def save(self, *args, **kwargs):
+         instance = super(UserQuotaForm, self).save(commit=False)
+         self.cleaned_data['user'].save()
+         return instance
 
 class QuotaAdmin(admin.ModelAdmin):
+    model = UserQuota
+    form = UserQuotaForm
+    # list_select_related = True
+    # list_editable = ('user',)
+    #readonly_fields = ('user',)
+    #add_fieldsets = (
+    #    (None, {
+    #        'classes': ('wide',),
+    #        'fields': ('user',)}),
+    #)
     list_display = ('user', 'allocated_value', 'used_value', 'unit', 'zone')
     list_filter = ('zone',)
 
 
 admin.site.register(HomePage, HomePageAdmin)
 admin.site.register(SiteConfiguration, SingletonAdmin)
+admin.site.register(User, admin.ModelAdmin)
 admin.site.register(UserQuota, QuotaAdmin)
 admin.site.register(QuotaMessage, SingletonAdmin)

--- a/theme/admin.py
+++ b/theme/admin.py
@@ -48,6 +48,5 @@ class QuotaAdmin(admin.ModelAdmin):
 
 admin.site.register(HomePage, HomePageAdmin)
 admin.site.register(SiteConfiguration, SingletonAdmin)
-admin.site.register(User, admin.ModelAdmin)
 admin.site.register(UserQuota, QuotaAdmin)
 admin.site.register(QuotaMessage, SingletonAdmin)

--- a/theme/admin.py
+++ b/theme/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django import forms
 from django.contrib.auth.models import User
 
-from mezzanine.core.admin import TabularDynamicInlineAdmin, SingletonAdmin, OwnableAdmin
+from mezzanine.core.admin import TabularDynamicInlineAdmin, SingletonAdmin
 from mezzanine.pages.admin import PageAdmin
 
 from models import SiteConfiguration, HomePage, IconBox, UserQuota, QuotaMessage
@@ -20,14 +20,15 @@ class HomePageAdmin(PageAdmin):
 
 class UserQuotaForm(forms.ModelForm):
     user = forms.ModelChoiceField(queryset=User.objects.all())
+
     class Meta:
         model = UserQuota
         fields = ['user', 'allocated_value', 'used_value', 'unit', 'zone']
 
     def save(self, *args, **kwargs):
-         instance = super(UserQuotaForm, self).save(commit=False)
-         instance.user = self.cleaned_data['user']
-         return instance
+        instance = super(UserQuotaForm, self).save(commit=False)
+        instance.user = self.cleaned_data['user']
+        return instance
 
 
 class QuotaAdmin(admin.ModelAdmin):

--- a/theme/admin.py
+++ b/theme/admin.py
@@ -19,7 +19,7 @@ class HomePageAdmin(PageAdmin):
 
 
 class UserQuotaForm(forms.ModelForm):
-    user = forms.ModelChoiceField(queryset=User.objects.all())
+    user = forms.ModelChoiceField(queryset=User.objects.exclude(is_superuser=True))
 
     class Meta:
         model = UserQuota


### PR DESCRIPTION
@pkdash @aphelionz Can one or both of you review this small PR when you get a chance? It should be a quick review. The issue being addressed in this PR is that the foreign key field (i.e., User in this case) does not show up in the default Django admin implementation when adding a new UserQuota object which prevented admin user to add a new UserQuota object for an existing user for a different zone for example. What I did to work around this issue is to override the get_form() method from Django ModelAdmin to use a customized model form for adding UserQuota object so that the foreign key User field can show up for selection, and use the default form in Django when changing an existing UserQuota object. I have tested various scenarios locally and everything works well as expected. This needs to get in for release 1.11 as part of quota implementation. Thanks.