### PR TITLE
Address issue #2045: added include_obsolete parameter to get resource list REST API

### DIFF
--- a/hs_core/hydroshare/users.py
+++ b/hs_core/hydroshare/users.py
@@ -8,7 +8,8 @@ from django.core.files.uploadedfile import UploadedFile
 from django.core import exceptions
 from django.db.models import Q
 
-from hs_core.models import BaseResource, Contributor, Creator, Subject, Description, Title, Coverage
+from hs_core.models import BaseResource, Contributor, Creator, Subject, Description, Title, \
+    Coverage, Relation
 from .utils import user_from_id, group_from_id, get_profile
 from theme.models import UserQuota
 
@@ -247,7 +248,7 @@ def get_resource_list(creator=None, group=None, user=None, owner=None, from_date
                       to_date=None, start=None, count=None, full_text_search=None,
                       published=False, edit_permission=False, public=False,
                       type=None, author=None, contributor=None, subject=None, coverage_type=None,
-                      north=None, south=None, east=None, west=None):
+                      north=None, south=None, east=None, west=None, include_obsolete=False):
     """
     Return a list of pids for Resources that have been shared with a group identified by groupID.
 
@@ -379,6 +380,11 @@ def get_resource_list(creator=None, group=None, user=None, owner=None, from_date
         q.append(Q(object_id__in=subjects.values_list('object_id', flat=True)))
 
     flt = BaseResource.objects.all()
+
+    if not include_obsolete:
+        flt = flt.exclude(object_id__in=Relation.objects.filter(
+            type='isReplacedBy').values('object_id'))
+
     for q in q:
         flt = flt.filter(q)
 

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -353,6 +353,8 @@ class ResourceListCreate(ResourceToListItemMixin, generics.ListCreateAPIView):
     :param  types: (optional) - to get a list of resources of the specified resource types
     :param  from_date: (optional) - to get a list of resources created on or after this date
     :param  to_date: (optional) - to get a list of resources created on or before this date
+    :param  include_obsolete: (optional) - default is False which means the returned resource list
+    does not include obsoleted resource; if set to True, obsoleted resource will be included
     :param  edit_permission: (optional) - to get a list of resources for which the authorised user
     has edit permission
     :rtype:  json string
@@ -526,7 +528,6 @@ class ResourceListCreate(ResourceToListItemMixin, generics.ListCreateAPIView):
             filter_parms['type'] = list(filter_parms['type'])
 
         filter_parms['public'] = not self.request.user.is_authenticated()
-
         filtered_res_list = []
 
         for r in hydroshare.get_resource_list(**filter_parms):

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -86,6 +86,7 @@ class ResourceListRequestValidator(serializers.Serializer):
     south = serializers.CharField(required=False)
     east = serializers.CharField(required=False)
     west = serializers.CharField(required=False)
+    include_obsolete = serializers.BooleanField(required=False, default=False)
 
 
 class ResourceListItemSerializer(serializers.Serializer):


### PR DESCRIPTION
@pkdash Can you review this small PR? I added an optional "include_obsolete" parameter that allows callers to set it to True if they want to get obsoleted resources in the returned resource list from REST API, and the default is False, meaning the obsoleted resources will be filtered out and thus not included in the returned resource list. Tests are also added and all tests have passed. 