### PR TITLE
2153 unzip performance

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2514,11 +2514,10 @@ class ResourceFile(models.Model):
                     raise ValidationError("ResourceFile.create: move did not work")
             elif file is not None and source is None:
                 # file points to an existing iRODS file
+                # no need to verify whether the file exists in iRODS since the file
+                # name is returned from iRODS ils list dir command which already
+                # confirmed the file exists already in iRODS
                 target = get_resource_file_path(resource, file, folder=folder)
-                istorage = resource.get_irods_storage()
-                if not istorage.exists(target):
-                    raise ValidationError("ResourceFile.create: target {} does not exist"
-                                          .format(target))
             else:
                 raise ValidationError(
                     "ResourceFile.create: exactly one of source or file must be specified")

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -457,12 +457,11 @@ def show_relations_section(res_obj):
 
 
 # TODO: no handling of pre_create or post_create signals
-def link_irods_file_to_django(resource, filepath, size=0):
+def link_irods_file_to_django(resource, filepath):
     """
     Link a newly created irods file to Django resource model
 
     :param filepath: full path to file
-    :size: deprecated; size of file; not needed
     """
     # link the newly created file (**filepath**) to Django resource model
     b_add_file = False
@@ -508,9 +507,8 @@ def link_irods_folder_to_django(resource, istorage, foldername, exclude=()):
         for file in store[1]:
             if file not in exclude:
                 file_path = os.path.join(foldername, file)
-                size = istorage.size(file_path)
                 # This assumes that file_path is a full path
-                link_irods_file_to_django(resource, file_path, size)
+                link_irods_file_to_django(resource, file_path)
         # recursively add sub-folders into Django resource model
         for folder in store[0]:
             link_irods_folder_to_django(resource,

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -619,7 +619,7 @@ def zip_folder(user, res_id, input_coll_path, output_zip_fname, bool_remove_orig
 
     output_zip_size = istorage.size(output_zip_full_path)
 
-    link_irods_file_to_django(resource, output_zip_full_path, output_zip_size)
+    link_irods_file_to_django(resource, output_zip_full_path)
 
     if bool_remove_original:
         for f in ResourceFile.objects.filter(object_id=resource.id):

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -499,7 +499,8 @@ def link_irods_folder_to_django(resource, istorage, foldername, exclude=()):
     """
     if __debug__:
         assert(isinstance(resource, BaseResource))
-    istorage = resource.get_irods_storage()
+    if istorage is None:
+        istorage = resource.get_irods_storage()
 
     if foldername:
         store = istorage.listdir(foldername)


### PR DESCRIPTION
@alvacouch @pkdash @dtarb @mjstealey I have made the following changes and did the timing using the zip file in this resource https://www.hydroshare.org/resource/37594b5bba544e14905dc0f8257c874f/ as the test case. This zip file include many folders and a large set of files. Note that ibun unzip call only took 4 seconds for this test case, which can be ignored compared to the link_irods_folder_to_django() call which takes 102 seconds as is now.

1. removed the deprecated istorage.size() call. This reduced the link call from 102 seconds to 82 seconds.
2. removed duplicate ```istorage = resource.get_irods_storage()``` call by adding the if condition to only call it when pass in istorage is None. Since we already pass in an istorage object, this call is not needed. This reduced the link call from 82 seconds to 81 seconds consistently, a small improvement, although not critical, but nice to have.
3. removed istorage.exist() verification calls in ResourceFile.create() call for this specific case where we already know files exist in iRODS as the file names come from icommand list dir ils call, so no need to call istorage.exist() to verify file exist in iRODS. This further reduced the time from 81 seconds to 62 seconds.

So this PR if merged will reduce the unzip time from the original 106 seconds (4 second ibun call plus 102 seconds link call) to 66 seconds (4 second ibun call plus 62 seconds link call) for this test case. Please take a look at this PR @alvacouch and @pkdash at your earliest convenience to see if you can +1 this so that we can merge it for Tanu and her team to test tomorrow to see if the performance is acceptable for their demo for Earthcube workshop that will happen this Wed. If you approve this PR. I'll create another PR against the hotfix branch. @pkdash @mjstealey Please advise which branch I should create the PR against for them to use. I assume they will do demo against master branch, right? 