### PR TITLE
HOTFIX: remove second resource_modified call

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -696,9 +696,6 @@ def update_science_metadata(pk, metadata, user):
     # set to private if metadata has become non-compliant
     resource.update_public_and_discoverable()  # set to False if necessary
 
-    # TODO: This is a bit of a lie since the user initiating this is not the creator
-    utils.resource_modified(resource, resource.creator, overwrite_bag=False)
-
 
 def delete_resource(pk):
     """


### PR DESCRIPTION
Hotfix for #2191 
As described in #2182 