### PR TITLE
REST endpoint support for resource specific metadata editing

### DIFF
--- a/hs_app_netCDF/forms.py
+++ b/hs_app_netCDF/forms.py
@@ -126,6 +126,24 @@ class OriginalCoverageForm(forms.Form):
         return self.cleaned_data
 
 
+class OriginalCoverageValidationForm(forms.Form):
+    PRO_STR_TYPES = (
+        ('', '---------'),
+        ('WKT String', 'WKT String'),
+        ('Proj4 String', 'Proj4 String')
+    )
+
+    projection = forms.CharField(max_length=100, required=False)
+    northlimit = forms.DecimalField()
+    eastlimit = forms.DecimalField()
+    southlimit = forms.DecimalField()
+    westlimit = forms.DecimalField()
+    units = forms.CharField(max_length=100)
+    projection_string_type = forms.ChoiceField(choices=PRO_STR_TYPES, required=False)
+    projection_string_text = forms.CharField(max_length=1000, required=False)
+    datum = forms.CharField(max_length=300, required=False)
+
+
 class OriginalCoverageMetaDelete(MetaDataElementDeleteForm):
     def __init__(self, res_short_id, element_name, element_id, *args, **kwargs):
         super(OriginalCoverageMetaDelete, self).__init__(res_short_id, element_name,

--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -420,6 +420,25 @@ class NetcdfMetaData(NetCDFMetaDataMixin, CoreMetaData):
     def resource(self):
         return NetcdfResource.objects.filter(object_id=self.id).first()
 
+    @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self """
+        from serializers import NetCDFMetaDataSerializer
+        return NetCDFMetaDataSerializer(self)
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Overriding the base class method"""
+
+        CoreMetaData.parse_for_bulk_update(metadata, parsed_metadata)
+        keys_to_update = metadata.keys()
+        if 'originalcoverage' in keys_to_update:
+            parsed_metadata.append({"originalcoverage": metadata.pop('originalcoverage')})
+
+        if 'variables' in keys_to_update:
+            for variable in metadata.pop('variables'):
+                parsed_metadata.append({"variable": variable})
+
     def set_dirty(self, flag):
         """
         Overriding the base class method

--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -448,9 +448,9 @@ class NetcdfMetaData(NetCDFMetaDataMixin, CoreMetaData):
             self.is_dirty = flag
             self.save()
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
-        super(NetcdfMetaData, self).update(metadata)
+        super(NetcdfMetaData, self).update(metadata, user)
         missing_file_msg = "Resource specific metadata can't be updated when there is no " \
                            "content files"
         with transaction.atomic():
@@ -488,6 +488,9 @@ class NetcdfMetaData(NetCDFMetaDataMixin, CoreMetaData):
                         variable_data.pop(key, None)
 
                     self.update_element('variable', var_element.id, **variable_data)
+
+        # write updated metadata to netcdf file
+        self.resource.update_netcdf_file(user)
 
     def get_xml(self, pretty_print=True, include_format_elements=True):
         from lxml import etree

--- a/hs_app_netCDF/serializers.py
+++ b/hs_app_netCDF/serializers.py
@@ -1,0 +1,32 @@
+from rest_framework import serializers
+
+from hs_core.views.resource_metadata_rest_api import CoreMetaDataSerializer
+from models import OriginalCoverage, Variable, NetcdfMetaData
+
+
+class OrginalCoverageSerializer(serializers.Serializer):
+    value = serializers.SerializerMethodField(required=False)
+    projection_string_type = serializers.CharField(required=False)
+    projection_string_text = serializers.CharField(required=False)
+    datum = serializers.CharField(required=False)
+
+    class Meta:
+        model = OriginalCoverage
+
+    def get_value(self, obj):
+        return obj.value
+
+
+class VariableSerilalizer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Variable
+        fields = ('name', 'unit', 'type', 'shape', 'descriptive_name', 'method', 'missing_value')
+
+
+class NetCDFMetaDataSerializer(CoreMetaDataSerializer):
+    originalCoverage = OrginalCoverageSerializer(required=False, many=False)
+    variables = VariableSerilalizer(required=False, many=True)
+
+    class Meta:
+        model = NetcdfMetaData

--- a/hs_app_netCDF/tests/test_netcdf_metadata.py
+++ b/hs_app_netCDF/tests/test_netcdf_metadata.py
@@ -450,7 +450,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
         metadata = []
         metadata.append({'originalcoverage': {'value': value}})
         with self.assertRaises(ValidationError):
-            self.resNetcdf.metadata.update(metadata)
+            self.resNetcdf.metadata.update(metadata, self.user)
 
         del metadata[:]
         metadata.append({'variable': {'name': 'SWE', 'type': 'Float',
@@ -461,7 +461,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                                       }
                          })
         with self.assertRaises(ValidationError):
-            self.resNetcdf.metadata.update(metadata)
+            self.resNetcdf.metadata.update(metadata, self.user)
         self.resNetcdf.delete()
         # create netcdf resource with uploaded valid netcdf file
         self._create_netcdf_resource()
@@ -478,7 +478,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
 
         del metadata[:]
         metadata.append({'originalcoverage': {'value': value}})
-        self.resNetcdf.metadata.update(metadata)
+        self.resNetcdf.metadata.update(metadata, self.user)
         self.assertNotEqual(self.resNetcdf.metadata.originalCoverage, None)
         self.assertEqual(self.resNetcdf.metadata.originalCoverage.value['northlimit'], '12')
         self.assertNotEqual(self.resNetcdf.metadata.originalCoverage.value['projection'],
@@ -494,7 +494,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                                               }
                          })
 
-        self.resNetcdf.metadata.update(metadata)
+        self.resNetcdf.metadata.update(metadata, self.user)
         self.assertNotEqual(self.resNetcdf.metadata.originalCoverage, None)
         self.assertEqual(self.resNetcdf.metadata.originalCoverage.value['northlimit'], '15')
         self.assertNotEqual(self.resNetcdf.metadata.originalCoverage.value['projection'],
@@ -521,7 +521,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                                       }
                          })
 
-        self.resNetcdf.metadata.update(metadata)
+        self.resNetcdf.metadata.update(metadata, self.user)
         swe_variable = self.resNetcdf.metadata.variables.filter(name='SWE').first()
         self.assertEqual(swe_variable.unit, 'feet')
         # test that update of variable should fail if update is made for non-existing variable
@@ -536,7 +536,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                          })
 
         with self.assertRaises(ValidationError):
-            self.resNetcdf.metadata.update(metadata)
+            self.resNetcdf.metadata.update(metadata, self.user)
 
         # there should no variable with name SWE1
         self.assertEqual(self.resNetcdf.metadata.variables.filter(name='SWE1').count(), 0)
@@ -556,7 +556,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                          })
         metadata.append({'variable': {'name': 'x', 'unit': 'Feet'}})
 
-        self.resNetcdf.metadata.update(metadata)
+        self.resNetcdf.metadata.update(metadata, self.user)
         swe_variable = self.resNetcdf.metadata.variables.filter(name='SWE').first()
         self.assertEqual(swe_variable.unit, 'm')
         x_variable = self.resNetcdf.metadata.variables.filter(name='x').first()
@@ -568,7 +568,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
 
         del metadata[:]
         metadata.append({'variable': {'name': 'x', 'type': 'Double', 'shape': 'y'}})
-        self.resNetcdf.metadata.update(metadata)
+        self.resNetcdf.metadata.update(metadata, self.user)
         x_variable = self.resNetcdf.metadata.variables.filter(name='x').first()
         self.assertEqual(x_variable.type, 'Float')
         self.assertEqual(x_variable.shape, 'x')
@@ -585,7 +585,7 @@ class TestNetcdfMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
         metadata.append({'contributor': {'name': 'contributor one'}})
         metadata.append({'contributor': {'name': 'contributor two'}})
         metadata.append({'variable': {'name': 'x', 'unit': 'Meter'}})
-        self.resNetcdf.metadata.update(metadata)
+        self.resNetcdf.metadata.update(metadata, self.user)
         x_variable = self.resNetcdf.metadata.variables.filter(name='x').first()
         self.assertEqual(x_variable.unit, 'Meter')
         # there should be 2 creators (the previous creator gets deleted as part of the update)

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -693,7 +693,7 @@ def update_science_metadata(pk, metadata, user):
     Returns:
     """
     resource = utils.get_resource_by_shortkey(pk)
-    resource.metadata.update(metadata)
+    resource.metadata.update(metadata, user)
     utils.resource_modified(resource, user, overwrite_bag=False)
 
     # set to private if metadata has become non-compliant

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3542,6 +3542,60 @@ class CoreMetaData(models.Model):
         """Return the first _publisher object from metadata."""
         return self._publisher.all().first()
 
+    @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self
+        Note: Subclass must override this property
+        """
+        from views.resource_metadata_rest_api import CoreMetaDataSerializer
+        return CoreMetaDataSerializer(self)
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Parse the input *metadata* dict to needed format and store it in
+        *parsed_metadata* list
+        :param  metadata: a dict of metadata that needs to be parsed to get the metadata in the
+        format needed for updating the metadata elements supported by generic resource type
+        :param  parsed_metadata: a list of dicts that will be appended with parsed data
+        """
+
+        keys_to_update = metadata.keys()
+        if 'title' in keys_to_update:
+            parsed_metadata.append({"title": {"value": metadata.pop('title')}})
+
+        if 'creators' in keys_to_update:
+            for creator in metadata.pop('creators'):
+                parsed_metadata.append({"creator": creator})
+
+        if 'contributors' in keys_to_update:
+            for contributor in metadata.pop('contributors'):
+                parsed_metadata.append({"contributor": contributor})
+
+        if 'coverages' in keys_to_update:
+            for coverage in metadata.pop('coverages'):
+                parsed_metadata.append({"coverage": coverage})
+
+        if 'dates' in keys_to_update:
+            for date in metadata.pop('dates'):
+                parsed_metadata.append({"date": date})
+
+        if 'description' in keys_to_update:
+            parsed_metadata.append({"description": {"abstract": metadata.pop('description')}})
+
+        if 'language' in keys_to_update:
+            parsed_metadata.append({"language": {"code": metadata.pop('language')}})
+
+        if 'rights' in keys_to_update:
+            parsed_metadata.append({"rights": {"statement": metadata.pop('rights')}})
+
+        if 'sources' in keys_to_update:
+            for source in metadata.pop('sources'):
+                parsed_metadata.append({"source": source})
+
+        if 'subjects' in keys_to_update:
+            for subject in metadata.pop('subjects'):
+                parsed_metadata.append({"subject": {"value": subject['value']}})
+
     @classmethod
     def get_supported_element_names(cls):
         """Return a list of supported metadata element names."""

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3789,7 +3789,7 @@ class CoreMetaData(models.Model):
                             coverage_value_dict = coverage_data['value']
                             coverage_type = coverage_data['type']
                             Coverage.validate_coverage_type_value_attributes(coverage_type,
-                                                                              coverage_value_dict)
+                                                                             coverage_value_dict)
                             continue
 
                         else:

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3726,13 +3726,14 @@ class CoreMetaData(models.Model):
 
     # this method needs to be overriden by any subclass of this class
     # to allow updating of extended (resource specific) metadata
-    def update(self, metadata):
+    def update(self, metadata, user):
         """Define custom update method for CoreMetaData model.
 
         :param metadata: a list of dicts - each dict in the format of {element_name: **kwargs}
         element_name must be in lowercase.
         example of a dict in metadata list:
             {'creator': {'name': 'John Howard', 'email: 'jh@gmail.com'}}
+        :param  user: user who is updating metadata
         :return:
         """
         # updating non-repeatable elements

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3781,6 +3781,13 @@ class CoreMetaData(models.Model):
                             subjects.append(dict_item['subject']['value'])
                             continue
                         if element_name == 'coverage':
+                            # coverage metadata is not allowed for update for composite
+                            # and time series resource
+                            if self.resource.resource_type in ("CompositeResource",
+                                                               "TimeSeriesResource"):
+                                err_msg = "Coverage metadata can't be updated for {} resource"
+                                err_msg = err_msg.format(self.resource.resource_type)
+                                raise ValidationError(err_msg)
                             coverage_data = dict_item[element_name]
                             if 'type' not in coverage_data:
                                 raise ValidationError("Coverage type data is missing")

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -272,9 +272,9 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         # metadata update (Note: the only resource specific metadata element that can be updated
         # is BandInformation)
 
-        # create a netcdf resource
-        netcdf_file = 'hs_core/tests/data/cea.tif'
-        file_to_upload = open(netcdf_file, "r")
+        # create a raster resource
+        raster_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(raster_file, "r")
         self._create_resource(resource_type="RasterResource", file_to_upload=file_to_upload)
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
             res_id=self.resource.short_id)
@@ -348,9 +348,9 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         # metadata update (Note: the only resource specific metadata element that can be updated
         # is BandInformation)
 
-        # create a netcdf resource
-        netcdf_file = 'hs_core/tests/data/cea.tif'
-        file_to_upload = open(netcdf_file, "r")
+        # create a raster resource
+        raster_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(raster_file, "r")
         self._create_resource(resource_type="RasterResource", file_to_upload=file_to_upload)
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
             res_id=self.resource.short_id)
@@ -367,6 +367,109 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                  'noDataValue': -9999
                  }
             ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_modelprogram_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes both core metadata and resource specific
+        # metadata update
+
+        # create a model program resource
+        some_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(some_file, "r")
+        self._create_resource(resource_type="ModelProgramResource", file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ],
+            "mpmetadata": {
+                 "modelVersion": "5.1.011",
+                 "modelProgramLanguage": "Fortran",
+                 "modelOperatingSystem": "Windows",
+                 "modelReleaseDate": "2016-10-24T21:05:00.315907+00:00",
+                 "modelWebsite": "http://www.hydroshare.org",
+                 "modelCodeRepository": "http://www.github.com",
+                 "modelReleaseNotes": "releaseNote.pdf",
+                 "modelDocumentation": "manual.pdf",
+                 "modelSoftware": "utilities.exe",
+                 "modelEngine": "sourceCode.zip"
+                 }
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_modelprogram_resource_without_core_metadata(self):
+        # testing bulk metadata update that only updates resource specific
+        # metadata
+
+        # create a model program resource
+        some_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(some_file, "r")
+        self._create_resource(resource_type="ModelProgramResource", file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "mpmetadata": {
+                 "modelVersion": "5.1.011",
+                 "modelProgramLanguage": "Fortran",
+                 "modelOperatingSystem": "Windows",
+                 "modelReleaseDate": "2016-10-24T21:05:00.315907+00:00",
+                 "modelWebsite": "http://www.hydroshare.org",
+                 "modelCodeRepository": "http://www.github.com",
+                 "modelReleaseNotes": "releaseNote.pdf",
+                 "modelDocumentation": "manual.pdf",
+                 "modelSoftware": "utilities.exe",
+                 "modelEngine": "sourceCode.zip"
+                 }
         }
         response = self.client.put(sysmeta_url, put_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -1078,7 +1078,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                 "value": "https://www.hydroshare.org/static/img/logo-sm.png"
             },
             "apphomepageurl": {
-                "value": "https://my_web_app.com"
+                "value": "https://mywebapp.com"
             }
         }
 
@@ -1111,7 +1111,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                 "value": "https://www.hydroshare.org/static/img/logo-sm.png"
             },
             "apphomepageurl": {
-                "value": "https://my_web_app.com"
+                "value": "https://mywebapp.com"
             }
         }
         response = self.client.put(sysmeta_url, put_data, format='json')

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -1,5 +1,3 @@
-# import json
-
 from rest_framework import status
 
 from hs_core.hydroshare import resource
@@ -80,7 +78,6 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         }
         response = self.client.put(sysmeta_url, put_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
-        # content = json.loads(response.content)
 
     def test_put_scimeta_double_none(self):
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(res_id=self.pid)
@@ -141,9 +138,11 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         }
         response = self.client.put(sysmeta_url, put_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        # content = json.loads(response.content)
 
-    def test_put_scimeta_netcdf_resource(self):
+    def test_put_scimeta_netcdf_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes both core metadata and resource specific
+        # metadata update
+
         # create a netcdf resource
         netcdf_file = 'hs_core/tests/data/netcdf_valid.nc'
         file_to_upload = open(netcdf_file, "r")
@@ -226,6 +225,152 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         }
         response = self.client.put(sysmeta_url, put_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_netcdf_resource_without_core_metadata(self):
+        # testing bulk metadata update that only updates resource specific metadata
+
+        # create a netcdf resource
+        netcdf_file = 'hs_core/tests/data/netcdf_valid.nc'
+        file_to_upload = open(netcdf_file, "r")
+        self._create_resource(resource_type="NetcdfResource", file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "originalcoverage": {
+                "value": {
+                    "northlimit": '12', "projection": "transverse_mercator",
+                    "units": "meter", "southlimit": '10',
+                    "eastlimit": '23', "westlimit": '2'
+                },
+                "projection_string_text": '+proj=tmerc +lon_0=-111.0 +lat_0=0.0 +x_0=500000.0 '
+                                          '+y_0=0.0 +k_0=0.9996',
+                "projection_string_type": 'Proj4 String'
+            },
+            "variables": [
+                {
+                    "name": "SWE",
+                    "type": "Float",
+                    "shape": "y,x,time",
+                    "unit": "m",
+                    "missing_value": "-9999",
+                    "descriptive_name": "Snow water equivalent",
+                    "method": "model simulation of UEB"
+                },
+                {
+                    "name": "x",
+                    "unit": "Centimeter"
+                }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_raster_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes both core metadata and resource specific
+        # metadata update (Note: the only resource specific metadata element that can be updated
+        # is BandInformation)
+
+        # create a netcdf resource
+        netcdf_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(netcdf_file, "r")
+        self._create_resource(resource_type="RasterResource", file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ],
+            "bandinformations": [
+                {'original_band_name': 'Band_1',
+                 'name': 'Band_2',
+                 'variableName': 'digital elevation',
+                 'variableUnit': 'meter',
+                 'method': 'this is method',
+                 'comment': 'this is comment',
+                 'maximumValue': 1000,
+                 'minimumValue': 0,
+                 'noDataValue': -9999
+                 }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_raster_resource_without_core_metadata(self):
+        # testing bulk metadata update that includes only resource specific
+        # metadata update (Note: the only resource specific metadata element that can be updated
+        # is BandInformation)
+
+        # create a netcdf resource
+        netcdf_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(netcdf_file, "r")
+        self._create_resource(resource_type="RasterResource", file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "bandinformations": [
+                {'original_band_name': 'Band_1',
+                 'name': 'Band_2',
+                 'variableName': 'digital elevation',
+                 'variableUnit': 'meter',
+                 'method': 'this is method',
+                 'comment': 'this is comment',
+                 'maximumValue': 1000,
+                 'minimumValue': 0,
+                 'noDataValue': -9999
+                 }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
 
     def _create_resource(self, resource_type, file_to_upload):
         self.resource = resource.create_resource(

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -3,6 +3,7 @@
 from rest_framework import status
 
 from hs_core.hydroshare import resource
+from hs_core.hydroshare.utils import resource_post_create_actions
 from .base import HSRESTTestCase
 
 
@@ -141,3 +142,95 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         response = self.client.put(sysmeta_url, put_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         # content = json.loads(response.content)
+
+    def test_put_scimeta_netcdf_resource(self):
+        # create a netcdf resource
+        netcdf_file = 'hs_core/tests/data/netcdf_valid.nc'
+        file_to_upload = open(netcdf_file, "r")
+        self._create_resource(resource_type="NetcdfResource", file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": None,
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ],
+            "originalcoverage": {
+                "value": {
+                    "northlimit": '12', "projection": "transverse_mercator",
+                    "units": "meter", "southlimit": '10',
+                    "eastlimit": '23', "westlimit": '2'},
+                "projection_string_text": '+proj=tmerc +lon_0=-111.0 +lat_0=0.0 +x_0=500000.0 '
+                                                         '+y_0=0.0 +k_0=0.9996',
+                "projection_string_type": 'Proj4 String'
+            },
+            "variables": [
+                {
+                    "name": "SWE",
+                    "type": "Float",
+                    "shape": "y,x,time",
+                    "unit": "m",
+                    "missing_value": "-9999",
+                    "descriptive_name": "Snow water equivalent",
+                    "method": "model simulation of UEB"
+                },
+                {
+                    "name": "x",
+                    "unit": "Centimeter"
+                }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+    def _create_resource(self, resource_type, file_to_upload):
+        self.resource = resource.create_resource(
+            resource_type=resource_type,
+            owner=self.user,
+            title= "Testing bulk metadata update for resource type - {}".format(resource_type),
+            files=(file_to_upload,)
+            )
+        resource_post_create_actions(resource=self.resource, user=self.user,
+                                     metadata=self.resource.metadata)

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -148,7 +148,8 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         netcdf_file = 'hs_core/tests/data/netcdf_valid.nc'
         file_to_upload = open(netcdf_file, "r")
         self._create_resource(resource_type="NetcdfResource", file_to_upload=file_to_upload)
-        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(res_id=self.resource.short_id)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
         put_data = {
             "title": "New Title",
             "description": "New Description",
@@ -202,9 +203,9 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                     "northlimit": '12', "projection": "transverse_mercator",
                     "units": "meter", "southlimit": '10',
                     "eastlimit": '23', "westlimit": '2'},
-                "projection_string_text": '+proj=tmerc +lon_0=-111.0 +lat_0=0.0 +x_0=500000.0 '
-                                                         '+y_0=0.0 +k_0=0.9996',
-                "projection_string_type": 'Proj4 String'
+                    "projection_string_text": '+proj=tmerc +lon_0=-111.0 +lat_0=0.0 +x_0=500000.0 '
+                                              '+y_0=0.0 +k_0=0.9996',
+                    "projection_string_type": 'Proj4 String'
             },
             "variables": [
                 {
@@ -229,7 +230,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.resource = resource.create_resource(
             resource_type=resource_type,
             owner=self.user,
-            title= "Testing bulk metadata update for resource type - {}".format(resource_type),
+            title="Testing bulk metadata update for resource type - {}".format(resource_type),
             files=(file_to_upload,)
             )
         resource_post_create_actions(resource=self.resource, user=self.user,

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -475,6 +475,96 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.resource.delete()
 
+    def test_put_scimeta_modelinstance_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes both core metadata and resource specific
+        # metadata update
+
+        # create a model program resource
+        some_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(some_file, "r")
+        self._create_resource(resource_type="ModelInstanceResource", file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ],
+            "modeloutput": {"includes_output": False},
+            "executedby": {"model_name": "id of a an existing model program resource"}
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_modelinstance_resource_without_core_metadata(self):
+        # testing bulk metadata update updates only resource specific metadata
+
+        # create a model program resource
+        some_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(some_file, "r")
+        self._create_resource(resource_type="ModelInstanceResource", file_to_upload=file_to_upload)
+        # create a model program resource to link as executed by
+        model_program_resource = resource.create_resource(
+            resource_type="ModelProgramResource",
+            owner=self.user,
+            title="A model program resource",
+            files=(file_to_upload,)
+            )
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "modeloutput": {"includes_output": True},
+            "executedby": {"model_name": model_program_resource.short_id}
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+        model_program_resource.delete()
+
     def _create_resource(self, resource_type, file_to_upload):
         self.resource = resource.create_resource(
             resource_type=resource_type,

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -32,7 +32,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # content = json.loads(response.content)
 
-    def test_put_scimeta(self):
+    def test_put_scimeta_generic_resource(self):
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(res_id=self.pid)
         put_data = {
             "title": "New Title",
@@ -96,7 +96,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         response = self.client.put(sysmeta_url, put_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
-    def test_put_scimeta_double_none(self):
+    def test_put_scimeta_generic_resource_double_none(self):
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(res_id=self.pid)
         put_data = {
             "title": "New Title",
@@ -155,6 +155,115 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         }
         response = self.client.put(sysmeta_url, put_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_put_scimeta_composite_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes only core metadata
+
+        # create a composite resource
+        self._create_resource(resource_type="CompositeResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_composite_resource_with_core_metadata_failure(self):
+        # testing bulk metadata update that includes only core metadata with coverage metadata
+        # coverage metadata can't be updated for composite resource - this bulk update should fail
+
+        # create a composite resource
+        self._create_resource(resource_type="CompositeResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.resource.delete()
 
     def test_put_scimeta_netcdf_resource_with_core_metadata(self):
         # testing bulk metadata update that includes both core metadata and resource specific

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -632,7 +632,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                 "maximumElevation": 3333,
                 "minimumElevation": 4444
             },
-            "griddimensions":{
+            "griddimensions": {
                 "numberOfLayers": 5555,
                 "typeOfRows": "Irregular",
                 "numberOfRows": 6666,
@@ -698,7 +698,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                 "maximumElevation": 3333,
                 "minimumElevation": 4444
             },
-            "griddimensions":{
+            "griddimensions": {
                 "numberOfLayers": 5555,
                 "typeOfRows": "Irregular",
                 "numberOfRows": 6666,

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -840,6 +840,155 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.resource.delete()
 
+    def test_put_scimeta_SWATModelInstance_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes both core metadata and resource specific
+        # metadata update
+
+        # create a SWAT model resource
+        self._create_resource(resource_type="SWATModelInstanceResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ],
+            "modeloutput": {"includes_output": False},
+            "executedby": {"model_name": "id of a an existing model program resource"},
+            "modelobjective": {
+                "swat_model_objectives": ["BMPs", "Hydrology", "Water quality"],
+                "other_objectives": "some other objectives"
+            },
+            "simulationtype": {
+                "simulation_type_name": "Normal Simulation"
+            },
+            "modelmethod": {
+                "runoffCalculationMethod": "A test calculation method",
+                "flowRoutingMethod": "A test flow routing method",
+                "petEstimationMethod": "A test estimation method"
+            },
+            "modelparameter": {
+                "model_parameters": ["Crop rotation", "Tillage operation"],
+                "other_parameters": "some other model parameters"
+            },
+            "modelinput": {
+                "warmupPeriodValue": 10,
+                "rainfallTimeStepType": "Daily",
+                "rainfallTimeStepValue": 5,
+                "routingTimeStepType": "Daily",
+                "routingTimeStepValue": 2,
+                "simulationTimeStepType": "Hourly",
+                "simulationTimeStepValue": 1,
+                "watershedArea": 1000,
+                "numberOfSubbasins": 200,
+                "numberOfHRUs": 10000,
+                "demResolution": 30,
+                "demSourceName": "Unknown",
+                "demSourceURL": "http://dem-source.org",
+                "landUseDataSourceName": "Unknown",
+                "landUseDataSourceURL": "http://land-data.org",
+                "soilDataSourceName": "Unknown",
+                "soilDataSourceURL": "http://soil-data.org"
+            }
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_SWATModelInstance_resource_without_core_metadata(self):
+        # testing bulk metadata update that includes only resource specific
+        # metadata update
+
+        # create a SWAT model resource
+        self._create_resource(resource_type="SWATModelInstanceResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "modeloutput": {"includes_output": False},
+            "executedby": {"model_name": "id of a an existing model program resource"},
+            "modelobjective": {
+                "swat_model_objectives": ["BMPs", "Hydrology", "Water quality"],
+                "other_objectives": "some other objectives"
+            },
+            "simulationtype": {
+                "simulation_type_name": "Normal Simulation"
+            },
+            "modelmethod": {
+                "runoffCalculationMethod": "A test calculation method",
+                "flowRoutingMethod": "A test flow routing method",
+                "petEstimationMethod": "A test estimation method"
+            },
+            "modelparameter": {
+                "model_parameters": ["Crop rotation", "Tillage operation"],
+                "other_parameters": "some other model parameters"
+            },
+            "modelinput": {
+                "warmupPeriodValue": 10,
+                "rainfallTimeStepType": "Daily",
+                "rainfallTimeStepValue": 5,
+                "routingTimeStepType": "Daily",
+                "routingTimeStepValue": 2,
+                "simulationTimeStepType": "Hourly",
+                "simulationTimeStepValue": 1,
+                "watershedArea": 1000,
+                "numberOfSubbasins": 200,
+                "numberOfHRUs": 10000,
+                "demResolution": 30,
+                "demSourceName": "Unknown",
+                "demSourceURL": "http://dem-source.org",
+                "landUseDataSourceName": "Unknown",
+                "landUseDataSourceURL": "http://land-data.org",
+                "soilDataSourceName": "Unknown",
+                "soilDataSourceURL": "http://soil-data.org"
+            }
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
     def _create_resource(self, resource_type, file_to_upload=None):
         files = ()
         if file_to_upload is not None:

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -162,7 +162,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                 "name": "Test Name 1",
                 "organization": "Org 1"
             }, {
-                "name": None,
+                "name": "Test Name 2",
                 "organization": "Org 2"
             }],
             "creators": [{
@@ -202,10 +202,11 @@ class TestResourceScienceMetadata(HSRESTTestCase):
                 "value": {
                     "northlimit": '12', "projection": "transverse_mercator",
                     "units": "meter", "southlimit": '10',
-                    "eastlimit": '23', "westlimit": '2'},
-                    "projection_string_text": '+proj=tmerc +lon_0=-111.0 +lat_0=0.0 +x_0=500000.0 '
-                                              '+y_0=0.0 +k_0=0.9996',
-                    "projection_string_type": 'Proj4 String'
+                    "eastlimit": '23', "westlimit": '2'
+                },
+                "projection_string_text": '+proj=tmerc +lon_0=-111.0 +lat_0=0.0 +x_0=500000.0 '
+                                          '+y_0=0.0 +k_0=0.9996',
+                "projection_string_type": 'Proj4 String'
             },
             "variables": [
                 {

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -989,6 +989,118 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.resource.delete()
 
+    def test_put_web_app_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes both core metadata and resource specific
+        # metadata update
+
+        # create a web app resource
+        self._create_resource(resource_type="ToolResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ],
+            "requesturlbase": {
+                "value": "https://www.google.com"
+            },
+            "toolversion": {
+                "value": "1.12"
+            },
+            "supportedrestypes": {
+                "supported_res_types": ["NetcdfResource", "TimeSeriesResource"]
+            },
+            "supportedsharingstatuses": {
+                "sharing_status": ["Public", "Discoverable"]
+            },
+            "toolicon": {
+                "value": "https://www.hydroshare.org/static/img/logo-sm.png"
+            },
+            "apphomepageurl": {
+                "value": "https://my_web_app.com"
+            }
+        }
+
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_web_app_resource_without_core_metadata(self):
+        # testing bulk metadata update that includes only resource specific
+        # metadata update
+
+        # create a web app resource
+        self._create_resource(resource_type="ToolResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "requesturlbase": {
+                "value": "https://www.google.com"
+            },
+            "toolversion": {
+                "value": "1.12"
+            },
+            "supportedrestypes": {
+                "supported_res_types": ["NetcdfResource", "TimeSeriesResource"]
+            },
+            "supportedsharingstatuses": {
+                "sharing_status": ["Public", "Discoverable"]
+            },
+            "toolicon": {
+                "value": "https://www.hydroshare.org/static/img/logo-sm.png"
+            },
+            "apphomepageurl": {
+                "value": "https://my_web_app.com"
+            }
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
     def _create_resource(self, resource_type, file_to_upload=None):
         files = ()
         if file_to_upload is not None:

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -205,11 +205,120 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.resource.delete()
 
     def test_put_scimeta_composite_resource_with_core_metadata_failure(self):
-        # testing bulk metadata update that includes only core metadata with coverage metadata
+        # testing bulk metadata update with only core metadata that includes coverage metadata
         # coverage metadata can't be updated for composite resource - this bulk update should fail
 
         # create a composite resource
         self._create_resource(resource_type="CompositeResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.resource.delete()
+
+    def test_put_scimeta_timeseries_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes only core metadata
+
+        # create a composite resource
+        self._create_resource(resource_type="TimeSeriesResource")
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ]
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_timeseries_resource_with_core_metadata_failure(self):
+        # testing bulk metadata update with only core metadata that includes coverage metadata
+        # coverage metadata can't be updated for time series resource - this bulk update should fail
+
+        # create a composite resource
+        self._create_resource(resource_type="TimeSeriesResource")
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
             res_id=self.resource.short_id)
         put_data = {

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -479,7 +479,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         # testing bulk metadata update that includes both core metadata and resource specific
         # metadata update
 
-        # create a model program resource
+        # create a model instance resource
         some_file = 'hs_core/tests/data/cea.tif'
         file_to_upload = open(some_file, "r")
         self._create_resource(resource_type="ModelInstanceResource", file_to_upload=file_to_upload)
@@ -543,7 +543,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
     def test_put_scimeta_modelinstance_resource_without_core_metadata(self):
         # testing bulk metadata update updates only resource specific metadata
 
-        # create a model program resource
+        # create a model instance resource
         some_file = 'hs_core/tests/data/cea.tif'
         file_to_upload = open(some_file, "r")
         self._create_resource(resource_type="ModelInstanceResource", file_to_upload=file_to_upload)
@@ -564,6 +564,190 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.resource.delete()
         model_program_resource.delete()
+
+    def test_put_scimeta_modflowinstance_resource_with_core_metadata(self):
+        # testing bulk metadata update that includes both core metadata and resource specific
+        # metadata update
+
+        # create a MODFLOW model instance resource
+        some_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(some_file, "r")
+        self._create_resource(resource_type="MODFLOWModelInstanceResource",
+                              file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "title": "New Title",
+            "description": "New Description",
+            "subjects": [
+                {"value": "subject1"},
+                {"value": "subject2"},
+                {"value": "subject3"}
+            ],
+            "contributors": [{
+                "name": "Test Name 1",
+                "organization": "Org 1"
+            }, {
+                "name": "Test Name 2",
+                "organization": "Org 2"
+            }],
+            "creators": [{
+                "name": "Creator",
+                "organization": None
+            }],
+            "coverages": [{
+                "type": "box",
+                "value": {
+                    "northlimit": 43.19716728247476,
+                    "projection": "WGS 84 EPSG:4326",
+                    "name": "A whole bunch of the atlantic ocean",
+                    "units": "Decimal degrees",
+                    "southlimit": 23.8858376999,
+                    "eastlimit": -19.16015625,
+                    "westlimit": -62.75390625
+                }
+            }],
+            "dates": [
+                {
+                    "type": "valid",
+                    "start_date": "2016-12-07T00:00:00Z",
+                    "end_date": "2018-12-07T00:00:00Z"
+                }
+            ],
+            "language": "fre",
+            "rights": "CCC",
+            "sources": [
+                {
+                    "derived_from": "Source 3"
+                },
+                {
+                    "derived_from": "Source 2"
+                }
+            ],
+            "modeloutput": {"includes_output": False},
+            "executedby": {"model_name": "id of a an existing model program resource"},
+            "studyarea": {
+                "totalLength": 1111,
+                "totalWidth": 2222,
+                "maximumElevation": 3333,
+                "minimumElevation": 4444
+            },
+            "griddimensions":{
+                "numberOfLayers": 5555,
+                "typeOfRows": "Irregular",
+                "numberOfRows": 6666,
+                "typeOfColumns": "Regular",
+                "numberOfColumns": 7777
+            },
+            "stressperiod": {
+                "stressPeriodType":  "Steady and Transient",
+                "steadyStateValue": 8888,
+                "transientStateValueType": "Monthly",
+                "transientStateValue": 9999
+            },
+            "groundwaterflow": {
+                "flowPackage": "LPF",
+                "flowParameter": "Hydraulic Conductivity"
+            },
+            "boundarycondition": {
+                "specified_head_boundary_packages":  ["CHD", "FHB"],
+                "specified_flux_boundary_packages": ["FHB", "WEL"],
+                "head_dependent_flux_boundary_packages": ["RIV", "MNW1"]
+            },
+            "modelcalibration": {
+                "calibratedParameter": "test parameter",
+                "observationType": "test observation type",
+                "observationProcessPackage": "GBOB",
+                "calibrationMethod": "test calibration method"
+            },
+            "modelinputs": [
+                {
+                    "inputType": "test input type",
+                    "inputSourceName": "test source name",
+                    "inputSourceURL": "http://www.test.com"
+                }
+            ],
+            "generalelements": {
+                "modelParameter": "test model parameter",
+                "modelSolver": "SIP",
+                "output_control_package": ["HYD", "OC"],
+                "subsidencePackage": "SWT"
+            }
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
+
+    def test_put_scimeta_modflowinstance_resource_without_core_metadata(self):
+        # testing bulk metadata update that updates onlt the resource specific
+        # metadata
+
+        # create a MODFLOW model instance resource
+        some_file = 'hs_core/tests/data/cea.tif'
+        file_to_upload = open(some_file, "r")
+        self._create_resource(resource_type="MODFLOWModelInstanceResource",
+                              file_to_upload=file_to_upload)
+        sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(
+            res_id=self.resource.short_id)
+        put_data = {
+            "modeloutput": {"includes_output": False},
+            "executedby": {"model_name": "id of a an existing model program resource"},
+            "studyarea": {
+                "totalLength": 1111,
+                "totalWidth": 2222,
+                "maximumElevation": 3333,
+                "minimumElevation": 4444
+            },
+            "griddimensions":{
+                "numberOfLayers": 5555,
+                "typeOfRows": "Irregular",
+                "numberOfRows": 6666,
+                "typeOfColumns": "Regular",
+                "numberOfColumns": 7777
+            },
+            "stressperiod": {
+                "stressPeriodType":  "Steady and Transient",
+                "steadyStateValue": 8888,
+                "transientStateValueType": "Monthly",
+                "transientStateValue": 9999
+            },
+            "groundwaterflow": {
+                "flowPackage": "LPF",
+                "flowParameter": "Hydraulic Conductivity"
+            },
+            "boundarycondition": {
+                "specified_head_boundary_packages":  ["CHD", "FHB"],
+                "specified_flux_boundary_packages": ["FHB", "WEL"],
+                "head_dependent_flux_boundary_packages": ["RIV", "MNW1"]
+            },
+            "modelcalibration": {
+                "calibratedParameter": "test parameter",
+                "observationType": "test observation type",
+                "observationProcessPackage": "GBOB",
+                "calibrationMethod": "test calibration method"
+            },
+            "modelinputs": [
+                {
+                    "inputType": "test input type-1",
+                    "inputSourceName": "test source name-1",
+                    "inputSourceURL": "http://www.test-1.com"
+                },
+                {
+                    "inputType": "test input type-2",
+                    "inputSourceName": "test source name-2",
+                    "inputSourceURL": "http://www.test-2.com"
+                }
+            ],
+            "generalelements": {
+                "modelParameter": "test model parameter",
+                "modelSolver": "SIP",
+                "output_control_package": ["HYD", "OC"],
+                "subsidencePackage": "SWT"
+            }
+        }
+        response = self.client.put(sysmeta_url, put_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.resource.delete()
 
     def _create_resource(self, resource_type, file_to_upload):
         self.resource = resource.create_resource(

--- a/hs_core/views/resource_metadata_rest_api.py
+++ b/hs_core/views/resource_metadata_rest_api.py
@@ -180,56 +180,20 @@ class MetadataElementsRetrieveUpdate(generics.RetrieveUpdateDestroyAPIView):
     def get(self, request, pk):
         view_utils.authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_METADATA)
         resource = hydroshare.get_resource_by_shortkey(shortkey=pk)
-        serializer = CoreMetaDataSerializer(resource.metadata)
+        serializer = resource.metadata.serializer
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
     def put(self, request, pk):
         # Update science metadata
-        view_utils.authorize(
+        resource, _, _ = view_utils.authorize(
             request, pk,
             needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
 
         metadata = []
         put_data = request.data.copy()
-        keys_to_update = put_data.keys()
 
         try:
-            if 'title' in keys_to_update:
-                metadata.append({"title": {"value": put_data.pop('title')}})
-
-            if 'creators' in keys_to_update:
-                for creator in put_data.pop('creators'):
-                    metadata.append({"creator": creator})
-
-            if 'contributors' in keys_to_update:
-                for contributor in put_data.pop('contributors'):
-                    metadata.append({"contributor": contributor})
-
-            if 'coverages' in keys_to_update:
-                for coverage in put_data.pop('coverages'):
-                    metadata.append({"coverage": coverage})
-
-            if 'dates' in keys_to_update:
-                for date in put_data.pop('dates'):
-                    metadata.append({"date": date})
-
-            if 'description' in keys_to_update:
-                metadata.append({"description": {"abstract": put_data.pop('description')}})
-
-            if 'language' in keys_to_update:
-                metadata.append({"language": {"code": put_data.pop('language')}})
-
-            if 'rights' in keys_to_update:
-                metadata.append({"rights": {"statement": put_data.pop('rights')}})
-
-            if 'sources' in keys_to_update:
-                for source in put_data.pop('sources'):
-                    metadata.append({"source": source})
-
-            if 'subjects' in keys_to_update:
-                for subject in put_data.pop('subjects'):
-                    metadata.append({"subject": {"value": subject['value']}})
-
+            resource.metadata.parse_for_bulk_update(put_data, metadata)
             hydroshare.update_science_metadata(pk=pk, metadata=metadata, user=request.user)
         except Exception as ex:
             error_msg = {
@@ -239,5 +203,5 @@ class MetadataElementsRetrieveUpdate(generics.RetrieveUpdateDestroyAPIView):
             raise ValidationError(detail=error_msg)
 
         resource = hydroshare.get_resource_by_shortkey(shortkey=pk)
-        serializer = CoreMetaDataSerializer(resource.metadata)
+        serializer = resource.metadata.serializer
         return Response(data=serializer.data, status=status.HTTP_202_ACCEPTED)

--- a/hs_geo_raster_resource/models.py
+++ b/hs_geo_raster_resource/models.py
@@ -447,6 +447,23 @@ class RasterMetaData(GeoRasterMetaDataMixin, CoreMetaData):
     def resource(self):
         return RasterResource.objects.filter(object_id=self.id).first()
 
+    @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self """
+        from serializers import GeoRasterMetaDataSerializer
+        return GeoRasterMetaDataSerializer(self)
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Overriding the base class method"""
+
+        CoreMetaData.parse_for_bulk_update(metadata, parsed_metadata)
+        keys_to_update = metadata.keys()
+
+        if 'bandinformations' in keys_to_update:
+            for bandinformation in metadata.pop('bandinformations'):
+                parsed_metadata.append({"bandinformation": bandinformation})
+
     def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
 

--- a/hs_geo_raster_resource/models.py
+++ b/hs_geo_raster_resource/models.py
@@ -447,11 +447,11 @@ class RasterMetaData(GeoRasterMetaDataMixin, CoreMetaData):
     def resource(self):
         return RasterResource.objects.filter(object_id=self.id).first()
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
 
         # update any core metadata
-        super(RasterMetaData, self).update(metadata)
+        super(RasterMetaData, self).update(metadata, user)
         # update resource specific metadata
         # for geo raster resource type only band information can be updated
         missing_file_msg = "Resource specific metadata can't be updated when there is no " \

--- a/hs_geo_raster_resource/models.py
+++ b/hs_geo_raster_resource/models.py
@@ -467,6 +467,7 @@ class RasterMetaData(GeoRasterMetaDataMixin, CoreMetaData):
     def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
 
+        from forms import BandInfoValidationForm
         # update any core metadata
         super(RasterMetaData, self).update(metadata, user)
         # update resource specific metadata
@@ -489,6 +490,16 @@ class RasterMetaData(GeoRasterMetaDataMixin, CoreMetaData):
                     raise ValidationError("No matching band information element was found")
 
                 bandinfo_data.pop('original_band_name')
+                if 'name' not in bandinfo_data:
+                    bandinfo_data['name'] = band_element.name
+                if 'variableName' not in bandinfo_data:
+                    bandinfo_data['variableName'] = band_element.variableName
+                if 'variableUnit' not in bandinfo_data:
+                    bandinfo_data['variableUnit'] = band_element.variableUnit
+                validation_form = BandInfoValidationForm(bandinfo_data)
+                if not validation_form.is_valid():
+                    err_string = self.get_form_errors_as_string(validation_form)
+                    raise ValidationError(err_string)
                 self.update_element('bandinformation', band_element.id, **bandinfo_data)
 
     def get_xml(self, pretty_print=True, include_format_elements=True):

--- a/hs_geo_raster_resource/serializers.py
+++ b/hs_geo_raster_resource/serializers.py
@@ -1,0 +1,37 @@
+from rest_framework import serializers
+
+from hs_core.views.resource_metadata_rest_api import CoreMetaDataSerializer
+from models import OriginalCoverage, BandInformation, CellInformation, RasterMetaData
+
+
+class OrginalCoverageSerializer(serializers.Serializer):
+    value = serializers.SerializerMethodField(required=False)
+
+    class Meta:
+        model = OriginalCoverage
+
+    def get_value(self, obj):
+        return obj.value
+
+
+class BandInformationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = BandInformation
+        fields = ('name', 'variableName', 'variableUnit', 'method', 'comment', 'noDataValue',
+                  'maximumValue', 'minimumValue')
+
+
+class CellInformationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CellInformation
+        fields = ('name', 'rows', 'columns', 'cellSizeXValue', 'cellSizeYValue', 'cellDataType')
+
+
+class GeoRasterMetaDataSerializer(CoreMetaDataSerializer):
+    originalCoverage = OrginalCoverageSerializer(required=False, many=False)
+    cellInformation = CellInformationSerializer(required=False, many=False)
+    bandInformations = BandInformationSerializer(required=False, many=True)
+
+    class Meta:
+        model = RasterMetaData

--- a/hs_geo_raster_resource/tests/test_raster_metadata.py
+++ b/hs_geo_raster_resource/tests/test_raster_metadata.py
@@ -636,7 +636,7 @@ class TestRasterMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
         metadata = []
         metadata.append({'bandinformation': band_data})
         with self.assertRaises(ValidationError):
-            self.resRaster.metadata.update(metadata)
+            self.resRaster.metadata.update(metadata, self.user)
         self.assertEqual(self.resRaster.metadata.bandInformations.all().count(), 0)
         del metadata[:]
         # adding a valid tiff file should generate some core metadata and all extended metadata
@@ -665,7 +665,7 @@ class TestRasterMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
 
         metadata.append({'bandinformation': band_data})
         with self.assertRaises(ValidationError):
-            self.resRaster.metadata.update(metadata)
+            self.resRaster.metadata.update(metadata, self.user)
         self.assertEqual(self.resRaster.metadata.bandInformations.all().count(), 1)
         # updating of bandinformation using a valid band lookup name (Band_1) should be successful
         band_data = {'original_band_name': 'Band_1',
@@ -680,7 +680,7 @@ class TestRasterMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                      }
         del metadata[:]
         metadata.append({'bandinformation': band_data})
-        self.resRaster.metadata.update(metadata)
+        self.resRaster.metadata.update(metadata, self.user)
         self.assertEqual(self.resRaster.metadata.bandInformations.all().count(), 1)
         band_info = self.resRaster.metadata.bandInformations.first()
         self.assertEqual(band_info.name, 'Band_2')
@@ -698,7 +698,7 @@ class TestRasterMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                      }
         del metadata[:]
         metadata.append({'bandinformation': band_data})
-        self.resRaster.metadata.update(metadata)
+        self.resRaster.metadata.update(metadata, self.user)
         self.assertEqual(self.resRaster.metadata.bandInformations.all().count(), 1)
         band_info = self.resRaster.metadata.bandInformations.first()
         self.assertEqual(band_info.name, 'Band_1')
@@ -717,7 +717,7 @@ class TestRasterMetaData(MockIRODSTestCaseMixin, TestCaseCommonUtilities, Transa
                      'name': 'Band_3'
                      }
         metadata.append({'bandinformation': band_data})
-        self.resRaster.metadata.update(metadata)
+        self.resRaster.metadata.update(metadata, self.user)
         band_info = self.resRaster.metadata.bandInformations.first()
         self.assertEqual(band_info.name, 'Band_3')
         # there should be 2 creators

--- a/hs_model_program/forms.py
+++ b/hs_model_program/forms.py
@@ -90,7 +90,7 @@ class mp_form(ModelForm):
         exclude = ['content_object']
 
 
-class mp_form_validation(forms.Form):
+class ModelProgramMetadataValidationForm(forms.Form):
     modelVersion = forms.CharField(required=False)
     modelProgramLanguage = forms.CharField(required=False)
     modelOperatingSystem = forms.CharField(required=False)
@@ -101,5 +101,3 @@ class mp_form_validation(forms.Form):
     modelDocumentation = forms.CharField(required=False)
     modelSoftware = forms.CharField(required=False)
     modelEngine = forms.CharField(required=False)
-
-

--- a/hs_model_program/models.py
+++ b/hs_model_program/models.py
@@ -105,8 +105,23 @@ class ModelProgramMetaData(CoreMetaData):
         return ModelProgramResource.objects.filter(object_id=self.id).first()
 
     @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self """
+        from serializers import ModelProgramMetaDataSerializer
+        return ModelProgramMetaDataSerializer(self)
+
+    @property
     def program(self):
         return self._mpmetadata.all().first()
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Overriding the base class method"""
+
+        CoreMetaData.parse_for_bulk_update(metadata, parsed_metadata)
+        keys_to_update = metadata.keys()
+        if 'mpmetadata' in keys_to_update:
+            parsed_metadata.append({"mpmetadata": metadata.pop('mpmetadata')})
 
     @classmethod
     def get_supported_element_names(cls):

--- a/hs_model_program/models.py
+++ b/hs_model_program/models.py
@@ -116,9 +116,9 @@ class ModelProgramMetaData(CoreMetaData):
         elements.append('MpMetadata')
         return elements
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
-        super(ModelProgramMetaData, self).update(metadata)
+        super(ModelProgramMetaData, self).update(metadata, user)
         attribute_mappings = {'mpmetadata': 'program'}
         with transaction.atomic():
             # update/create non-repeatable element

--- a/hs_model_program/receivers.py
+++ b/hs_model_program/receivers.py
@@ -14,7 +14,7 @@ def metadata_element_pre_create_handler(sender, **kwargs):
     request = kwargs['request']
 
     if element_name == "mpmetadata":
-        element_form = mp_form_validation(request.POST)
+        element_form = ModelProgramMetadataValidationForm(request.POST)
 
     if element_form.is_valid():
         return {'is_valid': True, 'element_data_dict': element_form.cleaned_data}
@@ -28,7 +28,7 @@ def mp_pre_update_handler(sender, **kwargs):
     request = kwargs['request']
 
     if element_name == "mpmetadata":
-        element_form = mp_form_validation(request.POST)
+        element_form = ModelProgramMetadataValidationForm(request.POST)
 
     if element_form.is_valid():
         cleaned_form = element_form.cleaned_data

--- a/hs_model_program/serializers.py
+++ b/hs_model_program/serializers.py
@@ -1,0 +1,21 @@
+from rest_framework import serializers
+
+from hs_core.views.resource_metadata_rest_api import CoreMetaDataSerializer
+from models import MpMetadata, ModelProgramMetaData
+
+
+class MpMetaDataSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = MpMetadata
+        fields = ('modelVersion', 'modelProgramLanguage', 'modelOperatingSystem',
+                  'modelReleaseDate', 'modelWebsite', 'modelCodeRepository',
+                  'modelReleaseNotes', 'modelDocumentation', 'modelSoftware',
+                  'modelEngine')
+
+
+class ModelProgramMetaDataSerializer(CoreMetaDataSerializer):
+    program = MpMetaDataSerializer(required=False, many=False)
+
+    class Meta:
+        model = ModelProgramMetaData

--- a/hs_model_program/tests/test_model_program_metadata.py
+++ b/hs_model_program/tests/test_model_program_metadata.py
@@ -435,7 +435,8 @@ class TestModelProgramMetaData(MockIRODSTestCaseMixin, TransactionTestCase):
         self.assertEqual(self.resModelProgram.metadata.creators.count(), 1)
         self.resModelProgram.metadata.update([{'creator': {'name': 'Second Creator'}},
                                               {'creator': {'name': 'Third Creator'}},
-                                              {'mpmetadata': {'modelVersion': '5.1.012'}}], self.user)
+                                              {'mpmetadata': {'modelVersion': '5.1.012'}}],
+                                             self.user)
         # there should be 2 creators at this point (previously existed creator gets
         # delete as part of the update() call
         self.assertEqual(self.resModelProgram.metadata.creators.count(), 2)

--- a/hs_model_program/tests/test_model_program_metadata.py
+++ b/hs_model_program/tests/test_model_program_metadata.py
@@ -427,7 +427,7 @@ class TestModelProgramMetaData(MockIRODSTestCaseMixin, TransactionTestCase):
                                              'modelSoftware': 'utilities.exe',
                                              'modelEngine': 'sourceCode.zip'}}
 
-        self.resModelProgram.metadata.update([model_program_data])
+        self.resModelProgram.metadata.update([model_program_data], self.user)
         # check that there is extended metadata elements at this point
         self.assertNotEqual(self.resModelProgram.metadata.program, None)
         # test that we can also update core metadata using update()
@@ -435,7 +435,7 @@ class TestModelProgramMetaData(MockIRODSTestCaseMixin, TransactionTestCase):
         self.assertEqual(self.resModelProgram.metadata.creators.count(), 1)
         self.resModelProgram.metadata.update([{'creator': {'name': 'Second Creator'}},
                                               {'creator': {'name': 'Third Creator'}},
-                                              {'mpmetadata': {'modelVersion': '5.1.012'}}])
+                                              {'mpmetadata': {'modelVersion': '5.1.012'}}], self.user)
         # there should be 2 creators at this point (previously existed creator gets
         # delete as part of the update() call
         self.assertEqual(self.resModelProgram.metadata.creators.count(), 2)

--- a/hs_modelinstance/models.py
+++ b/hs_modelinstance/models.py
@@ -137,6 +137,24 @@ class ModelInstanceMetaData(CoreMetaData):
     def executed_by(self):
         return self._executed_by.all().first()
 
+    @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self """
+        from serializers import ModelInstanceMetaDataSerializer
+        return ModelInstanceMetaDataSerializer(self)
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Overriding the base class method"""
+
+        CoreMetaData.parse_for_bulk_update(metadata, parsed_metadata)
+        keys_to_update = metadata.keys()
+        if 'modeloutput' in keys_to_update:
+            parsed_metadata.append({"modeloutput": metadata.pop('modeloutput')})
+
+        if 'executedby' in keys_to_update:
+            parsed_metadata.append({"executedby": metadata.pop('executedby')})
+
     @classmethod
     def get_supported_element_names(cls):
         # get the names of all core metadata elements

--- a/hs_modelinstance/models.py
+++ b/hs_modelinstance/models.py
@@ -146,9 +146,9 @@ class ModelInstanceMetaData(CoreMetaData):
         elements.append('ExecutedBy')
         return elements
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
-        super(ModelInstanceMetaData, self).update(metadata)
+        super(ModelInstanceMetaData, self).update(metadata, user)
         attribute_mappings = {'modeloutput': 'model_output', 'executedby': 'executed_by'}
         with transaction.atomic():
             # update/create non-repeatable element

--- a/hs_modelinstance/serializers.py
+++ b/hs_modelinstance/serializers.py
@@ -1,0 +1,26 @@
+from rest_framework import serializers
+
+from hs_core.views.resource_metadata_rest_api import CoreMetaDataSerializer
+from models import ModelOutput, ExecutedBy, ModelInstanceMetaData
+
+
+class ModelOutputMetaDataSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = ModelOutput
+        fields = ('includes_output',)
+
+
+class ExecutedByMetaDataSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = ExecutedBy
+        fields = ('modelProgramName', 'modelProgramIdentifier')
+
+
+class ModelInstanceMetaDataSerializer(CoreMetaDataSerializer):
+    model_output = ModelOutputMetaDataSerializer(required=False, many=False)
+    executed_by = ExecutedByMetaDataSerializer(required=False, many=False)
+
+    class Meta:
+        model = ModelInstanceMetaData

--- a/hs_modelinstance/tests/test_modelinstance_metadata.py
+++ b/hs_modelinstance/tests/test_modelinstance_metadata.py
@@ -397,17 +397,19 @@ class TestModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCase):
         self.assertEquals(self.resModelInstance.metadata.model_output, None)
         self.assertEquals(self.resModelInstance.metadata.executed_by, None)
         # create modeloutput element using the update()
-        self.resModelInstance.metadata.update([{'modeloutput': {'includes_output': False}}])
+        self.resModelInstance.metadata.update([{'modeloutput': {'includes_output': False}}],
+                                              self.user)
         self.assertNotEqual(self.resModelInstance.metadata.model_output, None)
 
-        self.resModelInstance.metadata.update([{'modeloutput': {'includes_output': True}}])
+        self.resModelInstance.metadata.update([{'modeloutput': {'includes_output': True}}],
+                                              self.user)
         self.assertEqual(self.resModelInstance.metadata.model_output.includes_output, True)
 
         # test that we can also update core metadata using update()
         # there should be a creator element
         self.assertEqual(self.resModelInstance.metadata.creators.count(), 1)
         self.resModelInstance.metadata.update([{'creator': {'name': 'Second Creator'}},
-                                               {'creator': {'name': 'Third Creator'}}])
+                                               {'creator': {'name': 'Third Creator'}}], self.user)
         # there should be 2 creators at this point (previously existed creator gets
         # delete as part of the update() call
         self.assertEqual(self.resModelInstance.metadata.creators.count(), 2)
@@ -416,7 +418,7 @@ class TestModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCase):
         metadata = list()
         metadata.append({'executedby': {'model_name': self.resModelProgram.short_id}})
         metadata.append({'modeloutput': {'includes_output': False}})
-        self.resModelInstance.metadata.update(metadata)
+        self.resModelInstance.metadata.update(metadata, self.user)
         # check that there are extended metadata elements at this point
         self.assertNotEqual(self.resModelInstance.metadata.model_output, None)
         self.assertNotEqual(self.resModelInstance.metadata.executed_by, None)

--- a/hs_modflow_modelinstance/models.py
+++ b/hs_modflow_modelinstance/models.py
@@ -693,6 +693,43 @@ class MODFLOWModelInstanceMetaData(ModelInstanceMetaData):
     def general_elements(self):
         return self._general_elements.all().first()
 
+    @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self """
+        from serializers import MODFLOWModelInstanceMetaDataSerializer
+        return MODFLOWModelInstanceMetaDataSerializer(self)
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Overriding the base class method"""
+
+        ModelInstanceMetaData.parse_for_bulk_update(metadata, parsed_metadata)
+        keys_to_update = metadata.keys()
+        if 'studyarea' in keys_to_update:
+            parsed_metadata.append({"studyarea": metadata.pop('studyarea')})
+
+        if 'griddimensions' in keys_to_update:
+            parsed_metadata.append({"griddimensions": metadata.pop('griddimensions')})
+
+        if 'stressperiod' in keys_to_update:
+            parsed_metadata.append({"stressperiod": metadata.pop('stressperiod')})
+
+        if 'groundwaterflow' in keys_to_update:
+            parsed_metadata.append({"groundwaterflow": metadata.pop('groundwaterflow')})
+
+        if 'boundarycondition' in keys_to_update:
+            parsed_metadata.append({"boundarycondition": metadata.pop('boundarycondition')})
+
+        if 'modelcalibration' in keys_to_update:
+            parsed_metadata.append({"modelcalibration": metadata.pop('modelcalibration')})
+
+        if 'generalelements' in keys_to_update:
+            parsed_metadata.append({"generalelements": metadata.pop('generalelements')})
+
+        if 'modelinputs' in keys_to_update:
+            for modelinput in metadata.pop('modelinputs'):
+                parsed_metadata.append({"modelinput": modelinput})
+
     @classmethod
     def get_supported_element_names(cls):
         # get the names of all core metadata elements

--- a/hs_modflow_modelinstance/models.py
+++ b/hs_modflow_modelinstance/models.py
@@ -708,9 +708,9 @@ class MODFLOWModelInstanceMetaData(ModelInstanceMetaData):
         elements.append('GeneralElements')
         return elements
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method
-        super(MODFLOWModelInstanceMetaData, self).update(metadata)
+        super(MODFLOWModelInstanceMetaData, self).update(metadata, user)
         attribute_mappings = {'studyarea': 'study_area',
                               'griddimensions': 'grid_dimensions',
                               'stressperiod': 'stress_period',

--- a/hs_modflow_modelinstance/serializers.py
+++ b/hs_modflow_modelinstance/serializers.py
@@ -1,0 +1,122 @@
+from rest_framework import serializers
+
+from hs_modelinstance.serializers import ModelInstanceMetaDataSerializer
+from models import ModelOutput, ExecutedBy, StudyArea, GridDimensions, \
+    StressPeriod, GroundWaterFlow, BoundaryCondition, ModelCalibration,\
+    ModelInput, GeneralElements, SpecifiedHeadBoundaryPackageChoices, \
+    SpecifiedFluxBoundaryPackageChoices, HeadDependentFluxBoundaryPackageChoices, \
+    OutputControlPackageChoices, MODFLOWModelInstanceMetaData
+
+
+class ModelOutputMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelOutput
+        fields = ('includes_output',)
+
+
+class ExecutedByMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ExecutedBy
+        fields = ('modelProgramName', 'modelProgramIdentifier')
+
+
+class StudyAreaMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StudyArea
+        fields = ('totalLength', 'totalWidth', 'maximumElevation', 'minimumElevation')
+
+
+class GridDimensionsMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GridDimensions
+        fields = ('numberOfLayers', 'typeOfRows', 'numberOfRows',
+                  'typeOfColumns', 'numberOfColumns')
+
+
+class StressPeriodMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StressPeriod
+        fields = ('stressPeriodType', 'steadyStateValue', 'transientStateValueType',
+                  'transientStateValue')
+
+
+class GroundWaterFlowMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GroundWaterFlow
+        fields = ('flowPackage', 'flowParameter')
+
+
+class SpecifiedHeadBoundaryPackageChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SpecifiedHeadBoundaryPackageChoices
+        fields = ('description',)
+
+
+class SpecifiedFluxBoundaryPackageChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SpecifiedFluxBoundaryPackageChoices
+        fields = ('description',)
+
+
+class HeadDependentFluxBoundaryPackageChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = HeadDependentFluxBoundaryPackageChoices
+        fields = ('description',)
+
+
+class OutputControlPackageChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OutputControlPackageChoices
+        fields = ('description',)
+
+
+class BoundaryConditionMetaDataSerializer(serializers.ModelSerializer):
+    specified_head_boundary_packages = SpecifiedHeadBoundaryPackageChoicesMetaDataSerializer(
+        required=False, many=True)
+    specified_flux_boundary_packages = SpecifiedHeadBoundaryPackageChoicesMetaDataSerializer(
+        required=False, many=True)
+    head_dependent_flux_boundary_packages = \
+        HeadDependentFluxBoundaryPackageChoicesMetaDataSerializer(required=False, many=True)
+
+    class Meta:
+        model = BoundaryCondition
+        fields = ('specified_head_boundary_packages', 'other_specified_head_boundary_packages',
+                  'specified_flux_boundary_packages', 'other_specified_flux_boundary_packages',
+                  'head_dependent_flux_boundary_packages',
+                  'other_head_dependent_flux_boundary_packages')
+
+
+class ModelCalibrationMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelCalibration
+        fields = ('calibratedParameter', 'observationType',
+                  'observationProcessPackage', 'calibrationMethod')
+
+
+class ModelInputMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelInput
+        fields = ('inputType', 'inputSourceName', 'inputSourceURL')
+
+
+class GeneralElementsMetaDataSerializer(serializers.ModelSerializer):
+    output_control_package = OutputControlPackageChoicesMetaDataSerializer(required=False,
+                                                                           many=True)
+
+    class Meta:
+        model = GeneralElements
+        fields = ('modelParameter', 'modelSolver', 'output_control_package', 'subsidencePackage')
+
+
+class MODFLOWModelInstanceMetaDataSerializer(ModelInstanceMetaDataSerializer):
+    study_area = StudyAreaMetaDataSerializer(required=False, many=False)
+    grid_dimensions = GridDimensionsMetaDataSerializer(required=False, many=False)
+    stress_period = StressPeriodMetaDataSerializer(required=False, many=False)
+    ground_water_flow = GroundWaterFlowMetaDataSerializer(required=False, many=False)
+    boundary_condition = BoundaryConditionMetaDataSerializer(required=False, many=False)
+    model_calibration = ModelCalibrationMetaDataSerializer(required=False, many=False)
+    model_inputs = ModelInputMetaDataSerializer(required=False, many=True)
+    general_elements = GeneralElementsMetaDataSerializer(required=False, many=False)
+
+    class Meta:
+        model = MODFLOWModelInstanceMetaData

--- a/hs_modflow_modelinstance/tests/test_modflow_modelinstance_metadata.py
+++ b/hs_modflow_modelinstance/tests/test_modflow_modelinstance_metadata.py
@@ -1302,17 +1302,17 @@ class TestMODFLOWModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCa
         self.assertEqual(self.res.metadata.general_elements, None)
 
         # create modeloutput element using the update()
-        self.res.metadata.update([{'modeloutput': {'includes_output': False}}])
+        self.res.metadata.update([{'modeloutput': {'includes_output': False}}], self.user)
         self.assertNotEqual(self.res.metadata.model_output, None)
 
-        self.res.metadata.update([{'modeloutput': {'includes_output': True}}])
+        self.res.metadata.update([{'modeloutput': {'includes_output': True}}], self.user)
         self.assertEqual(self.res.metadata.model_output.includes_output, True)
 
         # test that we can also update core metadata using update()
         # there should be a creator element
         self.assertEqual(self.res.metadata.creators.count(), 1)
         self.res.metadata.update([{'creator': {'name': 'Second Creator'}},
-                                  {'creator': {'name': 'Third Creator'}}])
+                                  {'creator': {'name': 'Third Creator'}}], self.user)
         # there should be 2 creators at this point (previously existed creator gets
         # delete as part of the update() call
         self.assertEqual(self.res.metadata.creators.count(), 2)
@@ -1344,7 +1344,7 @@ class TestMODFLOWModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCa
         metadata.append({'modelcalibration': {'calibratedParameter': 'a', 'observationType': 'b',
                                               'observationProcessPackage': 'RVOB',
                                               'calibrationMethod': 'c'}})
-        self.res.metadata.update(metadata)
+        self.res.metadata.update(metadata, self.user)
         # check that there are extended metadata elements at this point
         self.assertNotEqual(self.res.metadata.model_output, None)
         self.assertNotEqual(self.res.metadata.executed_by, None)

--- a/hs_script_resource/models.py
+++ b/hs_script_resource/models.py
@@ -98,9 +98,9 @@ class ScriptMetaData(CoreMetaData):
 
         return missing_required_elements
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
-        super(ScriptMetaData, self).update(metadata)
+        super(ScriptMetaData, self).update(metadata, user)
         attribute_mappings = {'scriptspecificmetadata': 'program'}
         with transaction.atomic():
             # update/create non-repeatable element

--- a/hs_script_resource/models.py
+++ b/hs_script_resource/models.py
@@ -74,6 +74,26 @@ class ScriptMetaData(CoreMetaData):
     def program(self):
         return self.scriptspecificmetadata.all().first()
 
+    @property
+    def script_specific_metadata(self):
+        return self.program
+
+    @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self """
+        from serializers import ScriptMetaDataSerializer
+        return ScriptMetaDataSerializer(self)
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Overriding the base class method"""
+
+        CoreMetaData.parse_for_bulk_update(metadata, parsed_metadata)
+        keys_to_update = metadata.keys()
+        if 'scriptspecificmetadata' in keys_to_update:
+            parsed_metadata.append({"scriptspecificmetadata":
+                                    metadata.pop('scriptspecificmetadata')})
+
     @classmethod
     def get_supported_element_names(cls):
         elements = super(ScriptMetaData, cls).get_supported_element_names()

--- a/hs_script_resource/serializers.py
+++ b/hs_script_resource/serializers.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+
+from hs_core.views.resource_metadata_rest_api import CoreMetaDataSerializer
+from models import ScriptSpecificMetadata, ScriptMetaData
+
+
+class ScriptSpecificMetadataSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = ScriptSpecificMetadata
+        fields = ('scriptLanguage', 'languageVersion', 'scriptVersion', 'scriptDependencies',
+                  'scriptReleaseDate', 'scriptCodeRepository')
+
+
+class ScriptMetaDataSerializer(CoreMetaDataSerializer):
+    script_specific_metadata = ScriptSpecificMetadataSerializer(required=False, many=False)
+
+    class Meta:
+        model = ScriptMetaData

--- a/hs_script_resource/tests/test_script_resource.py
+++ b/hs_script_resource/tests/test_script_resource.py
@@ -122,7 +122,8 @@ class TestScriptResource(TransactionTestCase):
                                                                     'scriptReleaseDate':
                                                                         '2015-12-01 00:00',
                                                                     'scriptCodeRepository':
-                                                                        'http://www.google.com'}}])
+                                                                        'http://www.google.com'}}],
+                                       self.user)
         # check that there is now extended metadata elements at this point
         self.assertNotEqual(self.resScript.metadata.program, None)
         # test that we can also update core metadata using update()
@@ -130,7 +131,8 @@ class TestScriptResource(TransactionTestCase):
         self.assertEqual(self.resScript.metadata.creators.count(), 1)
         self.resScript.metadata.update([{'creator': {'name': 'Second Creator'}},
                                         {'creator': {'name': 'Third Creator'}},
-                                        {'scriptspecificmetadata': {'scriptVersion': '1.5'}}])
+                                        {'scriptspecificmetadata': {'scriptVersion': '1.5'}}],
+                                       self.user)
         # there should be 2 creators at this point (previously existed creator gets
         # delete as part of the update() call
         self.assertEqual(self.resScript.metadata.creators.count(), 2)

--- a/hs_swat_modelinstance/models.py
+++ b/hs_swat_modelinstance/models.py
@@ -488,8 +488,9 @@ class SWATModelInstanceMetaData(ModelInstanceMetaData):
                         if not validation_form.is_valid():
                             err_string = self.get_form_errors_as_string(validation_form)
                             raise ValidationError(err_string)
-                element_property_name = attribute_mappings[element_name]
-                self.update_non_repeatable_element(element_name, metadata, element_property_name)
+                        element_property_name = attribute_mappings[element_name]
+                        self.update_non_repeatable_element(element_name, metadata,
+                                                           element_property_name)
 
     def get_xml(self, pretty_print=True, include_format_elements=True):
 

--- a/hs_swat_modelinstance/models.py
+++ b/hs_swat_modelinstance/models.py
@@ -431,9 +431,9 @@ class SWATModelInstanceMetaData(ModelInstanceMetaData):
             missing_required_elements.append('ModelObjective')
         return missing_required_elements
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
-        super(SWATModelInstanceMetaData, self).update(metadata)
+        super(SWATModelInstanceMetaData, self).update(metadata, user)
         attribute_mappings = {'modelobjective': 'model_objective',
                               'simulationtype': 'simulation_type',
                               'modelmethod': 'model_method',

--- a/hs_swat_modelinstance/serializers.py
+++ b/hs_swat_modelinstance/serializers.py
@@ -1,0 +1,66 @@
+from rest_framework import serializers
+
+from hs_modelinstance.serializers import ModelInstanceMetaDataSerializer
+from models import ModelObjective, SimulationType, ModelMethod, ModelParameter, ModelInput, \
+     ModelObjectiveChoices, ModelParametersChoices, SWATModelInstanceMetaData
+
+
+class ModelObjectiveChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelObjectiveChoices
+        fields = ('description',)
+
+
+class ModelParametersChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelParametersChoices
+        fields = ('description',)
+
+
+class ModelObjectiveMetaDataSerializer(serializers.ModelSerializer):
+    swat_model_objectives = ModelObjectiveChoicesMetaDataSerializer(required=False, many=True)
+
+    class Meta:
+        model = ModelObjective
+        fields = ('swat_model_objectives', 'other_objectives')
+
+
+class SimulationTypeMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SimulationType
+        fields = ('simulation_type_name',)
+
+
+class ModelMethodMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelMethod
+        fields = ('runoffCalculationMethod', 'flowRoutingMethod', 'petEstimationMethod')
+
+
+class ModelParameterMetaDataSerializer(serializers.ModelSerializer):
+    model_parameters = ModelParametersChoicesMetaDataSerializer(required=False, many=True)
+
+    class Meta:
+        model = ModelParameter
+        fields = ('model_parameters', 'other_parameters')
+
+
+class ModelInputMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ModelInput
+        fields = ('warmupPeriodValue', 'rainfallTimeStepType', 'rainfallTimeStepValue',
+                  'routingTimeStepType', 'routingTimeStepValue', 'simulationTimeStepType',
+                  'simulationTimeStepValue', 'watershedArea', 'numberOfSubbasins', 'numberOfHRUs',
+                  'demResolution', 'demSourceName', 'demSourceURL', 'landUseDataSourceName',
+                  'landUseDataSourceURL', 'soilDataSourceName', 'soilDataSourceURL')
+
+
+class SWATModelInstanceMetaDataSerializer(ModelInstanceMetaDataSerializer):
+    model_objective = ModelObjectiveMetaDataSerializer(required=False, many=False)
+    simulation_type = SimulationTypeMetaDataSerializer(required=False, many=False)
+    model_method = ModelMethodMetaDataSerializer(required=False, many=False)
+    model_parameter = ModelParameterMetaDataSerializer(required=False, many=False)
+    model_input = ModelInputMetaDataSerializer(required=False, many=False)
+
+    class Meta:
+        model = SWATModelInstanceMetaData

--- a/hs_swat_modelinstance/tests/test_swat_modelinstance_metadata.py
+++ b/hs_swat_modelinstance/tests/test_swat_modelinstance_metadata.py
@@ -906,17 +906,20 @@ class TestSWATModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCase)
         self.assertEquals(self.resSWATModelInstance.metadata.model_objective, None)
 
         # create modeloutput element using the update()
-        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': False}}], self.user)
+        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': False}}],
+                                                  self.user)
         self.assertNotEqual(self.resSWATModelInstance.metadata.model_output, None)
 
-        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': True}}], self.user)
+        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': True}}],
+                                                  self.user)
         self.assertEqual(self.resSWATModelInstance.metadata.model_output.includes_output, True)
 
         # test that we can also update core metadata using update()
         # there should be a creator element
         self.assertEqual(self.resSWATModelInstance.metadata.creators.count(), 1)
         self.resSWATModelInstance.metadata.update([{'creator': {'name': 'Second Creator'}},
-                                                   {'creator': {'name': 'Third Creator'}}], self.user)
+                                                   {'creator': {'name': 'Third Creator'}}],
+                                                  self.user)
         # there should be 2 creators at this point (previously existed creator gets
         # delete as part of the update() call
         self.assertEqual(self.resSWATModelInstance.metadata.creators.count(), 2)

--- a/hs_swat_modelinstance/tests/test_swat_modelinstance_metadata.py
+++ b/hs_swat_modelinstance/tests/test_swat_modelinstance_metadata.py
@@ -906,17 +906,17 @@ class TestSWATModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCase)
         self.assertEquals(self.resSWATModelInstance.metadata.model_objective, None)
 
         # create modeloutput element using the update()
-        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': False}}])
+        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': False}}], self.user)
         self.assertNotEqual(self.resSWATModelInstance.metadata.model_output, None)
 
-        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': True}}])
+        self.resSWATModelInstance.metadata.update([{'modeloutput': {'includes_output': True}}], self.user)
         self.assertEqual(self.resSWATModelInstance.metadata.model_output.includes_output, True)
 
         # test that we can also update core metadata using update()
         # there should be a creator element
         self.assertEqual(self.resSWATModelInstance.metadata.creators.count(), 1)
         self.resSWATModelInstance.metadata.update([{'creator': {'name': 'Second Creator'}},
-                                                   {'creator': {'name': 'Third Creator'}}])
+                                                   {'creator': {'name': 'Third Creator'}}], self.user)
         # there should be 2 creators at this point (previously existed creator gets
         # delete as part of the update() call
         self.assertEqual(self.resSWATModelInstance.metadata.creators.count(), 2)
@@ -952,7 +952,7 @@ class TestSWATModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCase)
                                         'soilDataSourceName': 'p',
                                         'soilDataSourceURL': 'q'}})
 
-        self.resSWATModelInstance.metadata.update(metadata)
+        self.resSWATModelInstance.metadata.update(metadata, self.user)
 
         # check that there are extended metadata elements at this point
         self.assertNotEqual(self.resSWATModelInstance.metadata.model_output, None)

--- a/hs_swat_modelinstance/tests/test_swat_modelinstance_metadata.py
+++ b/hs_swat_modelinstance/tests/test_swat_modelinstance_metadata.py
@@ -949,11 +949,11 @@ class TestSWATModelInstanceMetaData(MockIRODSTestCaseMixin, TransactionTestCase)
                                         'numberOfHRUs': 'j',
                                         'demResolution': 'k',
                                         'demSourceName': 'l',
-                                        'demSourceURL': 'm',
+                                        'demSourceURL': 'http://dem-source.org',
                                         'landUseDataSourceName': 'n',
-                                        'landUseDataSourceURL': 'o',
+                                        'landUseDataSourceURL': 'http://land-data.org',
                                         'soilDataSourceName': 'p',
-                                        'soilDataSourceURL': 'q'}})
+                                        'soilDataSourceURL': 'http://soil-data.org'}})
 
         self.resSWATModelInstance.metadata.update(metadata, self.user)
 

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -161,6 +161,11 @@ class ToolIconForm(ModelForm):
         exclude = ['content_object']
 
 
+class ToolIconValidationForm(forms.Form):
+    value = forms.CharField(max_length=1024, required=False)
+    data_url = forms.URLField(required=False)
+
+
 class MetadataField(Field):
     def __init__(self, *args, **kwargs):
         kwargs['css_class'] = 'form-control input-sm'

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -245,7 +245,7 @@ class ToolIcon(AbstractMetaDataElement):
             raise ValidationError("Failed to read data from given url: {0}".format(ex.message))
         if response.status_code != 200:
             raise HttpResponse("Failed to read data from given url. HTTP_code {0}".
-                               fromat(response.status_code))
+                               format(response.status_code))
         image_size_mb = float(response.headers["content-length"])
         if image_size_mb > 1000000:  # 1mb
             raise ValidationError("Icon image size should be less than 1MB.")
@@ -300,6 +300,61 @@ class ToolMetaData(CoreMetaData):
     @property
     def resource(self):
         return ToolResource.objects.filter(object_id=self.id).first()
+
+    @property
+    def url_base(self):
+        return self.url_bases.all().first()
+
+    @property
+    def version(self):
+        return self.versions.all().first()
+
+    @property
+    def supported_resource_types(self):
+        return self.supported_res_types.all().first()
+        
+    @property
+    def supported_sharing_statuses(self):
+        return self.supported_sharing_status.all().first()
+
+    @property
+    def app_home_page_url(self):
+        return self.homepage_url.all().first()
+
+    @property
+    def app_icon(self):
+        return self.tool_icon.all().first()
+
+    @property
+    def serializer(self):
+        """Return an instance of rest_framework Serializer for self """
+        from serializers import ToolMetaDataSerializer
+        return ToolMetaDataSerializer(self)
+
+    @classmethod
+    def parse_for_bulk_update(cls, metadata, parsed_metadata):
+        """Overriding the base class method"""
+
+        CoreMetaData.parse_for_bulk_update(metadata, parsed_metadata)
+        keys_to_update = metadata.keys()
+        if 'requesturlbase' in keys_to_update:
+            parsed_metadata.append({"requesturlbase": metadata.pop('requesturlbase')})
+
+        if 'toolversion' in keys_to_update:
+            parsed_metadata.append({"toolversion": metadata.pop('toolversion')})
+
+        if 'toolicon' in keys_to_update:
+            parsed_metadata.append({"toolicon": metadata.pop('toolicon')})
+
+        if 'apphomepageurl' in keys_to_update:
+            parsed_metadata.append({"apphomepageurl": metadata.pop('apphomepageurl')})
+
+        if 'supportedrestypes' in keys_to_update:
+            parsed_metadata.append({"supportedrestypes": metadata.pop('supportedrestypes')})
+
+        if 'supportedsharingstatuses' in keys_to_update:
+            parsed_metadata.append({"supportedsharingstatus":
+                                    metadata.pop('supportedsharingstatuses')})
 
     @classmethod
     def get_supported_element_names(cls):

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -355,11 +355,11 @@ class ToolMetaData(CoreMetaData):
         self.supported_sharing_status.all().delete()
         self.homepage_url.all().delete()
 
-    def update(self, metadata):
+    def update(self, metadata, user):
         # overriding the base class update method for bulk update of metadata
 
         # update any core metadata
-        super(ToolMetaData, self).update(metadata)
+        super(ToolMetaData, self).update(metadata, user)
         # update resource specific metadata
         with transaction.atomic():
             for dict_item in metadata:

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -312,7 +312,7 @@ class ToolMetaData(CoreMetaData):
     @property
     def supported_resource_types(self):
         return self.supported_res_types.all().first()
-        
+
     @property
     def supported_sharing_statuses(self):
         return self.supported_sharing_status.all().first()

--- a/hs_tools_resource/serializers.py
+++ b/hs_tools_resource/serializers.py
@@ -1,0 +1,70 @@
+from rest_framework import serializers
+
+from hs_core.views.resource_metadata_rest_api import CoreMetaDataSerializer
+from models import AppHomePageUrl, RequestUrlBase, ToolVersion, SupportedResTypeChoices, \
+    SupportedResTypes, SupportedSharingStatusChoices, SupportedSharingStatus, ToolIcon, \
+    ToolMetaData
+
+
+class SupportedResTypeChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SupportedResTypeChoices
+        fields = ('description',)
+
+
+class SupportedSharingStatusChoicesMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SupportedSharingStatusChoices
+        fields = ('description',)
+
+
+class AppHomePageUrlMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AppHomePageUrl
+        fields = ('value',)
+
+
+class RequestUrlBaseMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RequestUrlBase
+        fields = ('value',)
+
+
+class ToolVersionMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ToolVersion
+        fields = ('value',)
+
+
+class SupportedResTypesMetaDataSerializer(serializers.ModelSerializer):
+    supported_res_types = SupportedResTypeChoicesMetaDataSerializer(required=False, many=True)
+
+    class Meta:
+        model = SupportedResTypes
+        fields = ('supported_res_types', )
+
+
+class SupportedSharingStatusMetaDataSerializer(serializers.ModelSerializer):
+    sharing_status = SupportedSharingStatusChoicesMetaDataSerializer(required=False, many=True)
+
+    class Meta:
+        model = SupportedSharingStatus
+        fields = ('sharing_status', )
+
+
+class ToolIconMetaDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ToolIcon
+        fields = ('value',)
+
+
+class ToolMetaDataSerializer(CoreMetaDataSerializer):
+    url_base = RequestUrlBaseMetaDataSerializer(required=False, many=False)
+    version = ToolVersionMetaDataSerializer(required=False, many=False)
+    supported_resource_types = SupportedResTypesMetaDataSerializer(required=False, many=False)
+    app_icon = ToolIconMetaDataSerializer(required=False, many=False)
+    supported_sharing_statuses = SupportedSharingStatusMetaDataSerializer(required=False, many=False)
+    app_home_page_url = AppHomePageUrlMetaDataSerializer(required=False, many=False)
+
+    class Meta:
+        model = ToolMetaData

--- a/hs_tools_resource/serializers.py
+++ b/hs_tools_resource/serializers.py
@@ -63,7 +63,8 @@ class ToolMetaDataSerializer(CoreMetaDataSerializer):
     version = ToolVersionMetaDataSerializer(required=False, many=False)
     supported_resource_types = SupportedResTypesMetaDataSerializer(required=False, many=False)
     app_icon = ToolIconMetaDataSerializer(required=False, many=False)
-    supported_sharing_statuses = SupportedSharingStatusMetaDataSerializer(required=False, many=False)
+    supported_sharing_statuses = SupportedSharingStatusMetaDataSerializer(required=False,
+                                                                          many=False)
     app_home_page_url = AppHomePageUrlMetaDataSerializer(required=False, many=False)
 
     class Meta:

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -239,7 +239,7 @@ class TestWebAppFeature(TransactionTestCase):
         # create 1 RequestUrlBase obj with required params
         metadata = []
         metadata.append({'requesturlbase': {'value': 'https://www.google.com'}})
-        self.resWebApp.metadata.update(metadata)
+        self.resWebApp.metadata.update(metadata, self.user)
         self.assertEqual(RequestUrlBase.objects.all().count(), 1)
         # no ToolVersion obj
         self.assertEqual(ToolVersion.objects.all().count(), 0)
@@ -247,7 +247,7 @@ class TestWebAppFeature(TransactionTestCase):
         # create 1 ToolVersion obj with required params
         del metadata[:]
         metadata.append({'toolversion': {'value': '1.0'}})
-        self.resWebApp.metadata.update(metadata)
+        self.resWebApp.metadata.update(metadata, self.user)
         self.assertEqual(ToolVersion.objects.all().count(), 1)
 
         # update/create multiple metadata elements
@@ -262,7 +262,7 @@ class TestWebAppFeature(TransactionTestCase):
         # update tool version
         metadata.append({'toolversion': {'value': '2.0'}})
         # do the bulk metadata update
-        self.resWebApp.metadata.update(metadata)
+        self.resWebApp.metadata.update(metadata, self.user)
         self.assertEqual(SupportedResTypes.objects.all().count(), 1)
         supported_res_type = SupportedResTypes.objects.first()
         for res_type in supported_res_type.supported_res_types.all():
@@ -276,7 +276,7 @@ class TestWebAppFeature(TransactionTestCase):
         metadata.append({'supportedsharingstatus': {'sharing_status':
                                                     ['Public', 'Discoverable']}})
         # do the bulk metadata update
-        self.resWebApp.metadata.update(metadata)
+        self.resWebApp.metadata.update(metadata, self.user)
         self.assertEqual(SupportedSharingStatus.objects.all().count(), 1)
         supported_sharing_status = SupportedSharingStatus.objects.first()
         for sharing_status in supported_sharing_status.sharing_status.all():
@@ -290,7 +290,7 @@ class TestWebAppFeature(TransactionTestCase):
         metadata.append({'toolicon': {'value':
                                       'https://www.hydroshare.org/static/img/logo-sm.png'}})
         # do the bulk metadata update
-        self.resWebApp.metadata.update(metadata)
+        self.resWebApp.metadata.update(metadata, self.user)
         self.assertEqual(ToolIcon.objects.all().count(), 1)
         self.assertEqual(ToolIcon.objects.first().value,
                          'https://www.hydroshare.org/static/img/logo-sm.png')
@@ -303,7 +303,7 @@ class TestWebAppFeature(TransactionTestCase):
         # create 1 AppHomePageUrl obj with required params
         metadata.append({'apphomepageurl': {'value': 'https://my_web_app.com'}})
         # do the bulk metadata update
-        self.resWebApp.metadata.update(metadata)
+        self.resWebApp.metadata.update(metadata, self.user)
         self.assertEqual(AppHomePageUrl.objects.all().count(), 1)
         self.assertEqual(AppHomePageUrl.objects.first().value, 'https://my_web_app.com')
         self.resWebApp.delete()

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -301,11 +301,11 @@ class TestWebAppFeature(TransactionTestCase):
         self.assertEqual(AppHomePageUrl.objects.all().count(), 0)
 
         # create 1 AppHomePageUrl obj with required params
-        metadata.append({'apphomepageurl': {'value': 'https://my_web_app.com'}})
+        metadata.append({'apphomepageurl': {'value': 'https://mywebapp.com'}})
         # do the bulk metadata update
         self.resWebApp.metadata.update(metadata, self.user)
         self.assertEqual(AppHomePageUrl.objects.all().count(), 1)
-        self.assertEqual(AppHomePageUrl.objects.first().value, 'https://my_web_app.com')
+        self.assertEqual(AppHomePageUrl.objects.first().value, 'https://mywebapp.com')
         self.resWebApp.delete()
 
     def test_utils(self):


### PR DESCRIPTION
This work enables editing of resource specific metadata editing in addition to core metadata using REST API.