### PR TITLE
Creating user/ endpoint

### DIFF
--- a/hs_rest_api/urls.py
+++ b/hs_rest_api/urls.py
@@ -119,6 +119,9 @@ urlpatterns = patterns(
         views.resource_rest_api.CheckTaskStatus.as_view(),
         name='get_task_status'),
 
+    url(r'^user/$',
+        views.user_rest_api.UserInfo.as_view(), name='get_logged_in_user_info'),
+
     url(r'^userInfo/$',
         views.user_rest_api.UserInfo.as_view(), name='get_logged_in_user_info'),
 


### PR DESCRIPTION
Tiny request from that fixes #2259 

Alva had requested that we rename userInfo/ to simply user/. I kept userInfo around for backwards compatibility