### PR TITLE
[#2341] pip install djangorestframework==3.6.4 prior to pip install d…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM mjstealey/hs_docker_base:1.9.5
 MAINTAINER Michael J. Stealey <stealey@renci.org>
 
 ### Begin - HydroShare Development Image Additions ###
-RUN pip install --upgrade pip && pip install \
+RUN pip install --upgrade pip && pip install djangorestframework==3.6.4
+RUN pip install \
   robot_detection \
   django-ipware \
   django-test-without-migrations \


### PR DESCRIPTION
…jango-rest-framework. This pull request has fewer commits from the branch of the same name which was merged into develop earlier this week. (Merged into develop already because builds based off develop were failing without it due to a change in an upstream dependency.) The purpose of this PR is simply to allow the RC to build with the correct version of the upstream dependency. The RC build will fail otherwise.