### PR TITLE
[#2536] Fix for URLs in abstract

### DIFF
--- a/theme/templates/resource-landing-page/abstract.html
+++ b/theme/templates/resource-landing-page/abstract.html
@@ -16,7 +16,7 @@
                 <div id="div_id_abstract" class="control-group">
                     <div class="controls"><textarea class="form-control input-sm textarea" cols="40"
                                                     id="id_abstract" name="abstract"
-                                                    rows="10">{{ cm.metadata.description|urlize }}</textarea></div>
+                                                    rows="10">{{ cm.metadata.description }}</textarea></div>
                 </div>
                 <div style="margin-top:10px">
                     <button id="btn-submit-abstract" type="button" class="btn btn-primary pull-right btn-form-submit"


### PR DESCRIPTION
This prevents the error from occurring again, but the resources affected need to be manually fixed by editing their abstracts. 

This bug occurred because the URL strings were being parsed and converted to links every time the abstract was changed. Solved it by converting only when rendering in view mode and not in the form input.