### PR TITLE
Temporary disabling of discovery sorting

### DIFF
--- a/hs_core/discovery_form.py
+++ b/hs_core/discovery_form.py
@@ -1,7 +1,5 @@
 from haystack.forms import FacetedSearchForm
-from haystack.query import SQ, SearchQuerySet
-from crispy_forms.layout import *
-from crispy_forms.bootstrap import *
+from haystack.query import SQ
 from django import forms
 
 class DiscoveryForm(FacetedSearchForm):

--- a/hs_core/templates/search/search.html
+++ b/hs_core/templates/search/search.html
@@ -11,9 +11,6 @@
             </h2>
         </div>
         <div class="col-sm-9 col-sm-offset-3 col-xs-12">
-            <button id="solr-help-info" class="btn btn-info" data-toggle="popover" data-placement="right"><i
-                    class="glyphicon glyphicon-info-sign"></i></button>
-
             <div id="discover-resource-search" class="resource-search">
                 <form id="search-field" method="get" action="." class="search-field">
                     {% for field in form %}

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1836,7 +1836,7 @@ a.tag:hover {
 }
 
 #discover-resource-search {
-	width: calc(100% - 50px);
+	width: 100%;
 	margin-bottom: 20px;
 	margin-left: 10px;
 	float: right;

--- a/theme/static/js/discover.js
+++ b/theme/static/js/discover.js
@@ -823,7 +823,8 @@ function initializeTable() {
         "paging": false,
         "searching": false,
         "info": false,
-        "order": [[TITLE_COL, "asc"]],
+        "ordering": false,
+        // "order": [[TITLE_COL, "asc"]],
         "columnDefs": colDefs
     });
 }

--- a/theme/static/js/discover.js
+++ b/theme/static/js/discover.js
@@ -975,10 +975,10 @@ $(document).ready(function () {
     });
 
 
-    $("#solr-help-info").popover({
-        html: true,
-        container: '#body',
-        content: '<p>Search here to find all public and discoverable resources. This search box supports <a href="https://cwiki.apache.org/confluence/display/solr/Searching" target="_blank">SOLR Query syntax</a>.</p>',
-        trigger: 'click'
-    });
+    // $("#solr-help-info").popover({
+    //     html: true,
+    //     container: '#body',
+    //     content: '<p>Search here to find all public and discoverable resources. This search box supports <a href="https://cwiki.apache.org/confluence/display/solr/Searching" target="_blank">SOLR Query syntax</a>.</p>',
+    //     trigger: 'click'
+    // });
 });


### PR DESCRIPTION
Temporarily fixes #2397 

This simply disables the sorting functionality as it is confusing. This is temporary for this week's discovery hotfix deploy.

Also fixes #2396 - removed the SOLR popup