### PR TITLE
[#2479] Changing URL parsing method.

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -894,7 +894,7 @@
                                             {% for source in sources %}
                                                 <div class="row">
                                                     <div class="col-sm-4"><strong>Derived From:</strong></div>
-                                                    <div class="col-sm-8 url-clickable">{{ source.derived_from }}</div>
+                                                    <div class="col-sm-8">{{ source.derived_from|urlize }}</div>
                                                 </div>
                                             {% endfor %}
                                         {% endif %}
@@ -906,7 +906,7 @@
                                                 {% if  relation.type|lower != "haspart"%}
                                                     <div class="row">
                                                         <div class="col-sm-4"><strong>{{ relation.type }}:</strong></div>
-                                                        <div class="col-sm-8 url-clickable">{{ relation.value }}</div>
+                                                        <div class="col-sm-8">{{ relation.value|urlize }}</div>
                                                     </div>
                                                 {% endif %}
                                             {% endfor %}
@@ -919,7 +919,7 @@
                                                 {% for source in source_formset.initial %}
                                                     <tr>
                                                         <th scope="row" class="dataset-label">Derived From:</th>
-                                                        <td class="dataset-details url-clickable">{{ source.derived_from }}</td>
+                                                        <td class="dataset-details">{{ source.derived_from|urlize }}</td>
                                                         <td>
                                                             <a data-toggle="modal" data-placement="auto" title="Edit"
                                                                class="glyphicon glyphicon-pencil icon-button icon-blue"
@@ -954,7 +954,7 @@
                                                     {% if  relation.type|lower != "haspart"%}
                                                         <tr>
                                                             <th scope="row" class="dataset-label">{{ relation.type }}:</th>
-                                                            <td class="dataset-details url-clickable">{{ relation.value }}</td>
+                                                            <td class="dataset-details">{{ relation.value|urlize }}</td>
                                                             <td>
                                                                 <a data-toggle="modal" data-placement="auto" title="Edit"
                                                                    class="glyphicon glyphicon-pencil icon-button icon-blue"
@@ -1129,8 +1129,8 @@
                                                     <td>
                                                         {{ extra_meta_name }}
                                                     </td>
-                                                    <td class="url-clickable">
-                                                        {{ extra_meta_value }}
+                                                    <td>
+                                                        {{ extra_meta_value|urlize }}
                                                     </td>
                                                     {% if metadata_form %}
                                                         <td>

--- a/theme/static/js/custom.js
+++ b/theme/static/js/custom.js
@@ -1,4 +1,5 @@
 (function ($) {
+    // Used to instantiate clickable urls in dynamically generated items
     $.fn.urlClickable = function () {
         var item = $(this);
 
@@ -148,11 +149,6 @@ $(document).ready(function () {
     }
 
     $("#keywords").remove();
-
-    // Make URLs inside text clickable
-    $(".url-clickable").each(function () {
-        $(this).urlClickable();
-    });
 
     // Make apps link open in new tab
     $('a[href^="https://appsdev.hydroshare.org/apps"]').attr('target', '_blank');

--- a/theme/templates/resource-landing-page/citation.html
+++ b/theme/templates/resource-landing-page/citation.html
@@ -6,7 +6,7 @@
     <div class="row">
         <div class="col-xs-12">
             <div class="flex">
-                <div id="citation-text" class="url-clickable">{{ citation }}</div>
+                <div id="citation-text">{{ citation|urlize }}</div>
 
                 <button class="btn btn-default clipboard-copy" data-target="citation-text"
                         type="button">


### PR DESCRIPTION
Simple change. Fixes some URL parsing errors for Relations, Sources as well as content in Extended Metadata tab.

Note: still keeping old method to use on dynamically generated items for now.