### PR TITLE
2431 HOTFIX dynamically create missing logical files

### DIFF
--- a/hs_core/management/commands/debug_resource.py
+++ b/hs_core/management/commands/debug_resource.py
@@ -1,0 +1,89 @@
+"""This prints the state of a logical file.
+
+* By default, prints errors on stdout.
+* Optional argument --log: logs output to system log.
+"""
+
+from django.core.management.base import BaseCommand
+from hs_core.models import BaseResource
+from hs_access_control.models import PrivilegeCodes
+
+def debug_resource(short_id):
+    """ Debug view for resource depicts output of various integrity checking scripts """
+
+    try:
+        res = BaseResource.objects.get(short_id=short_id)
+    except BaseResource.DoesNotExist:
+        print("{} does not exist\n".format(shortkey))
+
+    resource = res.get_content_model()
+    assert resource, (res, res.content_model)
+
+    irods_issues, irods_errors = resource.check_irods_files(log_errors=False, return_errors=True)
+
+    print("resource: {}".format(short_id))
+    print("resource type: {}".format(resource.resource_type))
+    print("resource creator: {} {}".format(resource.creator.first_name, resource.creator.last_name))
+    print("resource irods bag modified: {}".format(str(resource.getAVU('bag_modified'))))
+    print("resource irods isPublic: {}".format(str(resource.getAVU('isPublic'))))
+    print("resource irods resourceType: {}".format(str(resource.getAVU('resourceType'))))
+    print("resource irods quotaUserName: {}".format(str(resource.getAVU('quotaUserName'))))
+    if irods_errors:
+        print("iRODS errors:")
+        for e in irods_issues:
+            print("    {}".format(e))
+    else:
+        print("No iRODS errors")
+
+    if resource.resource_type == 'CompositeResource':
+        print("Resource file logical files:")
+        for res_file in resource.files.all():
+            if not res_file.has_logical_file:
+                print("    {} logical file NOT SPECIFIED".format(res_file.short_path))
+            else:
+                print("    {} logical file {} is [{}]".format(res_file.short_path,
+                                                              str(type(res_file.logical_file)),
+                                                              str(res_file.logical_file.id)))
+
+    # context = {
+    #     'shortkey': shortkey,
+    #     'creator': resource.creator,
+    #     'resource': resource,
+    #     'raccess': resource.raccess,
+    #     'owners': resource.raccess.owners,
+    #     'editors': resource.raccess.get_users_with_explicit_access(PrivilegeCodes.CHANGE),
+    #     'viewers': resource.raccess.get_users_with_explicit_access(PrivilegeCodes.VIEW),
+    #     'public_AVU': resource.getAVU('isPublic'),
+    #     'type_AVU': resource.getAVU('resourceType'),
+    #     'modified_AVU': resource.getAVU('bag_modified'),
+    #     'quota_AVU': resource.getAVU('quotaUserName'),
+    #     'irods_issues': irods_issues,
+    #     'irods_errors': irods_errors,
+    # }
+
+
+class Command(BaseCommand):
+    help = "Print debugging information about logical files."
+
+    def add_arguments(self, parser):
+
+        # a list of resource id's: none does nothing.
+        parser.add_argument('resource_ids', nargs='*', type=str)
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--log',
+            action='store_true',  # True for presence, False for absence
+            dest='log',           # value is options['log']
+            help='log errors to system log',
+        )
+
+    def handle(self, *args, **options):
+        if len(options['resource_ids']) > 0:  # an array of resource short_id to check.
+            for rid in options['resource_ids']:
+                debug_resource(rid)
+
+            else:
+                print("No resources to check.")
+
+

--- a/hs_core/management/commands/debug_resource.py
+++ b/hs_core/management/commands/debug_resource.py
@@ -6,7 +6,7 @@
 
 from django.core.management.base import BaseCommand
 from hs_core.models import BaseResource
-from hs_access_control.models import PrivilegeCodes
+
 
 def debug_resource(short_id):
     """ Debug view for resource depicts output of various integrity checking scripts """
@@ -14,7 +14,7 @@ def debug_resource(short_id):
     try:
         res = BaseResource.objects.get(short_id=short_id)
     except BaseResource.DoesNotExist:
-        print("{} does not exist\n".format(shortkey))
+        print("{} does not exist".format(short_id))
 
     resource = res.get_content_model()
     assert resource, (res, res.content_model)
@@ -85,5 +85,3 @@ class Command(BaseCommand):
 
             else:
                 print("No resources to check.")
-
-

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3043,6 +3043,22 @@ class ResourceFile(ResourceFileIRODSMixin):
         return self.logical_file is not None
 
     @property
+    def get_or_create_logical_file(self):
+        """ create a logical file on the fly if necessary """
+        # prevent import loops
+        from hs_file_types.models.generic import GenericLogicalFile
+        if self.content_object.resource_type == "CompositeResource":
+            if not self.has_logical_file:
+                logical_file = GenericLogicalFile.create()
+                self.logical_file_content_object = logical_file
+                self.save()
+                logger = logging.getLogger(__name__)
+                logger.warn("auto-create logical file for {}".format(self.storage_path))
+            return self.logical_file
+        else:
+            return None
+
+    @property
     def logical_file(self):
         """Return content_object of logical file."""
         return self.logical_file_content_object

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3044,7 +3044,12 @@ class ResourceFile(ResourceFileIRODSMixin):
 
     @property
     def get_or_create_logical_file(self):
-        """ create a logical file on the fly if necessary """
+        """
+        Create a logical file on the fly if it does not exist
+
+        This is a temporary fix just for release 1.14. It is expected that further
+        work on logical files will make this unnecessary.
+        """
         # prevent import loops
         from hs_file_types.models.generic import GenericLogicalFile
         if self.content_object.resource_type == "CompositeResource":

--- a/hs_core/views/resource_folder_hierarchy.py
+++ b/hs_core/views/resource_folder_hierarchy.py
@@ -105,9 +105,10 @@ def data_store_structure(request):
     except SessionException as ex:
         logger.error("session exception querying store_path {} for {}".format(store_path, res_id))
         return HttpResponse(ex.stderr, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    # THIS EXCEPTION HANDLER made file problems exceedingly difficult to find!
     # except Exception as ex:
-    # logger.error("unknown exception querying store_path {} for {}".format(store_path, res_id))
-    # return HttpResponse(ex.message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    #     logger.error("unknown exception querying store_path {} for {}".format(store_path, res_id))
+    #     return HttpResponse(ex.message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     return_object = {'files': files,
                      'folders': store[0],

--- a/hs_core/views/resource_folder_hierarchy.py
+++ b/hs_core/views/resource_folder_hierarchy.py
@@ -105,23 +105,18 @@ def data_store_structure(request):
     except SessionException as ex:
         logger.error("session exception querying store_path {} for {}".format(store_path, res_id))
         return HttpResponse(ex.stderr, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    # THIS EXCEPTION HANDLER made file problems exceedingly difficult to find!
-    # except Exception as ex:
-    #     logger.error("unknown exception querying store_path {} for {}".format(store_path, res_id))
-    #     return HttpResponse(ex.message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     return_object = {'files': files,
                      'folders': store[0],
                      'can_be_public': resource.can_be_public_or_discoverable}
 
     if resource.resource_type == "CompositeResource":
-        logger.debug("resource {}: begin CompositeResource handling".format(res_id))
-        logger.debug("begin composite resource handling")
+        # logger.debug("resource {}: begin CompositeResource handling".format(res_id))
         spatial_coverage_dict = get_coverage_data_dict(resource)
         temporal_coverage_dict = get_coverage_data_dict(resource, coverage_type='temporal')
         return_object['spatial_coverage'] = spatial_coverage_dict
         return_object['temporal_coverage'] = temporal_coverage_dict
-        logger.debug("resource {}: end CompositeResource handling".format(res_id))
+        # logger.debug("resource {}: end CompositeResource handling".format(res_id))
     return HttpResponse(
         json.dumps(return_object),
         content_type="application/json"

--- a/hs_core/views/resource_folder_hierarchy.py
+++ b/hs_core/views/resource_folder_hierarchy.py
@@ -32,6 +32,7 @@ def data_store_structure(request):
     """
     res_id = request.POST.get('res_id', None)
     if res_id is None:
+        logger.error("no resource id in request")
         return HttpResponse('Bad request - resource id is not included',
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     res_id = str(res_id).strip()
@@ -39,24 +40,30 @@ def data_store_structure(request):
         resource, _, _ = authorize(request, res_id,
                                    needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
     except NotFound:
+        logger.error("resource {} not found".format(res_id))
         return HttpResponse('Bad request - resource not found', status=status.HTTP_400_BAD_REQUEST)
     except PermissionDenied:
+        logger.error("permission denied for resource {}".format(res_id))
         return HttpResponse('Permission denied', status=status.HTTP_401_UNAUTHORIZED)
 
     store_path = request.POST.get('store_path', None)
     if store_path is None:
+        logger.error("store_path not included for resource {}".format(res_id))
         return HttpResponse('Bad request - store_path is not included',
                             status=status.HTTP_400_BAD_REQUEST)
     store_path = str(store_path).strip()
     if not store_path:
+        logger.error("store_path empty for resource {}".format(res_id))
         return HttpResponse('Bad request - store_path cannot be empty',
                             status=status.HTTP_400_BAD_REQUEST)
 
     if not store_path.startswith('data/contents'):
+        logger.error("store_path doesn't start with data/contents for resource {}".format(res_id))
         return HttpResponse('Bad request - store_path must start with data/contents/',
                             status=status.HTTP_400_BAD_REQUEST)
 
     if store_path.find('/../') >= 0 or store_path.endswith('/..'):
+        logger.error("store_path cannot contain .. for resource {}".format(res_id))
         return HttpResponse('Bad request - store_path cannot contain /../',
                             status=status.HTTP_400_BAD_REQUEST)
 
@@ -82,8 +89,9 @@ def data_store_structure(request):
                     f_pk = f.pk
                     f_url = get_resource_file_url(f)
                     if resource.resource_type == "CompositeResource":
+                        f_logical = f.get_or_create_logical_file
                         logical_file_type = f.logical_file_type_name
-                        logical_file_id = f.logical_file.id
+                        logical_file_id = f_logical.id
                     break
 
             if f_pk:  # file is found in Django
@@ -95,19 +103,24 @@ def data_store_structure(request):
                              .format(name_with_full_path))
 
     except SessionException as ex:
+        logger.error("session exception querying store_path {} for {}".format(store_path, res_id))
         return HttpResponse(ex.stderr, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    except Exception as ex:
-        return HttpResponse(ex.message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    # except Exception as ex:
+    # logger.error("unknown exception querying store_path {} for {}".format(store_path, res_id))
+    # return HttpResponse(ex.message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     return_object = {'files': files,
                      'folders': store[0],
                      'can_be_public': resource.can_be_public_or_discoverable}
 
     if resource.resource_type == "CompositeResource":
+        logger.debug("resource {}: begin CompositeResource handling".format(res_id))
+        logger.debug("begin composite resource handling")
         spatial_coverage_dict = get_coverage_data_dict(resource)
         temporal_coverage_dict = get_coverage_data_dict(resource, coverage_type='temporal')
         return_object['spatial_coverage'] = spatial_coverage_dict
         return_object['temporal_coverage'] = temporal_coverage_dict
+        logger.debug("resource {}: end CompositeResource handling".format(res_id))
     return HttpResponse(
         json.dumps(return_object),
         content_type="application/json"


### PR DESCRIPTION
@pkdash @aphelionz @martinseul Brute-force to fixing missing logical files creates missing generic logical files as needed. 

This is not finished but is provided for reference for others who might be working on the problem. 

* The game plan is to use `ResourceFile.get_or_create_logical_file` in any place that `ResourceFile.logical_file `fails to work due to a missing logical file. This includes templates. 
* Behavior of `get_or_create_logical_file` is identical to behavior of `./hsctl managepy fix_missing_logical_files`.
