### PR TITLE
HOTFIX-Ensures generic logical file is created when a file gets added

### DIFF
--- a/hs_composite_resource/tests/test_composite_resource.py
+++ b/hs_composite_resource/tests/test_composite_resource.py
@@ -73,8 +73,9 @@ class CompositeResourceTest(MockIRODSTestCaseMixin, TransactionTestCase):
             files=(self.raster_file_obj,)
         )
 
-        # there should not be aby GenericLogicalFile object at this point
-        self.assertEqual(GenericLogicalFile.objects.count(), 0)
+        # Deprecated: there should not be a GenericLogicalFile object at this point
+        # Issue 2456 Create composite with uploaded file now part of logical file
+        self.assertEqual(GenericLogicalFile.objects.count(), 1)
 
         # set the logical file
         resource_post_create_actions(resource=self.composite_resource, user=self.user,

--- a/hs_composite_resource/tests/test_composite_resource_user_zone.py
+++ b/hs_composite_resource/tests/test_composite_resource_user_zone.py
@@ -71,8 +71,9 @@ class CompositeResourceTest(TestCaseCommonUtilities, TransactionTestCase):
                                                 user=settings.HS_LOCAL_PROXY_USER_IN_FED_ZONE)
         self.assertEqual(self.composite_resource.resource_federation_path, fed_path)
 
-        # there should not be any GenericLogicalFile object at this point
-        self.assertEqual(GenericLogicalFile.objects.count(), 0)
+        # Deprecated: there should not be any GenericLogicalFile object at this point
+        # Issue 2456 Create composite with uploaded file now part of logical file
+        self.assertEqual(GenericLogicalFile.objects.count(), 1)
 
         # set the logical file - which get sets as part of the post resource creation signal
         resource_post_create_actions(resource=self.composite_resource, user=self.user,

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -951,6 +951,10 @@ def add_file_to_resource(resource, f, folder=None, source_name='',
 
     :return: The identifier of the ResourceFile added.
     """
+
+    # importing here to avoid circular import
+    from hs_file_types.models import GenericLogicalFile
+
     if f:
 
         openfile = File(f) if not isinstance(f, UploadedFile) else f
@@ -981,6 +985,13 @@ def add_file_to_resource(resource, f, folder=None, source_name='',
     # TODO: generate this from data in ResourceFile rather than extension
     if file_format_type not in [mime.value for mime in resource.metadata.formats.all()]:
         resource.metadata.create_element('format', value=file_format_type)
+
+    # if a file gets added successfully to composite resource, then better to set the generic
+    # logical file here
+    if resource.resource_type == "CompositeResource":
+        logical_file = GenericLogicalFile.create()
+        ret.logical_file_content_object = logical_file
+        ret.save()
 
     return ret
 

--- a/hs_file_types/models/geofeature.py
+++ b/hs_file_types/models/geofeature.py
@@ -282,9 +282,16 @@ class GeoFeatureLogicalFile(AbstractLogicalFile):
                 for fl in files_to_add_to_resource:
                     uploaded_file = UploadedFile(file=open(fl, 'rb'),
                                                  name=os.path.basename(fl))
+                    # the added resource file will be part of a new generic logical file by default
                     new_res_file = utils.add_file_to_resource(
                         resource, uploaded_file, folder=upload_folder
                     )
+
+                    # delete the generic logical file object
+                    if new_res_file.logical_file is not None:
+                        # deleting the file level metadata object will delete the associated
+                        # logical file object
+                        new_res_file.logical_file.metadata.delete()
 
                     # make each resource file we added part of the logical file
                     logical_file.add_resource_file(new_res_file)

--- a/hs_file_types/models/netcdf.py
+++ b/hs_file_types/models/netcdf.py
@@ -423,9 +423,17 @@ class NetCDFLogicalFile(AbstractLogicalFile):
                         for f in files_to_add_to_resource:
                             uploaded_file = UploadedFile(file=open(f, 'rb'),
                                                          name=os.path.basename(f))
+                            # the added resource file will be part of a new generic logical file
+                            # by default
                             new_res_file = utils.add_file_to_resource(
                                 resource, uploaded_file, folder=upload_folder
                             )
+
+                            # delete the generic logical file object
+                            if new_res_file.logical_file is not None:
+                                # deleting the file level metadata object will delete the associated
+                                # logical file object
+                                new_res_file.logical_file.metadata.delete()
 
                             # make each resource file we added part of the logical file
                             logical_file.add_resource_file(new_res_file)

--- a/hs_file_types/models/raster.py
+++ b/hs_file_types/models/raster.py
@@ -311,8 +311,16 @@ class GeoRasterLogicalFile(AbstractLogicalFile):
                         for f in files_to_add_to_resource:
                             uploaded_file = UploadedFile(file=open(f, 'rb'),
                                                          name=os.path.basename(f))
+                            # the added resource file will be part of a new generic logical file
+                            # by default
                             new_res_file = utils.add_file_to_resource(
                                 resource, uploaded_file, folder=upload_folder)
+
+                            # delete the generic logical file object
+                            if new_res_file.logical_file is not None:
+                                # deleting the file level metadata object will delete the associated
+                                # logical file object
+                                new_res_file.logical_file.metadata.delete()
 
                             # make each resource file we added as part of the logical file
                             logical_file.add_resource_file(new_res_file)

--- a/hs_file_types/models/reftimeseries.py
+++ b/hs_file_types/models/reftimeseries.py
@@ -786,10 +786,17 @@ class RefTimeseriesLogicalFile(AbstractLogicalFile):
                     # add the json file back to the resource
                     uploaded_file = UploadedFile(file=open(temp_file, 'rb'),
                                                  name=os.path.basename(temp_file))
-
+                    # the added resource file will be part of a new generic logical file by default
                     new_res_file = utils.add_file_to_resource(
                         resource, uploaded_file, folder=file_folder
                     )
+
+                    # delete the generic logical file object
+                    if new_res_file.logical_file is not None:
+                        # deleting the file level metadata object will delete the associated
+                        # logical file object
+                        new_res_file.logical_file.metadata.delete()
+
                     # make the resource file we added as part of the logical file
                     logical_file.add_resource_file(new_res_file)
                     logical_file.metadata.save()

--- a/hs_file_types/models/timeseries.py
+++ b/hs_file_types/models/timeseries.py
@@ -561,9 +561,17 @@ class TimeSeriesLogicalFile(AbstractLogicalFile):
                 # add the file to the resource
                 uploaded_file = UploadedFile(file=open(temp_res_file, 'rb'),
                                              name=os.path.basename(temp_res_file))
+
+                # the added resource file will be part of a new generic logical file by default
                 new_res_file = utils.add_file_to_resource(
                     resource, uploaded_file, folder=upload_folder
                 )
+
+                # delete the generic logical file object
+                if new_res_file.logical_file is not None:
+                    # deleting the file level metadata object will delete the associated
+                    # logical file object
+                    new_res_file.logical_file.metadata.delete()
 
                 # make each resource file we added part of the logical file
                 logical_file.add_resource_file(new_res_file)


### PR DESCRIPTION
If multiple files are added to the composite and one of the files does not get added for some reason (e.g., duplicate file name) then the system was failing to create a generic file for each of the files that got added. This may be one of the reasons why we have seen missing logical files that lead to no files being listed on the UI.