### PR TITLE
[#2116] Responsive layout fixes

### DIFF
--- a/hs_core/templates/pages/my-resources.html
+++ b/hs_core/templates/pages/my-resources.html
@@ -200,15 +200,17 @@
                     {% for res in collection %}
                         <tr class="data-row">
                             {# Selection controls #}
-                            <td>
+                            <td  data-col="actions">
                                 <input class="row-selector" type="checkbox">
                                 {# Delete resource forms #}
-                                <form class="hidden-form" data-id="form-delete-{{ res.short_id }}" data-form-type="delete-resource" method="POST"
+                                <form class="hidden-form" data-id="form-delete-{{ res.short_id }}"
+                                      data-form-type="delete-resource" method="POST"
                                       action="/hsapi/_internal/{{ res.short_id }}/delete-resource/">
                                     {% csrf_token %}
                                 </form>
                                 {% if res.is_favorite %}
-                                    <span data-form-id="form-favorite-{{ res.short_id }}" data-form-type="toggle-favorite"
+                                    <span data-form-id="form-favorite-{{ res.short_id }}"
+                                          data-form-type="toggle-favorite"
                                           class="glyphicon glyphicon-star btn-inline-favorite isfavorite"></span>
 
                                     <form class="hidden-form" data-id="form-favorite-{{ res.short_id }}"
@@ -219,7 +221,8 @@
                                         <input type="hidden" name="label_type" value="FAVORITE">
                                     </form>
                                 {% else %}
-                                    <span data-form-id="form-favorite-{{ res.short_id }}" data-form-type="toggle-favorite"
+                                    <span data-form-id="form-favorite-{{ res.short_id }}"
+                                          data-form-type="toggle-favorite"
                                           class="glyphicon glyphicon-star btn-inline-favorite"></span>
 
                                     <form class="hidden-form" data-id="form-favorite-{{ res.short_id }}"
@@ -231,7 +234,8 @@
                                     </form>
                                 {% endif %}
 
-                                <span class="glyphicon glyphicon-tag btn-inline-label" data-toggle="dropdown" aria-expanded="false"></span>
+                                <span class="glyphicon glyphicon-tag btn-inline-label" data-toggle="dropdown"
+                                      aria-expanded="false"></span>
 
                                 <div class="dropdown-menu inline-dropdown" role="menu">
                                     <div class="panel-body" role="form">
@@ -241,7 +245,7 @@
                                 </div>
                             </td>
                             {# Type #}
-                            <td>
+                            <td data-col="resource-type">
                                 {% include "includes/res_type_col.html" with resource=res %}
                             </td>
                             {# Title #}

--- a/hs_core/templates/search/search.html
+++ b/hs_core/templates/search/search.html
@@ -224,7 +224,7 @@
                         <tbody>
                             {% for result in page_obj.object_list %}
                                 <tr>
-                                    <td>
+                                    <td data-col="resource-type">
                                         {% include "includes/res_type_col.html" with resource=result.object %}
                                     </td>
                                     <td><strong><a href="{{ result.object.get_absolute_url }}">{{ result.object.metadata.title.value }}</a></strong></td>

--- a/theme/static/css/elements.css
+++ b/theme/static/css/elements.css
@@ -585,6 +585,16 @@ input[type="button"].hl-btn-block {
 	border-radius: 0; /* */
 }
 
+textarea.form-control {
+  resize: vertical;
+}
+
+@supports (-webkit-appearance:none) {
+  textarea.form-control {
+    width: calc(100% + 1px); /* Work around for recent chrome update that adds unnecessary horizontal scrollbar*/
+  }
+}
+
 /* ===== Navs ===== */
 
 /* 1. Nav tabs */

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -2808,10 +2808,15 @@ span.you-flag {
     border-top: 1px solid #DDD;
 }
 
-#item-selectors tr > td:first-child {
+#item-selectors tr > td[data-col='actions'] {
 	padding-right: 0;
-    max-width: 80px;
-	min-width: 80px;
+    max-width: 70px;
+	min-width: 70px;
+}
+
+#item-selectors tr > td[data-col='resource-type'], #items-discovered tr > td[data-col='resource-type'] {
+    max-width: 135px;
+	min-width: 135px;
 }
 
 #item-selectors.group-resource-list tr > td:first-child {

--- a/theme/static/js/my-resources.js
+++ b/theme/static/js/my-resources.js
@@ -21,13 +21,11 @@ var ACCESS_GRANTOR_COL =    14;
 var colDefs = [
     {
         "targets": [RESOURCE_TYPE_COL],     // Resource type
-        "width": "100px"
     },
     {
         "targets": [ACTIONS_COL],           // Actions
         "orderable": false,
         "searchable": false,
-        "width": "70px"
     },
     {
         "targets": [LAST_MODIFIED_COL],     // Last modified

--- a/theme/templates/pages/group.html
+++ b/theme/templates/pages/group.html
@@ -616,7 +616,7 @@
                                                 </div>
                                             </td>
                                             {# Type #}
-                                            <td>
+                                            <td data-col="resource-type">
                                                 {% include "includes/res_type_col.html" with resource=res %}
                                             </td>
                                             {# Title #}


### PR DESCRIPTION
Minor alignment fixes.
Prevents resource status icons from moving to a new line for small screen sizes.
![image](https://user-images.githubusercontent.com/2448568/34491944-cace5aea-efa2-11e7-9a4e-1ede7e45fe77.png)
