### PR TITLE
Allowing supports_folders for CompositeResource

### DIFF
--- a/hs_composite_resource/models.py
+++ b/hs_composite_resource/models.py
@@ -38,6 +38,11 @@ class CompositeResource(BaseResource):
                 res_file.save()
 
     @property
+    def supports_folders(self):
+        """ allow folders for CompositeResources """
+        return True
+
+    @property
     def supports_logical_file(self):
         """ if this resource allows associating resource file objects with logical file"""
         return True


### PR DESCRIPTION
Fixes #2537 

To test you can run this script where hs = hs_restclient:

```
from hs_restclient import HydroShare, HydroShareAuthBasic
auth = HydroShareAuthBasic(username='YOUR_USER', password='YOUR_PASS')
hs = HydroShare(hostname="dev-hs-2.cuahsi.org", auth=auth, verify=False)

resource = hs.createResource(
    'CompositeResource',
    "This is a test title",
    abstract="This is a test abstract",
    keywords=('mmw', 'model-my-watershed')
)

aoi_folder = 'area-of-interest'
hs.createResourceFolder(resource, pathname=aoi_folder)
```