### PR TITLE
2562 add abstract to resource list

### DIFF
--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -48,6 +48,7 @@ class ResourceToListItemMixin(object):
         resource_list_item = serializers.ResourceListItem(resource_type=r.resource_type,
                                                           resource_id=r.short_id,
                                                           resource_title=r.metadata.title.value,
+                                                          abstract=r.metadata.description,
                                                           creator=r.first_creator.name,
                                                           public=r.raccess.public,
                                                           discoverable=r.raccess.discoverable,

--- a/hs_core/views/resource_ticket_rest_api.py
+++ b/hs_core/views/resource_ticket_rest_api.py
@@ -45,7 +45,7 @@ class CreateResourceTicket(APIView):
 
     Error returns 400, 403, 404 return a string with the error message instead of JSON.
     """
-    allowed_methods = ('GET')
+    allowed_methods = ('GET',)
 
     def get(self, request, pk, op, pathname):
         """
@@ -120,7 +120,7 @@ class CreateBagTicket(APIView):
 
     Error returns 400, 403, 404 return a string with the error message instead of JSON.
     """
-    allowed_methods = ('GET')
+    allowed_methods = ('GET',)
 
     def get(self, request, pk):
         """

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -93,6 +93,7 @@ class ResourceListItemSerializer(serializers.Serializer):
     resource_type = serializers.CharField(max_length=100)
     resource_title = serializers.CharField(max_length=200)
     resource_id = serializers.CharField(max_length=100)
+    abstract = serializers.CharField()
     creator = serializers.CharField(max_length=100)
     date_created = serializers.DateTimeField(format='%m-%d-%Y')
     date_last_updated = serializers.DateTimeField(format='%m-%d-%Y')
@@ -123,6 +124,7 @@ ResourceListItem = namedtuple('ResourceListItem',
                               ['resource_type',
                                'resource_id',
                                'resource_title',
+                               'abstract',
                                'creator',
                                'public',
                                'discoverable',


### PR DESCRIPTION
Fixes #2562 

To test:

1. Checkout this branch and `./hsctl restart`
2. Simply visit /hsapi/resource and ensure that the "abstract" field appears in the results.