### PR TITLE
Adding recaptcha2 back to signup

### DIFF
--- a/theme/forms.py
+++ b/theme/forms.py
@@ -21,7 +21,7 @@ from .models import UserProfile
 from hs_core.hydroshare.users import create_account
 from hs_core.templatetags.hydroshare_tags import best_name
 
-from hydroshare import settings
+from hydroshare import settings as hydroshare_settings
 
 COMMENT_MAX_LENGTH = getattr(settings, 'COMMENT_MAX_LENGTH', 3000)
 
@@ -236,9 +236,9 @@ class SignupForm(forms.ModelForm):
         super(SignupForm, self).__init__(*args, **kwargs)
 
     def verify_captcha(self):
-        url = settings.RECAPTCHA_VERIFY_URL
+        url = hydroshare_settings.RECAPTCHA_VERIFY_URL
         values = {
-            'secret': settings.RECAPTCHA_SECRET_KEY,
+            'secret': hydroshare_settings.RECAPTCHA_SECRET_KEY,
             'response': self.request.POST.get('g-recaptcha-response')
         }
         response = requests.post(url, values)

--- a/theme/forms.py
+++ b/theme/forms.py
@@ -1,3 +1,5 @@
+import requests
+
 from django import forms
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django_comments.signals import comment_was_posted
@@ -18,6 +20,8 @@ from mezzanine.conf import settings
 from .models import UserProfile
 from hs_core.hydroshare.users import create_account
 from hs_core.templatetags.hydroshare_tags import best_name
+
+from hydroshare import settings
 
 COMMENT_MAX_LENGTH = getattr(settings, 'COMMENT_MAX_LENGTH', 3000)
 
@@ -225,9 +229,6 @@ class SignupForm(forms.ModelForm):
 
     password1 = forms.CharField(label="Password", widget=forms.PasswordInput())
     password2 = forms.CharField(label="Confirm Password", widget=forms.PasswordInput())
-    # Captcha = forms.CharField(required=False)
-    # challenge = forms.CharField()
-    # response = forms.CharField()
     organization = forms.CharField(required=True)
 
     def __init__(self, request, *args, **kwargs):
@@ -235,22 +236,23 @@ class SignupForm(forms.ModelForm):
         super(SignupForm, self).__init__(*args, **kwargs)
 
     def verify_captcha(self):
-        return True
+        url = settings.RECAPTCHA_VERIFY_URL
+        values = {
+            'secret': settings.RECAPTCHA_SECRET_KEY,
+            'response': self.request.POST.get('g-recaptcha-response')
+        }
+        response = requests.post(url, values)
+        result = response.json()
+        if(result["success"]):
+            return (True, [])
 
-        # params = dict(self.cleaned_data)
-        # params['privatekey'] = getattr(settings, 'RECAPTCHA_PRIVATE_KEY',
-        #                               "6LdNC_USAAAAADNdzytMK2-qmDCzJcgybFkw8Z5x")
-        # params['remoteip'] = self.request.META['REMOTE_ADDR']
-        # resp = requests.post('https://www.google.com/recaptcha/api/verify', params=params)
-        # lines = resp.text.split('\n')
-        # if not lines[0].startswith('false'):
-        #     return True
-        # return False
+        return (False, result["error-codes"])
 
     def clean(self):
-        if not self.verify_captcha():
-            self.add_error('Captcha', "You did not complete the CAPTCHA correctly. "
-                                      "Please try again.")
+        success, error_codes = self.verify_captcha()
+
+        if not success:
+            self.add_error(None, " ".join(error_codes))
 
     def clean_password2(self):
         data = self.cleaned_data

--- a/theme/templates/accounts/sign_up_form.html
+++ b/theme/templates/accounts/sign_up_form.html
@@ -45,7 +45,7 @@
     </div>
     <div class="row">
       <script src='https://www.google.com/recaptcha/api.js'></script>
-      <div class="g-recaptcha" data-sitekey="6LfmuEIUAAAAAOf7OAgOiz1bFlqRBt1rtbn0XYMN"></div>
+      <div class="g-recaptcha" data-sitekey="SITE_KEY"></div>
 
       <div id="missing-data-div"></div>
 

--- a/theme/templates/accounts/sign_up_form.html
+++ b/theme/templates/accounts/sign_up_form.html
@@ -21,9 +21,6 @@
 <form id="form-signup" action="/accounts/signup/" method="post" role="form">
     {% csrf_token %}
     {{ form.non_field_errors }}
-    <!-- recaptcha -->
-    <input type="hidden" name="challenge" />
-    <input type="hidden" name="response" />
     <div class="row">
         <div class="form-group half">
           {% include "includes/form_field.html" with field=form.first_name inline_label=True %}
@@ -47,8 +44,8 @@
         </div>
     </div>
     <div class="row">
-
-      <!--<div id="recaptcha-div"></div>-->
+      <script src='https://www.google.com/recaptcha/api.js'></script>
+      <div class="g-recaptcha" data-sitekey="6LfmuEIUAAAAAOf7OAgOiz1bFlqRBt1rtbn0XYMN"></div>
 
       <div id="missing-data-div"></div>
 
@@ -58,7 +55,6 @@
 </form>
 
 <script type="text/javascript" src="{{ STATIC_URL }}js/jquery.tagsinput-revisited.min.js"></script>
-<!--<script type="text/javascript" src="//www.google.com/recaptcha/api/js/recaptcha_ajax.js"></script>-->
 <script type="text/javascript">
     $(document).ready(function() {
          $('input[type="button"]').prop('disabled', false);
@@ -66,7 +62,6 @@
         // form fields
          var fieldsToCheck = ["#id_first_name", "#id_last_name", "#id_username", "#id_email",
              "#id_password1", "#id_password2"];
-            //  "#id_password1", "#id_password2", "#recaptcha_response_field"];
 
          var i;
          for (i=0; i< fieldsToCheck.length; i++){
@@ -98,25 +93,12 @@
     }
 
     $(function() {
-        // function cb() {
-        //     $("#recaptcha_privacy").attr('style', "display:none");
-        //     Recaptcha.focus_response_field();
-        // }
-
-        // Recaptcha.create("6LdNC_USAAAAAHSocU3ZpfEFHBwORoMdOBcrSUPP",
-        // "recaptcha-div", {
-        //   theme: "clean",
-        //   callback: cb // Recaptcha.focus_response_field
-        // });
-
         $("#signup").click(function() {
             var password = $("#id_password1").val();
             var pwconfirm = $("#id_password2").val();
             // These are the required form fields
             var requiredFieldsToCheck = ["#id_username", "#id_email", "#id_password1",
                 "#id_password2",  "[name='organization']"];
-                // "#id_password2", "#recaptcha_response_field", "[name='organization']"];
-            // var fieldNames = [ 'User name', 'Email', 'Password', 'Password (again)', 'ReCaptcha', "Organization"];
             var fieldNames = [ 'User name', 'Email', 'Password', 'Password (again)', "Organization"];
             var empty = false;
             var missingFields = 'Data missing for:';
@@ -160,8 +142,6 @@
             }
             if (password && pwconfirm) {
                 if (password === pwconfirm) {
-                    // $("[name=challenge]").val(Recaptcha.get_challenge());
-                    // $("[name=response]").val(Recaptcha.get_response());
                     $('#form-signup').submit();
                 } else {
                     $("#id_password1").val('');


### PR DESCRIPTION
Follow the instructions to test. You may have to register at https://www.google.com/recaptcha/admin to get your site key and secret. These are NOT checked in to Git (or at least shouldn't be).

1. Check out this branch and add the following to local_settings.py:
```
RECAPTCHA_VERIFY_URL='https://www.google.com/recaptcha/api/siteverify'
RECAPTCHA_SITE_KEY="enter site key here"
RECAPTCHA_SECRET_KEY="enter secret key here"
```
2. On line 48 of `theme/templates/accounts/sign_up_form.html` add the site key in the `data-sitekey` attribute
3. `./hsctl restart`
4. Test the signup flow with the new captcha. If all goes well it should create a new account for you with no problems.