### PR TITLE
[#2590] - increase time for group email links expirary

### DIFF
--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -1396,7 +1396,8 @@ def group_membership(request, uidb36, token, membership_request_id, **kwargs):
                 # redirect to group profile page
                 return HttpResponseRedirect('/group/{}/'.format(membership_request.group_to_join.id))
             else:
-                messages.error(request, "The link you clicked is no longer valid.")
+                messages.error(request, "The link you clicked is no longer valid. Please ask to "
+                                        "join the group again.")
                 return redirect("/")
         else:
             messages.error(request, "The group is no longer active.")

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -508,8 +508,8 @@ HAYSTACK_CONNECTIONS = {
 HAYSTACK_SIGNAL_PROCESSOR = "hs_core.hydro_realtime_signal_processor.HydroRealtimeSignalProcessor"
 
 
-# customized value for password reset token and email verification link token to expire in 1 day
-PASSWORD_RESET_TIMEOUT_DAYS = 1
+# customized value for password reset token, email verification and group invitation link token to expire in 7 days
+PASSWORD_RESET_TIMEOUT_DAYS = 7
 
 #
 RESOURCE_LOCK_TIMEOUT_SECONDS = 300 # in seconds


### PR DESCRIPTION
https://github.com/hydroshare/hydroshare/issues/2590

- [x] Positive Test Case Written by Dev
- [x] Automated Testing
- [x] If documentation is required, add documentation
- [x] Passing Jenkins Build
- [x] Peer Code review and approval

There was no suggested time period so I used 7 days.  A side effect of this is everything using django's authorization tokens will be increased to 7 days as well.  

I haven't really been able to test this, because it requires 7 days to test, so if another programmer could do a sanity check on this setting, that'd be great. 