### PR TITLE
[#2567] - expose folder downloading to rest api and update file url i…

### DIFF
--- a/hs_core/tests/api/rest/test_folder_download_zip.py
+++ b/hs_core/tests/api/rest/test_folder_download_zip.py
@@ -55,7 +55,7 @@ class TestPublicZipEndpoint(HSRESTTestCase):
 
     def test_folder_download_rest(self):
         date_folder = (date.today()).strftime('%Y-%m-%d')
-        zip_download_url = "/resource/{pid}/data/contents/foo".format(pid=self.pid)
+        zip_download_url = "/hsapi/resource/{pid}/data/contents/foo".format(pid=self.pid)
         response = self.client.get(zip_download_url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content)

--- a/hs_core/tests/api/rest/test_folder_download_zip.py
+++ b/hs_core/tests/api/rest/test_folder_download_zip.py
@@ -55,8 +55,7 @@ class TestPublicZipEndpoint(HSRESTTestCase):
 
     def test_folder_download_rest(self):
         date_folder = (date.today()).strftime('%Y-%m-%d')
-        zip_download_url = "/django_irods/rest_download/zips/{pid}/data/contents/foo".format(
-             pid=self.pid)
+        zip_download_url = "/resource/{pid}/data/contents/foo".format(pid=self.pid)
         response = self.client.get(zip_download_url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content)

--- a/hs_core/tests/api/rest/test_folder_download_zip.py
+++ b/hs_core/tests/api/rest/test_folder_download_zip.py
@@ -59,6 +59,10 @@ class TestPublicZipEndpoint(HSRESTTestCase):
         response = self.client.get(zip_download_url, format="json")
         # becasue of the redirect to the internal url, the status code is 301
         self.assertEqual(response.status_code, status.HTTP_301_MOVED_PERMANENTLY)
+        zip_download_url = "/django_irods/rest_download/zips/{pid}/data/contents/foo".format(
+            pid=self.pid)
+        response = self.client.get(zip_download_url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content)
         task_id = response_json["task_id"]
         download_path = response_json["download_path"]

--- a/hs_core/tests/api/rest/test_folder_download_zip.py
+++ b/hs_core/tests/api/rest/test_folder_download_zip.py
@@ -55,9 +55,10 @@ class TestPublicZipEndpoint(HSRESTTestCase):
 
     def test_folder_download_rest(self):
         date_folder = (date.today()).strftime('%Y-%m-%d')
-        zip_download_url = "/hsapi/resource/{pid}/data/contents/foo".format(pid=self.pid)
+        zip_download_url = "/resource/{pid}/data/contents/foo".format(pid=self.pid)
         response = self.client.get(zip_download_url, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # becasue of the redirect to the internal url, the status code is 301
+        self.assertEqual(response.status_code, status.HTTP_301_MOVED_PERMANENTLY)
         response_json = json.loads(response.content)
         task_id = response_json["task_id"]
         download_path = response_json["download_path"]

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -484,9 +484,11 @@ def file_download_url_mapper(request, shortkey):
 
     resource, _, _ = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
     istorage = resource.get_irods_storage()
-    irods_file_path = '/'.join(request.path.split('/')[2:-1])
-    listing = istorage.listdir('/'.join(irods_file_path.split('/')[0:-1]))
-    if irods_file_path.split('/')[-1] in listing[0]:
+    irods_split = request.path.split('/')[2:-1]
+    irods_file_path = '/'.join(irods_split)
+    # [0:-1] excludes the last item on the list
+    listing = istorage.listdir('/'.join(irods_split[0:-1]))
+    if irods_split[-1] in listing[0]:
         # it's a folder
         file_download_url = istorage.url(os.path.join('zips', irods_file_path))
         return HttpResponseRedirect(file_download_url)

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -3,6 +3,7 @@ import json
 import datetime
 import pytz
 import logging
+import os
 
 from django.core.mail import send_mail
 from django.contrib.auth import authenticate, login as auth_login
@@ -484,6 +485,11 @@ def file_download_url_mapper(request, shortkey):
     resource, _, _ = authorize(request, shortkey, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
     istorage = resource.get_irods_storage()
     irods_file_path = '/'.join(request.path.split('/')[2:-1])
+    listing = istorage.listdir('/'.join(irods_file_path.split('/')[0:-1]))
+    if irods_file_path.split('/')[-1] in listing[0]:
+        # it's a folder
+        file_download_url = istorage.url(os.path.join('zips', irods_file_path))
+        return HttpResponseRedirect(file_download_url)
     file_download_url = istorage.url(irods_file_path)
     return HttpResponseRedirect(file_download_url)
 

--- a/hs_core/views/resource_folder_hierarchy.py
+++ b/hs_core/views/resource_folder_hierarchy.py
@@ -74,7 +74,7 @@ def data_store_structure(request):
         for dname in store[0]:  # directories
             d_pk = dname.decode('utf-8')
             name_with_full_path = os.path.join(res_coll, d_pk)
-            d_url = to_external_url(istorage.url(os.path.join(name_with_full_path)))
+            d_url = to_external_url(istorage.url(name_with_full_path))
             dirs.append({'name': d_pk, 'url': d_url})
 
         files = []


### PR DESCRIPTION
…n file browser to use the rest api for downloads

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Open a resource, select a file in the file browser and click "get file url."  Verify the url path begins with "resource" NOT "django_irods/download".  Verify the url download the file.
2. Open a resource, select a folder in the file browser and click "get file url."  Verify the url path begins with "resource" NOT "django_irods/download".  Verify the url downloads folder as a zipped file.
