### PR TITLE
[#1867] strip out edit query params so edit mode is not reopened on save

### DIFF
--- a/theme/static/js/profile.js
+++ b/theme/static/js/profile.js
@@ -356,6 +356,8 @@ $(document).ready(function () {
 
     if(getUrlVars()["edit"] == 'true'){
         setEditMode();
+        // clear out the edit query params so edit mode isn't reopened on save
+        history.pushState('', document.title, window.location.pathname);
     }
 });
 


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Sign in and navigate to profile page.  Append the edit query params `?edit=true` to the url and press enter.  Validate the profile is opened in edit mode and the query params are no longer in the url.  Press Save Changes and Validate you're taken to the profile view page.
