### PR TITLE
Adding DOI to resource listing API

### DIFF
--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -45,11 +45,15 @@ class ResourceToListItemMixin(object):
         resource_url = site_url + r.get_absolute_url()
         coverages = [{"type": v['type'], "value": json.loads(v['_value'])}
                      for v in r.metadata.coverages.values()]
+        doi=None
+        if r.raccess.published:
+            doi = "10.4211/hs.{}".format(r.short_id)
         resource_list_item = serializers.ResourceListItem(resource_type=r.resource_type,
                                                           resource_id=r.short_id,
                                                           resource_title=r.metadata.title.value,
                                                           abstract=r.metadata.description,
                                                           creator=r.first_creator.name,
+                                                          doi=doi,
                                                           public=r.raccess.public,
                                                           discoverable=r.raccess.discoverable,
                                                           shareable=r.raccess.shareable,

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -45,7 +45,7 @@ class ResourceToListItemMixin(object):
         resource_url = site_url + r.get_absolute_url()
         coverages = [{"type": v['type'], "value": json.loads(v['_value'])}
                      for v in r.metadata.coverages.values()]
-        doi=None
+        doi = None
         if r.raccess.published:
             doi = "10.4211/hs.{}".format(r.short_id)
         resource_list_item = serializers.ResourceListItem(resource_type=r.resource_type,

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -95,6 +95,7 @@ class ResourceListItemSerializer(serializers.Serializer):
     resource_id = serializers.CharField(max_length=100)
     abstract = serializers.CharField()
     creator = serializers.CharField(max_length=100)
+    doi = serializers.CharField(max_length=200)
     date_created = serializers.DateTimeField(format='%m-%d-%Y')
     date_last_updated = serializers.DateTimeField(format='%m-%d-%Y')
     public = serializers.BooleanField()
@@ -127,6 +128,7 @@ ResourceListItem = namedtuple('ResourceListItem',
                                'resource_title',
                                'abstract',
                                'creator',
+                               'doi',
                                'public',
                                'discoverable',
                                'shareable',


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Check out `add-doi-to-resource-api` and restart 
2. Visit the /hsapi/resource page and ensure that doi is null for non-published resources, and filled in for published resources
