### PR TITLE
2713 res query bugs

### DIFF
--- a/hs_core/hydroshare/users.py
+++ b/hs_core/hydroshare/users.py
@@ -376,7 +376,8 @@ def get_resource_list(creator=None, group=None, user=None, owner=None, from_date
     if edit_permission:
         if group:
             group = group_from_id(group)
-            q.append(Q(gaccess__resource__in=group.gaccess.edit_resources))
+            q.append(Q(short_id__in=group.gaccess.edit_resources.values_list('short_id',
+                                                                             flat=True)))
 
         q = _filter_resources_for_user_and_owner(user=user, owner=owner, is_editable=True, query=q)
 
@@ -387,7 +388,8 @@ def get_resource_list(creator=None, group=None, user=None, owner=None, from_date
 
         if group:
             group = group_from_id(group)
-            q.append(Q(gaccess__resource__in=group.gaccess.view_resources))
+            q.append(Q(short_id__in=group.gaccess.view_resources.values_list('short_id',
+                                                                             flat=True)))
 
         q = _filter_resources_for_user_and_owner(user=user, owner=owner, is_editable=False, query=q)
 
@@ -408,7 +410,6 @@ def get_resource_list(creator=None, group=None, user=None, owner=None, from_date
     if not include_obsolete:
         flt = flt.exclude(object_id__in=Relation.objects.filter(
             type='isReplacedBy').values('object_id'))
-
     for q in q:
         flt = flt.filter(q)
 

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -125,6 +125,8 @@ def group_from_id(grp):
     except ObjectDoesNotExist:
         try:
             tgt = Group.objects.get(pk=int(grp))
+        except ValueError:
+            raise Http404('Group not found')
         except TypeError:
             raise Http404('Group not found')
         except ObjectDoesNotExist:

--- a/hs_core/tests/api/rest/base.py
+++ b/hs_core/tests/api/rest/base.py
@@ -33,7 +33,6 @@ class HSRESTTestCase(APITestCase):
 
         self.resources_to_delete = []
         self.groups_to_delete = []
-        self.users_to_delete = []
 
     def tearDown(self):
         for r in self.resources_to_delete:
@@ -41,9 +40,6 @@ class HSRESTTestCase(APITestCase):
 
         for g in self.groups_to_delete:
             g.delete()
-
-        for u in self.users_to_delete:
-            u.delete()
 
         self.user.delete()
 

--- a/hs_core/tests/api/rest/base.py
+++ b/hs_core/tests/api/rest/base.py
@@ -32,10 +32,18 @@ class HSRESTTestCase(APITestCase):
         self.client.force_authenticate(user=self.user)
 
         self.resources_to_delete = []
+        self.groups_to_delete = []
+        self.users_to_delete = []
 
     def tearDown(self):
         for r in self.resources_to_delete:
             resource.delete_resource(r)
+
+        for g in self.groups_to_delete:
+            g.delete()
+
+        for u in self.users_to_delete:
+            u.delete()
 
         self.user.delete()
 

--- a/hs_core/tests/api/rest/test_resource_list.py
+++ b/hs_core/tests/api/rest/test_resource_list.py
@@ -328,9 +328,9 @@ class TestResourceList(HSRESTTestCase):
         gen_res_two = resource.create_resource('GenericResource', self.user, 'Resource 2',
                                                edit_groups=None, view_groups=[group_one, group_two])
         gen_res_three = resource.create_resource('GenericResource', self.user, 'Resource 3',
-                                               edit_groups=[group_one], view_groups=None)
+                                                 edit_groups=[group_one], view_groups=None)
         gen_res_four = resource.create_resource('GenericResource', self.user, 'Resource 4',
-                                               edit_groups=None, view_groups=None)
+                                                edit_groups=None, view_groups=None)
 
         self.groups_to_delete.append(group_one)
         self.groups_to_delete.append(group_two)
@@ -339,7 +339,7 @@ class TestResourceList(HSRESTTestCase):
         self.resources_to_delete.append(gen_res_three.short_id)
         self.resources_to_delete.append(gen_res_four.short_id)
 
-        #resources by group id
+        # resources by group id
         response = self.client.get('/hsapi/resource/', {'group': str(group_one.pk)}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         content = json.loads(response.content)
@@ -363,7 +363,6 @@ class TestResourceList(HSRESTTestCase):
         content = json.loads(response.content)
         self.assertEqual(content['count'], 2)
 
-
     def test_resource_list_by_user(self):
         user_1 = users.create_account(
             'user_1@email.com',
@@ -381,7 +380,7 @@ class TestResourceList(HSRESTTestCase):
         gen_res_one = resource.create_resource('GenericResource', self.user, 'Resource 1',
                                                edit_users=[user_1, user_2], view_users=None)
         gen_res_two = resource.create_resource('GenericResource', self.user, 'Resource 2',
-                                               edit_users=[self.user], view_users=[user_1, user_2])
+                                               edit_users=None, view_users=[user_1, user_2])
         gen_res_three = resource.create_resource('GenericResource', self.user, 'Resource 3',
                                                  edit_users=None, view_users=[user_1])
         gen_res_four = resource.create_resource('GenericResource', user_1, 'Resource 4',

--- a/hs_core/tests/api/rest/test_resource_list.py
+++ b/hs_core/tests/api/rest/test_resource_list.py
@@ -3,7 +3,7 @@ import os
 
 from rest_framework import status
 
-from hs_core.hydroshare import resource, users
+from hs_core.hydroshare import resource
 from .base import HSRESTTestCase
 
 

--- a/hs_core/tests/api/rest/test_resource_list.py
+++ b/hs_core/tests/api/rest/test_resource_list.py
@@ -364,34 +364,14 @@ class TestResourceList(HSRESTTestCase):
         self.assertEqual(content['count'], 2)
 
     def test_resource_list_by_user(self):
-        user_1 = users.create_account(
-            'user_1@email.com',
-            username='user1',
-            first_name='one_first_name',
-            last_name='twp_last_name',
-            superuser=False)
-        user_2 = users.create_account(
-            'user_2@email.com',
-            username='user2',
-            first_name='two_first_name',
-            last_name='two_last_name',
-            superuser=False)
+        # HSRESTTestCase is forcing authentication of user, so we'll just test that user
+        gen_res_one = resource.create_resource('GenericResource', self.user, 'Resource 1')
+        gen_res_two = resource.create_resource('GenericResource', self.user, 'Resource 2')
+        gen_res_three = resource.create_resource('GenericResource', self.user, 'Resource 3')
 
-        gen_res_one = resource.create_resource('GenericResource', self.user, 'Resource 1',
-                                               edit_users=[user_1, user_2], view_users=None)
-        gen_res_two = resource.create_resource('GenericResource', self.user, 'Resource 2',
-                                               edit_users=None, view_users=[user_1, user_2])
-        gen_res_three = resource.create_resource('GenericResource', self.user, 'Resource 3',
-                                                 edit_users=None, view_users=[user_1])
-        gen_res_four = resource.create_resource('GenericResource', user_1, 'Resource 4',
-                                                edit_users=None, view_users=None)
-
-        self.users_to_delete.append(user_1)
-        self.users_to_delete.append(user_2)
         self.resources_to_delete.append(gen_res_one.short_id)
         self.resources_to_delete.append(gen_res_two.short_id)
         self.resources_to_delete.append(gen_res_three.short_id)
-        self.resources_to_delete.append(gen_res_four.short_id)
 
         # resources by owner username
         response = self.client.get('/hsapi/resource/', {'owner': self.user.username}, format='json')
@@ -399,31 +379,11 @@ class TestResourceList(HSRESTTestCase):
         content = json.loads(response.content)
         self.assertEqual(content['count'], 3)
 
-        response = self.client.get('/hsapi/resource/', {'owner': user_1.username}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 4)
-
-        response = self.client.get('/hsapi/resource/', {'owner': user_2.username}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 2)
-
         # resources by owner email
         response = self.client.get('/hsapi/resource/', {'owner': self.user.email}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         content = json.loads(response.content)
         self.assertEqual(content['count'], 3)
-
-        response = self.client.get('/hsapi/resource/', {'owner': user_1.email}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 4)
-
-        response = self.client.get('/hsapi/resource/', {'owner': user_2.email}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 2)
 
         # resources by creator username
         response = self.client.get('/hsapi/resource/', {'creator': self.user.username},
@@ -432,31 +392,11 @@ class TestResourceList(HSRESTTestCase):
         content = json.loads(response.content)
         self.assertEqual(content['count'], 3)
 
-        response = self.client.get('/hsapi/resource/', {'creator': user_1.username}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 1)
-
-        response = self.client.get('/hsapi/resource/', {'creator': user_2.username}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 0)
-
         # resources by creator email
         response = self.client.get('/hsapi/resource/', {'creator': self.user.email}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         content = json.loads(response.content)
         self.assertEqual(content['count'], 3)
-
-        response = self.client.get('/hsapi/resource/', {'creator': user_1.username}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 1)
-
-        response = self.client.get('/hsapi/resource/', {'creator': user_2.username}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 0)
 
         # resources by user username
         response = self.client.get('/hsapi/resource/', {'user': self.user.username},
@@ -465,30 +405,8 @@ class TestResourceList(HSRESTTestCase):
         content = json.loads(response.content)
         self.assertEqual(content['count'], 3)
 
-        response = self.client.get('/hsapi/resource/', {'user': user_1.username},
-                                   format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 1)
-
-        response = self.client.get('/hsapi/resource/', {'user': user_2.username},
-                                   format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 0)
-
         # resources by user email
         response = self.client.get('/hsapi/resource/', {'user': self.user.email}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         content = json.loads(response.content)
         self.assertEqual(content['count'], 3)
-
-        response = self.client.get('/hsapi/resource/', {'user': user_1.email}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 1)
-
-        response = self.client.get('/hsapi/resource/', {'user': user_2.email}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = json.loads(response.content)
-        self.assertEqual(content['count'], 0)

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 from hs_core.hydroshare import utils
 from hs_core import hydroshare
-from .utils import validate_json, validate_user_name,  validate_group_name
+from .utils import validate_json, validate_user,  validate_group
 
 RESOURCE_TYPES = [rtype.__name__ for rtype in utils.get_resource_types()]
 
@@ -67,10 +67,10 @@ class ResourceTypesSerializer(serializers.Serializer):
 
 
 class ResourceListRequestValidator(serializers.Serializer):
-    creator = serializers.CharField(min_length=1, required=False, validators=[validate_user_name])
-    group = serializers.CharField(min_length=1, required=False, validators=[validate_group_name])
-    user = serializers.CharField(min_length=1, required=False, validators=[validate_user_name])
-    owner = serializers.CharField(min_length=1, required=False, validators=[validate_user_name])
+    creator = serializers.CharField(min_length=1, required=False, validators=[validate_user])
+    group = serializers.CharField(min_length=1, required=False, validators=[validate_group])
+    user = serializers.CharField(min_length=1, required=False, validators=[validate_user])
+    owner = serializers.CharField(min_length=1, required=False, validators=[validate_user])
     from_date = serializers.DateField(required=False, default=None)
     to_date = serializers.DateField(required=False, default=None)
     start = serializers.IntegerField(required=False, default=None)

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -232,14 +232,22 @@ def validate_json(js):
         raise ValidationError(detail='Invalid JSON')
 
 
-def validate_user_name(user_name):
-    if not User.objects.filter(username=user_name).exists():
-        raise ValidationError(detail='No user found for user name:%s' % user_name)
+def validate_user(user_identifier):
+    if not User.objects.filter(username=user_identifier).exists():
+        if not User.objects.filter(email=user_identifier).exists():
+            raise ValidationError(detail='No user found for user identifier:%s' % user_identifier)
 
 
-def validate_group_name(group_name):
-    if not Group.objects.filter(name=group_name).exists():
-        raise ValidationError(detail='No group found for group name:%s' % group_name)
+def validate_group(group_identifier):
+    if not Group.objects.filter(name=group_identifier).exists():
+        try:
+            g_id = int(group_identifier)
+            if not Group.objects.filter(pk=g_id).exists():
+                raise ValidationError(
+                    detail='No group found for group identifier:%s' % group_identifier)
+        except ValueError:
+            raise ValidationError(
+                detail='No group found for group identifier:%s' % group_identifier)
 
 
 def validate_metadata(metadata, resource_type):


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Using hs_restclient, query resources by owner, creator and user by username and user email.  Validate username and email return the same resources.
2. Using hs_restclient  query resources by group name and group id.  Validate group id and name return the same resources.
