### PR TITLE
2724 create bag user zone

### DIFF
--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -370,23 +370,40 @@ def replicate_resource_bag_to_user_zone(user, res_id):
     res = get_resource_by_shortkey(res_id)
     res_coll = res.root_path
     istorage = res.get_irods_storage()
-    bag_modified = "false"
+    bag_modified_flag = True
     # needs to check whether res_id collection exists before getting/setting AVU on it to
     # accommodate the case where the very same resource gets deleted by another request when
     # it is getting downloaded
-    # TODO: why would we want to do anything at all if the resource does not exist???
     if istorage.exists(res_coll):
         bag_modified = istorage.getAVU(res_coll, 'bag_modified')
-        if bag_modified.lower() == "true":
+
+        # make sure bag_modified_flag is set to False only if bag exists and bag_modified AVU
+        # is False; otherwise, bag_modified_flag will take the default True value so that the
+        # bag will be created or recreated
+        if bag_modified:
+            if bag_modified.lower() == "false":
+                bag_file_name = res_id + '.zip'
+                if res.resource_federation_path:
+                    bag_full_path = os.path.join(res.resource_federation_path, 'bags', bag_file_name)
+                else:
+                    bag_full_path = os.path.join('bags', bag_file_name)
+
+                if istorage.exists(bag_full_path):
+                    bag_modified_flag = False
+
+        if bag_modified_flag:
             # import here to avoid circular import issue
             from hs_core.tasks import create_bag_by_irods
-            create_bag_by_irods(res_id)
+            status = create_bag_by_irods(res_id)
+            if not status:
+                # bag fails to be created successfully
+                raise SessionException(-1, '', 'The resource bag fails to be created '
+                                               'before bag replication')
 
         # do replication of the resource bag to irods user zone
         if not res.resource_federation_path:
             istorage.set_fed_zone_session()
         src_file = res.bag_path
-        # TODO: allow setting destination path
         tgt_file = '/{userzone}/home/{username}/{resid}.zip'.format(
             userzone=settings.HS_USER_IRODS_ZONE, username=user.username, resid=res_id)
         fsize = istorage.size(src_file)

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -384,7 +384,8 @@ def replicate_resource_bag_to_user_zone(user, res_id):
             if bag_modified.lower() == "false":
                 bag_file_name = res_id + '.zip'
                 if res.resource_federation_path:
-                    bag_full_path = os.path.join(res.resource_federation_path, 'bags', bag_file_name)
+                    bag_full_path = os.path.join(res.resource_federation_path, 'bags',
+                                                 bag_file_name)
                 else:
                     bag_full_path = os.path.join('bags', bag_file_name)
 

--- a/hs_core/tests/api/native/test_irods_user_zone_federation.py
+++ b/hs_core/tests/api/native/test_irods_user_zone_federation.py
@@ -264,7 +264,10 @@ class TestUserZoneIRODSFederation(TestCaseCommonUtilities, TransactionTestCase):
         # since 'copy' is used for fed_copy_or_move when adding the file to the resource
         self.assertTrue(self.irods_storage.exists(user_path + self.file_one))
 
-        # test replication of this resource to user zone
+        # test replication of this resource to user zone even if the bag_modified AVU for this
+        # resource is wrongly set to False when the bag for this resource does not exist and
+        # need to be recreated
+        res.setAVU('bag_modified', 'false')
         hydroshare.replicate_resource_bag_to_user_zone(self.user, res.short_id)
         self.assertTrue(self.irods_storage.exists(user_path + res.short_id + '.zip'),
                         msg='replicated resource bag is not in the user zone')

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -612,6 +612,12 @@ def rep_res_bag_to_irods_user_zone(request, shortkey, *args, **kwargs):
             json.dumps({"error": ex.message}),
             content_type="application/json"
         )
+    except ValidationError as ex:
+        return HttpResponse(
+            json.dumps({"error": ex.message}),
+            content_type="application/json"
+        )
+
 
 def copy_resource(request, shortkey, *args, **kwargs):
     res, authorized, user = authorize(request, shortkey,

--- a/irods_browser_app/static/js/irods.js
+++ b/irods_browser_app/static/js/irods.js
@@ -127,7 +127,7 @@ function click_folder_opr() {
     }
     else {
         var store = $(this).attr('name');
-        var parent = $(this)
+        var parent = $(this);
         get_store(store, parent, margin_left);
         $(this).addClass('isOpen');
         set_datastore($(this).attr('name'), true);


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
This fixes the bag_modified AVU on a resource being wrongly set to False when the resource bag does not even exist, which results in resource bag not being able to be copied to the user zone, as detailed in the issue #2724. To replicate this, one has to manually set bag_modified flag on a resource to be False when the resource bag does not exist yet. I augmented the test to cover this scenario. I also used local irods containers to replicate this scenario and made sure the updated code is able to handle this and successfully recreate the resource bag and copy the created bag to user zone as expected. 