### PR TITLE
2759 quota issues

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -58,7 +58,7 @@ def update_quota_usage(res=None, user=None):
             return
         # update quota usage by a celery task in 1 minute to give iRODS quota usage computation
         # services enough time to finish before reflecting the quota usage in django DB
-        update_quota_usage_task.apply_async((quser.username,), countdown=60)
+        update_quota_usage_task.apply_async((quser.username,), countdown=30)
     return
 
 
@@ -607,7 +607,7 @@ def create_empty_resource(pk, user, action='version'):
     return new_resource
 
 
-def copy_resource(ori_res, new_res):
+def copy_resource(ori_res, new_res, user=None):
     """
     Populate metadata and contents from ori_res object to new_res object to make new_res object
     as a copy of the ori_res object
@@ -615,6 +615,8 @@ def copy_resource(ori_res, new_res):
         ori_res: the original resource that is to be copied.
         new_res: the new_res to be populated with metadata and content from the original resource
         as a copy of the original resource.
+        user: requesting user for the copy action. It is optional, if being passed in, quota is
+        counted toward the user; otherwise, quota is not counted toward that user
     Returns:
         the new resource copied from the original resource
     """
@@ -636,7 +638,8 @@ def copy_resource(ori_res, new_res):
     # create bag for the new resource
     hs_bagit.create_bag(new_res)
     # need to update quota usage for new_res quota holder
-    update_quota_usage(res=new_res)
+    if user:
+        update_quota_usage(user=user)
     return new_res
 
 

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -19,6 +19,7 @@ from hs_core import signals
 from hs_core.hydroshare import utils
 from hs_access_control.models import ResourceAccess, UserResourcePrivilege, PrivilegeCodes
 from hs_labels.models import ResourceLabels
+from django_irods.icommands import SessionException
 
 
 FILE_SIZE_LIMIT = 1*(1024 ** 3)
@@ -29,16 +30,36 @@ METADATA_STATUS_INSUFFICIENT = 'Insufficient to publish or make public'
 logger = logging.getLogger(__name__)
 
 
-def update_quota_usage(res):
-    from hs_core.tasks import update_quota_usage_task
-    quser = res.get_quota_holder()
-    if quser is None:
-        # no quota holder for this resource, this should not happen, but check just in case
-        logger.error('no quota holder is found for resource' + res.short_id)
+def update_quota_usage(res=None, user=None):
+    """
+    Update quota usage as follows:
+    (1) if res is not None & user is None, quota usage of the res' quota holder will be updated
+    (2) if res is None & user is not None, quota usage of the user will be updated
+    (3) if both res and user are None, nothing is updated
+    (4) if both res and user are not None, quota usage of both res' quota holder and user will be
+    updated.
+    :param res: a resource object
+    :param user: a user object
+    :return:
+    """
+    if not res and not user:
         return
-    # update quota usage by a celery task in 1 minute to give iRODS quota usage computation
-    # services enough time to finish before reflecting the quota usage in django DB
-    update_quota_usage_task.apply_async((quser.username,), countdown=60)
+
+    from hs_core.tasks import update_quota_usage_task
+
+    if user:
+        update_quota_usage_task.apply_async((user.username,), countdown=30)
+
+    if res:
+        quser = res.get_quota_holder()
+        if quser is None:
+            # no quota holder for this resource, this should not happen, but check just in case
+            logger.error('no quota holder is found for resource' + res.short_id)
+            return
+        # update quota usage by a celery task in 1 minute to give iRODS quota usage computation
+        # services enough time to finish before reflecting the quota usage in django DB
+        update_quota_usage_task.apply_async((quser.username,), countdown=60)
+    return
 
 
 def get_resource(pk):
@@ -164,6 +185,66 @@ def update_resource_file(pk, filename, f):
                 rf.save()
             return rf
     raise ObjectDoesNotExist(filename)
+
+
+def replicate_resource_bag_to_user_zone(user, res_id):
+    """
+    Replicate resource bag to iRODS user zone
+    Args:
+        user: the requesting user
+        res_id: the resource id with its bag to be replicated to iRODS user zone
+
+    Returns:
+    None, but exceptions will be raised if there is an issue with iRODS operation
+    """
+    # do on-demand bag creation
+
+    res = utils.get_resource_by_shortkey(res_id)
+    res_coll = res.root_path
+    istorage = res.get_irods_storage()
+    bag_modified_flag = True
+    # needs to check whether res_id collection exists before getting/setting AVU on it to
+    # accommodate the case where the very same resource gets deleted by another request when
+    # it is getting downloaded
+    if istorage.exists(res_coll):
+        bag_modified = istorage.getAVU(res_coll, 'bag_modified')
+
+        # make sure bag_modified_flag is set to False only if bag exists and bag_modified AVU
+        # is False; otherwise, bag_modified_flag will take the default True value so that the
+        # bag will be created or recreated
+        if bag_modified:
+            if bag_modified.lower() == "false":
+                bag_file_name = res_id + '.zip'
+                if res.resource_federation_path:
+                    bag_full_path = os.path.join(res.resource_federation_path, 'bags',
+                                                 bag_file_name)
+                else:
+                    bag_full_path = os.path.join('bags', bag_file_name)
+
+                if istorage.exists(bag_full_path):
+                    bag_modified_flag = False
+
+        if bag_modified_flag:
+            # import here to avoid circular import issue
+            from hs_core.tasks import create_bag_by_irods
+            status = create_bag_by_irods(res_id)
+            if not status:
+                # bag fails to be created successfully
+                raise SessionException(-1, '', 'The resource bag fails to be created '
+                                               'before bag replication')
+
+        # do replication of the resource bag to irods user zone
+        if not res.resource_federation_path:
+            istorage.set_fed_zone_session()
+        src_file = res.bag_path
+        tgt_file = '/{userzone}/home/{username}/{resid}.zip'.format(
+            userzone=settings.HS_USER_IRODS_ZONE, username=user.username, resid=res_id)
+        fsize = istorage.size(src_file)
+        utils.validate_user_quota(user, fsize)
+        istorage.copyFiles(src_file, tgt_file)
+        update_quota_usage(user=user)
+    else:
+        raise ValidationError("Resource {} does not exist in iRODS".format(res.short_id))
 
 
 def get_related(pk):
@@ -554,7 +635,8 @@ def copy_resource(ori_res, new_res):
 
     # create bag for the new resource
     hs_bagit.create_bag(new_res)
-
+    # need to update quota usage for new_res quota holder
+    update_quota_usage(res=new_res)
     return new_res
 
 
@@ -607,6 +689,8 @@ def create_new_version_resource(ori_res, new_res, user):
     # obsoleted resources cannot be modified from REST API
     ori_res.raccess.immutable = True
     ori_res.raccess.save()
+    # need to update quota usage for the user
+    update_quota_usage(user=user)
     return new_res
 
 
@@ -663,7 +747,7 @@ def add_resource_files(pk, *files, **kwargs):
         utils.create_empty_contents_directory(resource)
     else:
         # some file(s) added, need to update quota usage
-        update_quota_usage(resource)
+        update_quota_usage(res=resource)
     return ret
 
 
@@ -767,7 +851,7 @@ def delete_resource(pk):
             obsolete_res.raccess.save()
 
     # need to update quota usage when a resource is deleted
-    update_quota_usage(res)
+    update_quota_usage(res=res)
 
     res.delete()
     return pk
@@ -799,7 +883,7 @@ def delete_resource_file_only(resource, f):
     short_path = f.short_path
     f.delete()
     # need to update quota usage when a file is deleted
-    update_quota_usage(resource)
+    update_quota_usage(res=resource)
     return short_path
 
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1803,16 +1803,28 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
         setter is the requesting user to transfer quota holder and setter must also be an owner
         """
         from hs_core.hydroshare.utils import validate_user_quota
+        from hs_core.hydroshare.resource import update_quota_usage
+
         if __debug__:
             assert(isinstance(setter, User))
             assert(isinstance(new_holder, User))
         if not setter.uaccess.owns_resource(self) or \
                 not new_holder.uaccess.owns_resource(self):
             raise PermissionDenied("Only owners can set or be set as quota holder for the resource")
+
         # QuotaException will be raised if new_holder does not have enough quota to hold this
         # new resource, in which case, set_quota_holder to the new user fails
         validate_user_quota(new_holder, self.size)
-        self.setAVU("quotaUserName", new_holder.username)
+        attname = "quotaUserName"
+        oldqu = self.getAVU(attname)
+        if oldqu and oldqu != new_holder.username:
+            # have to remove the old AVU first before setting to the new one in order to trigger
+            # quota micro-service PEP msiRemoveQuotaHolder so quota for old quota
+            # holder will be reduced as a result of setting quota holder to a different user
+            self.removeAVU(attname, oldqu)
+
+        self.setAVU(attname, new_holder.username)
+        update_quota_usage(res=self, user=setter)
 
     def get_quota_holder(self):
         """Get quota holder of the resource.
@@ -1830,6 +1842,16 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
         else:
             # quotaUserName AVU does not exist, return None
             return None
+
+    def removeAVU(self, attribute, value):
+        """Remove an AVU at the resource level.
+
+        This avoids mistakes in setting AVUs by assuring that the appropriate root path
+        is alway used.
+        """
+        istorage = self.get_irods_storage()
+        root_path = self.root_path
+        istorage.session.run("imeta", None, 'rm', '-C', root_path, attribute, value)
 
     def setAVU(self, attribute, value):
         """Set an AVU at the resource level.

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1816,12 +1816,15 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
         # new resource, in which case, set_quota_holder to the new user fails
         validate_user_quota(new_holder, self.size)
         attname = "quotaUserName"
-        oldqu = self.getAVU(attname)
-        if oldqu:
-            # have to remove the old AVU first before setting to the new one in order to trigger
-            # quota micro-service PEP msiRemoveQuotaHolder so quota for old quota
-            # holder will be reduced as a result of setting quota holder to a different user
-            self.removeAVU(attname, oldqu)
+
+        if setter.username != new_holder.username:
+            # this condition check is needed to make sure attname exists as AVU before getting it
+            oldqu = self.getAVU(attname)
+            if oldqu:
+                # have to remove the old AVU first before setting to the new one in order to trigger
+                # quota micro-service PEP msiRemoveQuotaHolder so quota for old quota
+                # holder will be reduced as a result of setting quota holder to a different user
+                self.removeAVU(attname, oldqu)
         self.setAVU(attname, new_holder.username)
         update_quota_usage(res=self, user=setter)
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1817,12 +1817,11 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
         validate_user_quota(new_holder, self.size)
         attname = "quotaUserName"
         oldqu = self.getAVU(attname)
-        if oldqu and oldqu != new_holder.username:
+        if oldqu:
             # have to remove the old AVU first before setting to the new one in order to trigger
             # quota micro-service PEP msiRemoveQuotaHolder so quota for old quota
             # holder will be reduced as a result of setting quota holder to a different user
             self.removeAVU(attname, oldqu)
-
         self.setAVU(attname, new_holder.username)
         update_quota_usage(res=self, user=setter)
 

--- a/hs_core/tests/api/native/test_irods_user_zone_federation.py
+++ b/hs_core/tests/api/native/test_irods_user_zone_federation.py
@@ -258,8 +258,11 @@ class TestUserZoneIRODSFederation(TestCaseCommonUtilities, TransactionTestCase):
         # since 'copy' is used for fed_copy_or_move when adding the file to the resource
         self.assertTrue(self.irods_storage.exists(user_path + self.file_one))
 
-        # test replication of this resource to user zone
-        hydroshare.replicate_resource_bag_to_user_zone(self.user, res.short_id)
+        # test replication of this resource to user zone even if the bag_modified AVU for this
+        # resource is wrongly set to False when the bag for this resource does not exist and
+        # need to be recreated
+        res.setAVU('bag_modified', 'false')
+        hydroshare.resource.replicate_resource_bag_to_user_zone(self.user, res.short_id)
         self.assertTrue(self.irods_storage.exists(user_path + res.short_id + '.zip'),
                         msg='replicated resource bag is not in the user zone')
 

--- a/hs_core/tests/api/native/test_irods_user_zone_federation.py
+++ b/hs_core/tests/api/native/test_irods_user_zone_federation.py
@@ -258,10 +258,6 @@ class TestUserZoneIRODSFederation(TestCaseCommonUtilities, TransactionTestCase):
         # since 'copy' is used for fed_copy_or_move when adding the file to the resource
         self.assertTrue(self.irods_storage.exists(user_path + self.file_one))
 
-        # test replication of this resource to user zone even if the bag_modified AVU for this
-        # resource is wrongly set to False when the bag for this resource does not exist and
-        # need to be recreated
-        res.setAVU('bag_modified', 'false')
         hydroshare.resource.replicate_resource_bag_to_user_zone(self.user, res.short_id)
         self.assertTrue(self.irods_storage.exists(user_path + res.short_id + '.zip'),
                         msg='replicated resource bag is not in the user zone')

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -621,7 +621,7 @@ def copy_resource(request, shortkey, *args, **kwargs):
     new_resource = None
     try:
         new_resource = hydroshare.create_empty_resource(shortkey, user, action='copy')
-        new_resource = hydroshare.copy_resource(res, new_resource)
+        new_resource = hydroshare.copy_resource(res, new_resource, user=request.user)
     except Exception as ex:
         if new_resource:
             new_resource.delete()
@@ -651,7 +651,8 @@ def create_new_version_resource(request, shortkey, *args, **kwargs):
             res.locked_time = None
             res.save()
         else:
-            # cannot create new version for this resource since the resource is locked by another user
+            # cannot create new version for this resource since the resource is locked by another
+            # user
             request.session['resource_creation_error'] = 'Failed to create a new version for ' \
                                                          'this resource since another user is ' \
                                                          'creating a new version for this ' \

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -41,7 +41,8 @@ from hs_core.hydroshare.utils import get_resource_by_shortkey, resource_modified
 from .utils import authorize, upload_from_irods, ACTION_TO_AUTHORIZE, run_script_to_update_hyrax_input_files, \
     get_my_resources_list, send_action_to_take_email, get_coverage_data_dict
 from hs_core.models import GenericResource, resource_processor, CoreMetaData, Subject
-from hs_core.hydroshare.resource import METADATA_STATUS_SUFFICIENT, METADATA_STATUS_INSUFFICIENT
+from hs_core.hydroshare.resource import METADATA_STATUS_SUFFICIENT, METADATA_STATUS_INSUFFICIENT, \
+    replicate_resource_bag_to_user_zone
 
 from . import resource_rest_api
 from . import resource_metadata_rest_api
@@ -598,7 +599,7 @@ def rep_res_bag_to_irods_user_zone(request, shortkey, *args, **kwargs):
         )
 
     try:
-        utils.replicate_resource_bag_to_user_zone(user, shortkey)
+        replicate_resource_bag_to_user_zone(user, shortkey)
         return HttpResponse(
             json.dumps({"success": "This resource bag zip file has been successfully copied to your iRODS user zone."}),
             content_type = "application/json"


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Copy a resource, wait for 30 seconds, you should see your quota usage increased by the size of the newly copied resource from your profile page.
2. Create a new version of a resource, wait for 30 seconds, you should see your quota usage increased by the size of the newly copied resource from your profile page.
3. Copy a resource bag to your iRODS user zone, wait for 30 seconds, you should see your quota usage increased by the size of the newly copied resource from your profile page.
