### PR TITLE
2738 discover by content type

### DIFF
--- a/hs_app_netCDF/models.py
+++ b/hs_app_netCDF/models.py
@@ -352,6 +352,8 @@ class NetcdfResource(BaseResource):
         if nc_res_file and txt_res_file:
             netcdf_file_update(self, nc_res_file[0], txt_res_file[0], user)
 
+    verbose_content_type = 'Multidimensional (NetCDF)'  # used during discovery
+
     class Meta:
         verbose_name = 'Multidimensional (NetCDF)'
         proxy = True

--- a/hs_app_timeseries/models.py
+++ b/hs_app_timeseries/models.py
@@ -838,6 +838,8 @@ class CVAggregationStatistic(AbstractCVLookupTable):
 class TimeSeriesResource(BaseResource):
     objects = ResourceManager("TimeSeriesResource")
 
+    verbose_content_type = 'Time Series'  # used during discovery
+
     class Meta:
         verbose_name = 'Time Series'
         proxy = True

--- a/hs_collection_resource/models.py
+++ b/hs_collection_resource/models.py
@@ -10,6 +10,8 @@ class CollectionResource(BaseResource):
 
     objects = ResourceManager('CollectionResource')
 
+    verbose_content_type = 'Collection'  # used during discovery
+
     class Meta:
         proxy = True
         verbose_name = 'Collection Resource'

--- a/hs_composite_resource/models.py
+++ b/hs_composite_resource/models.py
@@ -10,6 +10,8 @@ from hs_file_types.models import GenericLogicalFile
 class CompositeResource(BaseResource):
     objects = ResourceManager("CompositeResource")
 
+    verbose_content_type = 'Composite'  # used during discovery
+
     class Meta:
         verbose_name = 'Composite Resource'
         proxy = True

--- a/hs_core/discovery_form.py
+++ b/hs_core/discovery_form.py
@@ -4,7 +4,7 @@ from django import forms
 from hs_core.discovery_parser import ParseSQ, MatchingBracketsNotFoundError, \
     FieldNotRecognizedError, InequalityNotAllowedError, MalformedDateError
 
-FACETED_FIELDS = ['creator', 'contributor', 'owner', 'resource_type', 'subject', 'availability']
+FACETS_TO_SHOW = ['creator', 'contributor', 'owner', 'content_type', 'subject', 'availability']
 
 
 class DiscoveryForm(FacetedSearchForm):
@@ -114,7 +114,7 @@ class DiscoveryForm(FacetedSearchForm):
         contributor_sq = None
         owner_sq = None
         subject_sq = None
-        resource_type_sq = None
+        content_type_sq = None
         availability_sq = None
 
         # We need to process each facet to ensure that the field name and the
@@ -152,11 +152,11 @@ class DiscoveryForm(FacetedSearchForm):
                     else:
                         subject_sq.add(SQ(subject__exact=value), SQ.OR)
 
-                elif "resource_type" in field:
-                    if resource_type_sq is None:
-                        resource_type_sq = SQ(resource_type__exact=value)
+                elif "content_type" in field:
+                    if content_type_sq is None:
+                        content_type_sq = SQ(content_type__exact=value)
                     else:
-                        resource_type_sq.add(SQ(resource_type__exact=value), SQ.OR)
+                        content_type_sq.add(SQ(content_type__exact=value), SQ.OR)
 
                 elif "availability" in field:
                     if availability_sq is None:
@@ -175,8 +175,8 @@ class DiscoveryForm(FacetedSearchForm):
             sqs = sqs.filter(owner_sq)
         if subject_sq is not None:
             sqs = sqs.filter(subject_sq)
-        if resource_type_sq is not None:
-            sqs = sqs.filter(resource_type_sq)
+        if content_type_sq is not None:
+            sqs = sqs.filter(content_type_sq)
         if availability_sq is not None:
             sqs = sqs.filter(availability_sq)
 

--- a/hs_core/discovery_parser.py
+++ b/hs_core/discovery_parser.py
@@ -127,6 +127,7 @@ class ParseSQ(object):
         'source',
         'relation',
         'resource_type',
+        'content_type',
         'comment',
         'comments_count',
         'owner_login',

--- a/hs_core/management/commands/solr_facets.py
+++ b/hs_core/management/commands/solr_facets.py
@@ -4,7 +4,7 @@ It is used for debugging the faceting system.
 """
 
 from django.core.management.base import BaseCommand
-from hs_core.discovery_form import FACETED_FIELDS
+from hs_core.discovery_form import FIELDS_TO_SHOW
 from haystack.query import SearchQuerySet
 from pprint import pprint
 
@@ -30,4 +30,4 @@ class Command(BaseCommand):
             debug_facets(options['facet_fields'])
 
         else:
-            debug_facets(FACETED_FIELDS)
+            debug_facets(FIELDS_TO_SHOW)

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3277,6 +3277,8 @@ class BaseResource(Page, AbstractResource):
 
     collections = models.ManyToManyField('BaseResource', related_name='resources')
 
+    verbose_content_type = 'Generic'  # used during discovery
+
     class Meta:
         """Define meta properties for BaseResource model."""
 
@@ -3473,6 +3475,11 @@ class BaseResource(Page, AbstractResource):
         return self.get_content_model()._meta.verbose_name
 
     @property
+    def verbose_content_type(self):
+        """Return verbose name of content type."""
+        return self.get_content_model().verbose_content_type
+
+    @property
     def can_be_published(self):
         """Determine when data and metadata are complete enough for the resource to be published.
 
@@ -3542,9 +3549,10 @@ class GenericResource(BaseResource):
         """Return True always."""
         return True
 
+    verbose_content_type = 'Generic'  # used during discovery
+
     class Meta:
         """Define meta properties for GenericResource model."""
-
         verbose_name = 'Generic'
         proxy = True
 

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -107,6 +107,7 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
     source = indexes.MultiValueField()
     relation = indexes.MultiValueField()
     resource_type = indexes.CharField(faceted=True)
+    content_type = indexes.MultiValueField(faceted=True)
     comment = indexes.MultiValueField()
     comments_count = indexes.IntegerField(faceted=True)
     owner_login = indexes.MultiValueField(faceted=True)
@@ -530,6 +531,15 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
     def prepare_resource_type(self, obj):
         """Resource type is verbose_name attribute of obj argument."""
         return obj.verbose_name
+
+    def prepare_content_type(self, obj): 
+        if obj.verbose_name != 'Composite Resource': 
+            return [obj.verbose_content_type]
+        else: 
+            output = []
+            for f in obj.get_logical_files(): 
+                output.append(f.verbose_content_type) 
+            return output
 
     def prepare_comment(self, obj):
         """Return list of all comments on resource."""

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -537,7 +537,7 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
             return [obj.verbose_content_type]
         else: 
             output = []
-            for f in obj.get_logical_files(): 
+            for f in obj.logical_files: 
                 output.append(f.verbose_content_type) 
             return output
 

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -532,13 +532,13 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
         """Resource type is verbose_name attribute of obj argument."""
         return obj.verbose_name
 
-    def prepare_content_type(self, obj): 
-        if obj.verbose_name != 'Composite Resource': 
+    def prepare_content_type(self, obj):
+        if obj.verbose_name != 'Composite Resource':
             return [obj.verbose_content_type]
-        else: 
+        else:
             output = []
-            for f in obj.logical_files: 
-                output.append(f.verbose_content_type) 
+            for f in obj.logical_files:
+                output.append(f.verbose_content_type)
             return output
 
     def prepare_comment(self, obj):

--- a/hs_core/templates/search/search.html
+++ b/hs_core/templates/search/search.html
@@ -55,8 +55,8 @@
                                             &nbsp; Filter by contributor
                                         {% elif key ==  'subject'%}
                                             &nbsp; Filter by subject
-                                        {% elif key ==  'resource_type'%}
-                                            &nbsp; Filter by resource type
+                                        {% elif key ==  'content_type'%}
+                                            &nbsp; Filter by content type
                                         {% elif key ==  'owner'%}
                                             &nbsp; Filter by owner
                                         {% elif key ==  'availability'%}

--- a/hs_core/views/discovery_json_view.py
+++ b/hs_core/views/discovery_json_view.py
@@ -1,14 +1,14 @@
 import json
 from django.http import HttpResponse
 from haystack.generic_views import FacetedSearchView
-from hs_core.discovery_form import DiscoveryForm, FACETED_FIELDS
+from hs_core.discovery_form import DiscoveryForm, FACETS_TO_SHOW
 
 
 # View class for generating JSON data format from Haystack
 # returned JSON objects array is used for building the map view
 class DiscoveryJsonView(FacetedSearchView):
     # declare form class to use in this view
-    facet_fields = FACETED_FIELDS
+    facet_fields = FACETS_TO_SHOW
     form_class = DiscoveryForm
 
     # overwrite Haystack generic_view.py form_valid() function to generate JSON response

--- a/hs_core/views/discovery_view.py
+++ b/hs_core/views/discovery_view.py
@@ -1,11 +1,11 @@
 from haystack.generic_views import FacetedSearchView
 from haystack.generic_views import FacetedSearchMixin
-from hs_core.discovery_form import DiscoveryForm, FACETED_FIELDS
+from hs_core.discovery_form import DiscoveryForm, FACETS_TO_SHOW
 from haystack.query import SearchQuerySet
 
 
 class DiscoveryView(FacetedSearchView):
-    facet_fields = FACETED_FIELDS  # interpreted by FacetedSearchView; must be attribute
+    facet_fields = FACETS_TO_SHOW  # interpreted by FacetedSearchView; must be attribute
     form_class = DiscoveryForm
 
     def form_valid(self, form):

--- a/hs_file_types/models/base.py
+++ b/hs_file_types/models/base.py
@@ -595,6 +595,9 @@ class AbstractLogicalFile(models.Model):
     # also this data type needs to be defined in in terms.html page
     data_type = "Generic"
 
+    # display name for content type: used in discovery faceting
+    verbose_content_type = "Generic"
+
     class Meta:
         abstract = True
 

--- a/hs_file_types/models/generic.py
+++ b/hs_file_types/models/generic.py
@@ -116,6 +116,7 @@ class GenericLogicalFile(AbstractLogicalFile):
     Composite Resource """
     metadata = models.OneToOneField(GenericFileMetaData, related_name="logical_file")
     data_type = "genericData"
+    verbose_content_type = "Generic Data"  # used during discovery
 
     @classmethod
     def create(cls):

--- a/hs_file_types/models/geofeature.py
+++ b/hs_file_types/models/geofeature.py
@@ -161,6 +161,7 @@ class GeoFeatureFileMetaData(GeographicFeatureMetaDataMixin, AbstractFileMetaDat
 class GeoFeatureLogicalFile(AbstractLogicalFile):
     metadata = models.OneToOneField(GeoFeatureFileMetaData, related_name="logical_file")
     data_type = "GeographicFeature"
+    verbose_content_Type = "Geographic Feature (ESRI Shapefiles)" 
 
     @classmethod
     def get_allowed_uploaded_file_types(cls):

--- a/hs_file_types/models/geofeature.py
+++ b/hs_file_types/models/geofeature.py
@@ -161,7 +161,7 @@ class GeoFeatureFileMetaData(GeographicFeatureMetaDataMixin, AbstractFileMetaDat
 class GeoFeatureLogicalFile(AbstractLogicalFile):
     metadata = models.OneToOneField(GeoFeatureFileMetaData, related_name="logical_file")
     data_type = "GeographicFeature"
-    verbose_content_Type = "Geographic Feature (ESRI Shapefiles)" 
+    verbose_content_Type = "Geographic Feature (ESRI Shapefiles)"
 
     @classmethod
     def get_allowed_uploaded_file_types(cls):
@@ -571,12 +571,12 @@ def extract_metadata(shp_file_full_path):
             # if extent is a point, create point type coverage
             if wgs84_dict["westlimit"] == wgs84_dict["eastlimit"] \
                and wgs84_dict["northlimit"] == wgs84_dict["southlimit"]:
-                coverage_dict = {"Coverage": {"type": "point",
-                                 "value": {"east": wgs84_dict["eastlimit"],
-                                           "north": wgs84_dict["northlimit"],
-                                           "units": wgs84_dict["units"],
-                                           "projection": wgs84_dict["projection"]}
-                                }}
+                coverage_dict = {"Coverage":
+                                 {"type": "point",
+                                  "value": {"east": wgs84_dict["eastlimit"],
+                                            "north": wgs84_dict["northlimit"],
+                                            "units": wgs84_dict["units"],
+                                            "projection": wgs84_dict["projection"]}}}
             else:  # otherwise, create box type coverage
                 coverage_dict = {"Coverage": {"type": "box",
                                               "value": parsed_md_dict["wgs84_extent_dict"]}}

--- a/hs_file_types/models/netcdf.py
+++ b/hs_file_types/models/netcdf.py
@@ -276,6 +276,7 @@ class NetCDFFileMetaData(NetCDFMetaDataMixin, AbstractFileMetaData):
 class NetCDFLogicalFile(AbstractLogicalFile):
     metadata = models.OneToOneField(NetCDFFileMetaData, related_name="logical_file")
     data_type = "Multidimensional"
+    verbose_content_type = "Multidimensional (NetCDF)"  # used during discovery
 
     @classmethod
     def get_allowed_uploaded_file_types(cls):

--- a/hs_file_types/models/raster.py
+++ b/hs_file_types/models/raster.py
@@ -210,6 +210,7 @@ class GeoRasterFileMetaData(GeoRasterMetaDataMixin, AbstractFileMetaData):
 class GeoRasterLogicalFile(AbstractLogicalFile):
     metadata = models.OneToOneField(GeoRasterFileMetaData, related_name="logical_file")
     data_type = "GeographicRaster"
+    verbose_content_type = "Geographic Raster"  # used during discovery
 
     @classmethod
     def get_allowed_uploaded_file_types(cls):

--- a/hs_file_types/models/reftimeseries.py
+++ b/hs_file_types/models/reftimeseries.py
@@ -705,6 +705,7 @@ class RefTimeseriesLogicalFile(AbstractLogicalFile):
     Composite Resource """
     metadata = models.OneToOneField(RefTimeseriesFileMetaData, related_name="logical_file")
     data_type = "referenceTimeseriesData"
+    verbose_content_type = "Reference to Time Series"  # used during discovery
 
     @classmethod
     def get_allowed_uploaded_file_types(cls):

--- a/hs_file_types/models/timeseries.py
+++ b/hs_file_types/models/timeseries.py
@@ -404,6 +404,7 @@ class TimeSeriesFileMetaData(TimeSeriesMetaDataMixin, AbstractFileMetaData):
 class TimeSeriesLogicalFile(AbstractLogicalFile):
     metadata = models.OneToOneField(TimeSeriesFileMetaData, related_name="logical_file")
     data_type = "TimeSeries"
+    verbose_content_type = "Time Series"  # used during discovery
 
     @classmethod
     def get_allowed_uploaded_file_types(cls):

--- a/hs_geo_raster_resource/models.py
+++ b/hs_geo_raster_resource/models.py
@@ -347,6 +347,8 @@ class CellInformation(AbstractMetaDataElement):
 class RasterResource(BaseResource):
     objects = ResourceManager("RasterResource")
 
+    verbose_content_type = 'Geographic Raster'  # used during discovery
+
     class Meta:
         verbose_name = 'Geographic Raster'
         proxy = True

--- a/hs_geographic_feature_resource/models.py
+++ b/hs_geographic_feature_resource/models.py
@@ -256,6 +256,8 @@ class GeographicFeatureResource(BaseResource):
             hs_term_dict["HS_GFR_FEATURE_COUNT"] = 0
         return hs_term_dict
 
+    verbose_content_type = 'Geographic Feature (ESRI Shapefiles)'  # used during discovery
+
     class Meta:
         verbose_name = 'Geographic Feature (ESRI Shapefiles)'
         proxy = True

--- a/hs_model_program/models.py
+++ b/hs_model_program/models.py
@@ -84,6 +84,8 @@ class MpMetadata(AbstractMetaDataElement):
 class ModelProgramResource(BaseResource):
     objects = ResourceManager("ModelProgramResource")
 
+    verbose_content_type = 'Model Program'  # used during discovery
+
     class Meta:
         verbose_name = 'Model Program Resource'
         proxy = True

--- a/hs_modelinstance/models.py
+++ b/hs_modelinstance/models.py
@@ -111,6 +111,8 @@ class ExecutedBy(AbstractMetaDataElement):
 class ModelInstanceResource(BaseResource):
     objects = ResourceManager("ModelInstanceResource")
 
+    verbose_content_type = 'Model Instance'  # used during discovery
+
     class Meta:
         verbose_name = 'Model Instance Resource'
         proxy = True

--- a/hs_modflow_modelinstance/models.py
+++ b/hs_modflow_modelinstance/models.py
@@ -597,6 +597,8 @@ class GeneralElements(AbstractMetaDataElement):
 class MODFLOWModelInstanceResource(BaseResource):
     objects = ResourceManager("MODFLOWModelInstanceResource")
 
+    verbose_content_type = 'MODFLOW Model Instance'  # used during discovery
+
     class Meta:
         verbose_name = 'MODFLOW Model Instance Resource'
         proxy = True

--- a/hs_script_resource/models.py
+++ b/hs_script_resource/models.py
@@ -13,6 +13,8 @@ from hs_core.models import BaseResource, ResourceManager, resource_processor, Co
 class ScriptResource(BaseResource):
     objects = ResourceManager('ScriptResource')
 
+    verbose_content_type = 'Script'  # used during discovery
+
     class Meta:
         proxy = True
         verbose_name = 'Script Resource'

--- a/hs_swat_modelinstance/models.py
+++ b/hs_swat_modelinstance/models.py
@@ -355,6 +355,8 @@ class ModelInput(AbstractMetaDataElement):
 class SWATModelInstanceResource(BaseResource):
     objects = ResourceManager("SWATModelInstanceResource")
 
+    verbose_content_type = 'SWAT Model Instance'  # used during discovery
+
     class Meta:
         verbose_name = 'SWAT Model Instance Resource'
         proxy = True

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -17,6 +17,8 @@ from .utils import get_SupportedResTypes_choices, get_SupportedSharingStatus_cho
 class ToolResource(BaseResource):
     objects = ResourceManager('ToolResource')
 
+    verbose_content_type = 'Web App'  # used during discovery
+
     class Meta:
         proxy = True
         verbose_name = 'Web App Resource'

--- a/ref_ts/models.py
+++ b/ref_ts/models.py
@@ -13,6 +13,7 @@ class RefTimeSeriesResource(BaseResource):
 
     class Meta:
         verbose_name = "HIS Referenced Time Series"
+        verbose_content_type = "Reference to HIS Time Series"
         proxy = True
 
     @property

--- a/ref_ts/models.py
+++ b/ref_ts/models.py
@@ -11,9 +11,10 @@ from lxml import etree
 class RefTimeSeriesResource(BaseResource):
     objects = ResourceManager("RefTimeSeriesResource")
 
+    verbose_content_type = "Reference to HIS Time Series"  # used during discovery
+
     class Meta:
         verbose_name = "HIS Referenced Time Series"
-        verbose_content_type = "Reference to HIS Time Series"
         proxy = True
 
     @property


### PR DESCRIPTION
@aphelionz Add discovery by content type to discovery facets. 

The current discovery interface only discovers resources by resource type. This is useless, as people are currently only creating composite resources. This change allows users to search by the content types of files contained within the resource. These types are known as `content_type` in the discovery interface. 

The change involves: 

1. Defining print names for content types of both logical files and resources. These should agree. 
2. Harvesting the content types of composite resources. 
3. Exposing a new facet "Filter by content type" instead of "Filter by resource type" 
4. Exposing a new search command `content_type:X` that can be used in the query interface. 

I have based this PR on develop and am aware that it will require (minimal) changes once composite resource is merged. 
 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case

1. Check a content type box in discovery, only resources with that content type (or a more specific type) appear. 
2. The `content_type:value` filter in the query interface returns all resources with matching content types. 

