### PR TITLE
[#2502] fix the refresh error in firefox with message no files to be …

### DIFF
--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -1099,10 +1099,14 @@ $(document).ready(function () {
                         pathLog.push("data/contents");
                         pathLogIndex = pathLog.length - 1;
 
-                        refreshFileBrowser();
-                        $("#previews").empty();
                         if(resourceType === 'Composite Resource') {
+                            // uploaded files can affect metadata in composite resource.
+                            // a full refresh is needed to reflect those changes
                             refreshResourceEditPage();
+                        }
+                        else {
+                            refreshFileBrowser();
+                            $("#previews").empty();
                         }
                     }
                 });


### PR DESCRIPTION
When uploading files in firefox, an error in the file browser showed up with a message "No files to be displayed" briefly before a refresh.  These changes fix the problem.

@pkdash - could you take a look at this real quick.  I assume you're doing the full refresh for composite reosurces because an aggregation may have been uploaded which might change some of the metadata.  In that case, a full refresh would be needed to reflect those changes, rather than just a file browser refresh.