### PR TITLE
[#2502] update file_type key for GenericLogicalFile from Generic to S…

### DIFF
--- a/hs_file_types/utils.py
+++ b/hs_file_types/utils.py
@@ -214,7 +214,7 @@ def set_logical_file_type(res, user, file_id, hs_file_type=None, folder_path=Non
                                  "extensions are: {}".format(ext_to_type.keys()))
             return
 
-    file_type_map = {"Generic": GenericLogicalFile,
+    file_type_map = {"SingleFile": GenericLogicalFile,
                      "GeoRaster": GeoRasterLogicalFile,
                      "NetCDF": NetCDFLogicalFile,
                      'GeoFeature': GeoFeatureLogicalFile,

--- a/hs_file_types/views.py
+++ b/hs_file_types/views.py
@@ -41,7 +41,8 @@ def set_file_type(request, resource_id, hs_file_type, file_id=None, **kwargs):
     :param  file_id: id of the file which needs to be set to a file type. If file_id is not provided
     then the request must have a file_folder key. In that case the specified folder will be used
     for creating the logical file (aggregation)
-    :param  hs_file_type: file type to be set (e.g, NetCDF, GeoRaster, GeoFeature etc)
+    :param  hs_file_type: file type to be set (e.g, SingleFile, NetCDF, GeoRaster, RefTimeseries,
+    TimeSeries and GeoFeature)
     :return an instance of JsonResponse type
     """
 

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -1533,7 +1533,7 @@ $(document).ready(function () {
 
     // set generic file type method
      $("#btn-set-generic-file-type").click(function () {
-         setFileType("Generic");
+         setFileType("SingleFile");
       });
 
     // set geo raster file type method


### PR DESCRIPTION
For usability in the API and the client, I'm updating the keyword for the GenericLogicalFile type from Generic to SingleFile.

You can test by setting any file in a composite resource as a GenericLogicalFile.  In edit mode, right click the file and select "Add metadata to file"