### PR TITLE
fix #2865

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -1647,7 +1647,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
 
         and False otherwise
         """
-        has_files = self.has_required_content_files
+        has_files = self.has_required_content_files()
         has_metadata = self.has_required_metadata
         return has_files and has_metadata
 
@@ -1678,7 +1678,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
 
         # check that there is sufficient resource content
         has_metadata = self.has_required_metadata
-        has_files = self.has_required_content_files
+        has_files = self.has_required_content_files()
         if value and not (has_metadata and has_files):
 
             if not has_metadata and not has_files:
@@ -1730,7 +1730,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
 
         # check that there is sufficient resource content
         has_metadata = self.has_required_metadata
-        has_files = self.has_required_content_files
+        has_files = self.has_required_content_files()
         if value and not (has_metadata and has_files):
 
             if not has_metadata and not has_files:

--- a/hs_core/tests/api/rest/test_set_access_rules.py
+++ b/hs_core/tests/api/rest/test_set_access_rules.py
@@ -50,7 +50,7 @@ class TestSetAccessRules(HSRESTTestCase):
 
         access_url = "/hsapi/resource/accessRules/{res_id}/".format(res_id=res_id)
         response = self.client.put(access_url, {'public': True})
-        # the resource does not have content file, so it cannot be made public
+        # this test resource does not have content file, so it cannot be made public
         self.assertEqual(response.status_code, status.status.HTTP_403_FORBIDDEN)
 
         response = self.client.get(sysmeta_url)

--- a/hs_core/tests/api/rest/test_set_access_rules.py
+++ b/hs_core/tests/api/rest/test_set_access_rules.py
@@ -51,7 +51,7 @@ class TestSetAccessRules(HSRESTTestCase):
         access_url = "/hsapi/resource/accessRules/{res_id}/".format(res_id=res_id)
         response = self.client.put(access_url, {'public': True})
         # this test resource does not have content file, so it cannot be made public
-        self.assertEqual(response.status_code, status.status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         response = self.client.get(sysmeta_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/hs_core/tests/api/rest/test_set_access_rules.py
+++ b/hs_core/tests/api/rest/test_set_access_rules.py
@@ -50,12 +50,13 @@ class TestSetAccessRules(HSRESTTestCase):
 
         access_url = "/hsapi/resource/accessRules/{res_id}/".format(res_id=res_id)
         response = self.client.put(access_url, {'public': True})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # the resource does not have content file, so it cannot be made public
+        self.assertEqual(response.status_code, status.status.HTTP_403_FORBIDDEN)
 
         response = self.client.get(sysmeta_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         content = json.loads(response.content)
-        self.assertTrue(content['public'])
+        self.assertFalse(content['public'])
 
     def test_get_access_rules_via_sysmeta(self):
         rtype = 'GenericResource'

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -8,6 +8,7 @@ import json
 
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist, SuspiciousFileOperation
+from django.core.exceptions import ValidationError as CoreValidationError
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.contrib.sites.models import Site
@@ -639,7 +640,7 @@ class AccessRulesUpdate(APIView):
         res = get_resource_by_shortkey(pk)
         try:
             res.set_public(validated_request_data['public'], request.user)
-        except ValidationError:
+        except CoreValidationError:
             return Response(data={'resource_id': pk}, status=status.HTTP_403_FORBIDDEN)
 
         return Response(data={'resource_id': pk}, status=status.HTTP_200_OK)


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
This fixed the regression bug as detailed in issue #2865. The positive test case: create a composite or generic resource without uploading or adding any files. Edit the resource to give it an abstract and keyword, now the prompt reminds you that you have to provide content files in order to make it public or publish it, and the public button is grayed out so you cannot make this resource public. Try to add a file to this resource, now you can click public button to make this resource public. @aphelionz I will assign you to code review. I think this needs to go into at least 1.16 release since it is regression and it will not look good to have a public resource without any content, let alone publishing such a resource.