### PR TITLE
[#2899] allow box coverage for file metadta

### DIFF
--- a/hs_rest_api/resources/file_metadata.py
+++ b/hs_rest_api/resources/file_metadata.py
@@ -141,14 +141,16 @@ class FileMetaDataRetrieveUpdateDestroy(generics.RetrieveUpdateDestroyAPIView):
 
             spatial_coverage = file_serializer.data.pop("spatial_coverage", None)
             if spatial_coverage is not None:
+                # defaulting to point if not provided for backwards compatibility
+                type = spatial_coverage["type"] if "type" in spatial_coverage else "point"
                 if resource_file.metadata.spatial_coverage is not None:
                     cov_id = resource_file.metadata.spatial_coverage.id
                     resource_file.metadata.update_element('coverage',
                                                           cov_id,
-                                                          type='point',
+                                                          type=type,
                                                           value=spatial_coverage)
                 elif resource_file.metadata.spatial_coverage is None:
-                    resource_file.metadata.create_element('coverage', type="point",
+                    resource_file.metadata.create_element('coverage', type=type,
                                                           value=spatial_coverage)
 
             temporal_coverage = file_serializer.data.pop("temporal_coverage", None)


### PR DESCRIPTION
This covers a use case that is needed by a hydroshare user to write file specific box spatial coverage.  I talked to Dave about getting this into 1.15.5, which he approved.  The user needs the functionality for a demo at the end of the month.

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Write file specific metadata using `/resource/(?P<pk>[0-9a-f-]+)/files/(?P<file_id>[0-9]+)/metadata/$`
