### PR TITLE
2955 inform accurately the status of resource

### DIFF
--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -691,10 +691,13 @@ function metadata_update_ajax_submit(form_id){
                     if (json_response.metadata_status !== $('#metadata-status').text()) {
                         $('#metadata-status').text(json_response.metadata_status);
                         if (json_response.metadata_status.toLowerCase().indexOf("insufficient") == -1) {
-                            if(resourceType != 'Web App Resource')
-                                promptMessage = "This resource can be published or made public.";
+                            if(resourceType != 'Web App Resource' && resourceType != 'Collection Resource' )
+                                promptMessage = "All required fields are completed. The resource can now be made discoverable " + 
+                                                "or public. To permanently publish the resource and obtain a DOI, the resource " +
+                                                "must first be made public.";
                             else
-                                promptMessage = "This resource can be made public.";
+                                promptMessage = "All required fields are completed. It can now be made discoverable " + 
+                                                "or public.";
                             if (!metadata_update_ajax_submit.resourceSatusDisplayed){
                                 metadata_update_ajax_submit.resourceSatusDisplayed = true;
                                 if (json_response.hasOwnProperty('res_public_status')) {


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Have a resource without a keyword. Everything else are setup including abstract etc.
2. Going to edit mode, add a new keyword. 
3. Right after the keywrod is added, a pop up message has the accurate saying.
