### PR TITLE
[#3012] - handle display of zero in spatial coverage

### DIFF
--- a/hs_core/forms.py
+++ b/hs_core/forms.py
@@ -1007,12 +1007,12 @@ class CoverageSpatialForm(forms.Form):
         if spatial_coverage_type == 'point':
             north = temp_cleaned_data.get('north', None)
             east = temp_cleaned_data.get('east', None)
-            if not north:
+            if not north and north != 0:
                 self._errors['north'] = ["Data for north is missing"]
                 is_form_errors = True
                 del self.cleaned_data['north']
 
-            if not east:
+            if not east and east != 0:
                 self._errors['east'] = ["Data for east is missing"]
                 is_form_errors = True
                 del self.cleaned_data['east']

--- a/hs_core/tests/api/native/test_core_metadata.py
+++ b/hs_core/tests/api/native/test_core_metadata.py
@@ -538,7 +538,7 @@ class TestCoreMetadata(MockIRODSTestCaseMixin, TestCase):
             resource.create_metadata_element(self.res.short_id,'coverage', type='point', value=value_dict)
 
         # now create coverage of type 'point' with all valid data
-        value_dict = {'east': '120.45678', 'north': '80.60', 'units': 'decimal deg'}
+        value_dict = {'east': '120.45678', 'north': '0.0', 'units': 'decimal deg'}
         resource.create_metadata_element(self.res.short_id,'coverage', type='point', value=value_dict)
         self.assertEqual(self.res.metadata.coverages.filter(type='point').count(), 1)
 

--- a/theme/static/js/coverageMap.js
+++ b/theme/static/js/coverageMap.js
@@ -108,7 +108,7 @@ function drawInitialShape() {
                 }
             }
 
-            if (!bounds.north || !bounds.south || !bounds.east || !bounds.west) {
+            if (bounds.north === null || bounds.south === null || bounds.east === null || bounds.west === null) {
                 return;
             }
             // Define the rectangle and set its editable property to true.

--- a/theme/templates/resource-landing-page/coverage.html
+++ b/theme/templates/resource-landing-page/coverage.html
@@ -46,7 +46,7 @@
                                 {% endif %}
                             </div>
 
-                            {% if spatial_coverage.north or spatial_coverage.northlimit %}
+                            {% if spatial_coverage.north is not None or spatial_coverage.northlimit is not None %}
                                 <div class="row coordinates-list-container">
                                     {% if spatial_coverage.type == 'point' %}
                                         {% if spatial_coverage.east %}
@@ -60,22 +60,22 @@
                                             </div>
                                         {% endif %}
                                     {% else %}
-                                        {% if spatial_coverage.northlimit %}
+                                        {% if spatial_coverage.northlimit is not None %}
                                             <div class="col-xs-12 col-sm-6"><strong>North Latitude</strong>
                                                 <div id="cov_northlimit">{{ spatial_coverage.northlimit|floatformat:"4" }}°</div>
                                             </div>
                                         {% endif %}
-                                        {% if spatial_coverage.eastlimit %}
+                                        {% if spatial_coverage.eastlimit is not None %}
                                             <div class="col-xs-12 col-sm-6"><strong>East Longitude</strong>
                                                 <div id="cov_eastlimit">{{ spatial_coverage.eastlimit|floatformat:"4" }}°</div>
                                             </div>
                                         {% endif %}
-                                        {% if spatial_coverage.southlimit %}
+                                        {% if spatial_coverage.southlimit is not None %}
                                             <div class="col-xs-12 col-sm-6"><strong>South Latitude</strong>
                                                 <div id="cov_southlimit">{{ spatial_coverage.southlimit|floatformat:"4" }}°</div>
                                             </div>
                                         {% endif %}
-                                        {% if spatial_coverage.westlimit %}
+                                        {% if spatial_coverage.westlimit is not None %}
                                             <div class="col-xs-12 col-sm-6"><strong>West Longitude</strong>
                                                 <div id="cov_westlimit">{{ spatial_coverage.westlimit|floatformat:"4" }}°</div>
                                             </div>

--- a/theme/templates/resource-landing-page/coverage.html
+++ b/theme/templates/resource-landing-page/coverage.html
@@ -49,12 +49,12 @@
                             {% if spatial_coverage.north is not None or spatial_coverage.northlimit is not None %}
                                 <div class="row coordinates-list-container">
                                     {% if spatial_coverage.type == 'point' %}
-                                        {% if spatial_coverage.east %}
+                                        {% if spatial_coverage.east is not None %}
                                             <div class="col-xs-12 col-sm-6"><strong>Longitude</strong>
                                                 <div id="cov_east">{{ spatial_coverage.east|floatformat:"4" }}°</div>
                                             </div>
                                         {% endif %}
-                                        {% if spatial_coverage.north %}
+                                        {% if spatial_coverage.north is not None %}
                                             <div class="col-xs-12 col-sm-6"><strong>Latitude</strong>
                                                 <div id="cov_north">{{ spatial_coverage.north|floatformat:"4" }}°</div>
                                             </div>


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. update a spatial coverage limit to zero.  View the resource in view mode and verify the bounds box shows up correctly
