### PR TITLE
[#2808] Add conditionals for methods that only need to run in edit mode

### DIFF
--- a/theme/static/js/composite-resource.js
+++ b/theme/static/js/composite-resource.js
@@ -3,6 +3,7 @@
  */
 
 $(document).ready(function () {
+    const mode = $("#hs-file-browser").attr("data-mode");
 
     // Submit for resource spatial coverage update
     $("#btn-update-resource-spatial-coverage").click(function () {
@@ -16,12 +17,14 @@ $(document).ready(function () {
         resource_coverage_update_ajax_submit(resourceID, 'temporal');
     });
 
-    bindResourceSpatialDeleteOption();
-    bindResourceTemporalDeleteOption();
-    // show/hide spatial coverage delete option
-    setResourceSpatialCoverageDeleteOption();
-    // show/hide temporal coverage delete option
-    setResourceTemporalCoverageDeleteOption();
+    if (mode == "edit") {
+        bindResourceSpatialDeleteOption();
+        bindResourceTemporalDeleteOption();
+        // show/hide spatial coverage delete option
+        setResourceSpatialCoverageDeleteOption();
+        // show/hide temporal coverage delete option
+        setResourceTemporalCoverageDeleteOption();
+    }
 });
 
 function bindResourceSpatialDeleteOption() {

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -1114,6 +1114,8 @@ function get_irods_folder_struct_ajax_submit(res_id, store_path) {
             var files = result.files;
             var folders = result.folders;
             var can_be_public = result.can_be_public;
+            const mode = $("#hs-file-browser").attr("data-mode");
+
             $('#fb-files-container').empty();
             if (files.length > 0) {
                 $.each(files, function(i, v) {
@@ -1168,7 +1170,7 @@ function get_irods_folder_struct_ajax_submit(res_id, store_path) {
                 var spatialCoverage = result.spatial_coverage;
                 updateResourceSpatialCoverage(spatialCoverage);
             }
-            if (result.hasOwnProperty('temporal_coverage')){
+            if (mode == "edit" && result.hasOwnProperty('temporal_coverage')){
                 var temporalCoverage = result.temporal_coverage;
                 updateResourceTemporalCoverage(temporalCoverage);
             }

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -1166,7 +1166,7 @@ function get_irods_folder_struct_ajax_submit(res_id, store_path) {
             $(".selection-menu").hide();
             $("#flag-uploading").remove();
             $("#fb-files-container, #fb-files-container").css("cursor", "default");
-            if (result.hasOwnProperty('spatial_coverage')){
+            if (mode == "edit" && result.hasOwnProperty('spatial_coverage')){
                 var spatialCoverage = result.spatial_coverage;
                 updateResourceSpatialCoverage(spatialCoverage);
             }


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]

A method to update temporal coverage in resource landing page meant to run only in edit mode was causing the script to halt in view mode since it fails to get the DOM elements it needs. Fixed by adding conditionals so it only runs in edit mode.