### PR TITLE
Migrate generic resources to composite resource

### DIFF
--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -83,9 +83,7 @@ def create_bag_files(resource):
     # create resourcemetadata.xml in local directory and upload it to iRODS
     from_file_name = os.path.join(temp_path, 'resourcemetadata.xml')
     with open(from_file_name, 'w') as out:
-        # resources that don't support file types this would write only resource level metadata
-        # resource types that support file types this would write resource level metadata
-        # as well as file type metadata
+        # write resource level metadata
         out.write(resource.get_metadata_xml())
     to_file_name = os.path.join(resource.root_path, 'data', 'resourcemetadata.xml')
     istorage.saveFile(from_file_name, to_file_name, True)

--- a/hs_core/management/commands/migrate_generic_resources.py
+++ b/hs_core/management/commands/migrate_generic_resources.py
@@ -1,0 +1,46 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from hs_core.models import GenericResource
+from hs_core.hydroshare import current_site_url, set_dirty_bag_flag
+
+
+class Command(BaseCommand):
+    help = "Convert all generic resources to composite resource"
+
+    def handle(self, *args, **options):
+        logger = logging.getLogger(__name__)
+        resource_counter = 0
+        to_resource_type = 'CompositeResource'
+        msg = "THERE ARE CURRENTLY {} GENERIC RESOURCES PRIOR TO CONVERSION.".format(
+            GenericResource.objects.all().count())
+        logger.info(msg)
+        print(">> {}".format(msg))
+        for gen_res in GenericResource.objects.all():
+            # change the resource_type
+            gen_res.resource_type = to_resource_type
+            gen_res.content_model = to_resource_type.lower()
+            gen_res.save()
+
+            # get the converted resource object - CompositeResource
+            comp_res = gen_res.get_content_model()
+
+            # update url attribute of the metadata 'type' element
+            type_element = comp_res.metadata.type
+            type_element.url = '{0}/terms/{1}'.format(current_site_url(), to_resource_type)
+            type_element.save()
+
+            # set resource to dirty so that resource level xml files (resource map and
+            # metadata xml files) will be generated as part of next bag download
+            set_dirty_bag_flag(comp_res)
+            resource_counter += 1
+
+        msg = "{} GENERIC RESOURCES WERE CONVERTED TO COMPOSITE RESOURCE.".format(
+            resource_counter)
+        logger.info(msg)
+        print(">> {}".format(msg))
+        msg = "THERE ARE CURRENTLY {} GENERIC RESOURCES AFTER CONVERSION.".format(
+            GenericResource.objects.all().count())
+        logger.info(msg)
+        print(">> {}".format(msg))


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Testing locally:
    - Deploy the branch '3100-migrate-generic-resources'. 
    - Edit the 'hs_core/templates/pages/create-resource.html' file to enable creating generic resource.
    - Create couple of generic resource with/without file uploads using the local hydroshare website. Edit any metadata for each of these resources.
    - Run the management command 'migrate_generic_resources'. Output of the command should indicate the number of generic resources that were converted to composite resources and that there are 0 number of generic resources after the conversion. 
    - Click 'MY  RESOURCES' link on the webpage. You should see all resources are of type composite resource.
    - Go to the landing page of one of the composite resources. You should see all the resource metadata that you entered exist.
    - Download the bag for one of the composite resources. Verify the contents of the bag file that the expected resources files are there. Check that the 'resourcemap.xml' and 'resourcemetadata.xml' files do not contain the word 'GenericResource'.
2. Testing with real generic resources (**this test is essential for approving this PR**):
    - Deploy branch '3100-migrate-generic-resources' to deployment environment similar to 'beta' deployment where it would have access to a copy of real hydroshare resources.
    - Make a note of 'title' and 'resource id' of few generic resources so that you will able to check those resources after they are converted to composite resource.
    - Run the management command 'migrate_generic_resources'. Output of the command should indicate the number of generic resources that were converted to composite resources and that there are 0 number of generic resources after the conversion. 
   - Use the web interface to check that there are no generic resources. Use your note to verify that those resources have been converted to composite resource. Check that you are able to download the bag file for one of these converted resources. Verify the contents of the bag file. For one of these converted resource try to create an appropriate aggregation using the existing resource file(s). Try few other aggregation related functionalities for one of these converted resource.