### PR TITLE
[#2765] Fix for text input auto select on Zip Folder dialog

### DIFF
--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -1402,8 +1402,13 @@ $(document).ready(function () {
         $('#file_redirect_url').prop('href', ref_url);
     });
 
+    $("[data-fb-action='zip']").click(function() {
+         var folderName =$("#fb-files-container li.ui-selected").children(".fb-file-name").text();
+        $("#txtZipName").val(folderName);
+    });
+
     $('#zip-folder-dialog').on('shown.bs.modal', function () {
-        $('#txtFolderName').focus();
+        $('#txtZipName').focus();
 
         // Select the file name by default
         var input = document.getElementById("txtZipName");
@@ -1426,7 +1431,6 @@ $(document).ready(function () {
 
     $('#edit-referenced-url-dialog').on('shown.bs.modal', function () {
         var file = $("#fb-files-container li.ui-selected");
-        var fileName = file.children(".fb-file-name").text();
         var ref_url = file.attr("data-ref-url");
         $('#txtNewRefURL').val(ref_url);
         $('#txtNewRefURL').focus();
@@ -1915,11 +1919,6 @@ $(document).ready(function () {
                 refreshFileBrowser();
             });
         }
-    });
-
-    $("#btn-zip").click(function() {
-        var folderName =$("#fb-files-container li.ui-selected").children(".fb-file-name").text();
-        $("#txtZipName").val(folderName);
     });
 
     // Unzip method


### PR DESCRIPTION
Fixes an issue where the text input when trying to zip a folder was not automatically selected.

![image](https://user-images.githubusercontent.com/2448568/52009459-43a09a00-2490-11e9-9505-2f4a4525a2f1.png)


<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
