### PR TITLE
[#3130] Make metadata alert persist until all required metadata is filled in

### DIFF
--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1526,7 +1526,7 @@ body > .main-container {
 	cursor: default;
 }
 
-#success-alert, #error-alert {
+#success-alert, #error-alert, .custom-alert {
     position: fixed;
     z-index: 999;
     margin-right: auto;
@@ -1534,11 +1534,6 @@ body > .main-container {
     left: 50%;
     margin-left: -25%;
     top: 60px;
-}
-
-.custom-alert {
-	position: fixed;
-	z-index: 2;
 }
 
 .alert-dismissible {

--- a/theme/static/js/generic-resource.js
+++ b/theme/static/js/generic-resource.js
@@ -183,8 +183,7 @@ function customAlert(alertTitle, alertMessage, alertType, duration) {
     alertType = alertType || "success";
     var el = document.createElement("div");
     var top = 200;
-    var left = ($(window).width() / 2) - 150;
-    var style = "top:" + top + "px;left:" + left + "px";
+    var style = "top:" + top + "px";
     var alertTypes = {
         success: {class: "alert alert-success", icon: "fa fa-check"},
         error: {class: "alert alert-danger", icon: "fa fa-exclamation-triangle"},
@@ -200,7 +199,7 @@ function customAlert(alertTitle, alertMessage, alertType, duration) {
             $(this).remove();
         });
     }, duration);
-    document.body.appendChild(el);
+    $(el).appendTo("body > .main-container > .container");
     $(el).hide().fadeIn(400);
 }
 

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -639,12 +639,12 @@ function share_resource_ajax_submit(form_id) {
 }
 
 function metadata_update_ajax_submit(form_id){
-    $alert_success = '<div class="alert alert-success" id="success-alert"> \
+    let $alert_success = '<div class="alert alert-success" id="success-alert"> \
         <button type="button" class="close" data-dismiss="alert">x</button> \
         <strong>Success! </strong> \
         Metadata updated.\
     </div>';
-    $alert_error = '<div class="alert alert-danger" id="error-alert"> \
+    let $alert_error = '<div class="alert alert-danger" id="error-alert"> \
         <button type="button" class="close" data-dismiss="alert">x</button> \
         <strong>Error! </strong> \
         Metadata failed to update.\
@@ -655,7 +655,7 @@ function metadata_update_ajax_submit(form_id){
     }
     var flagAsync = (form_id == "id-subject" ? false : true);   // Run keyword related changes synchronously to prevent integrity error
     var resourceType = $("#resource-type").val();
-    $form = $('#' + form_id);
+    let $form = $('#' + form_id);
     var datastring = $form.serialize();
 
     // Disable button while request is being made
@@ -844,13 +844,13 @@ function metadata_update_ajax_submit(form_id){
                         }
                     }
                 }
-                $('body > .container').append($alert_success);
+                $('body > .main-container > .container').append($alert_success);
                 $('#error-alert').each(function(){
                     this.remove();
                 });
-                $(".alert-success").fadeTo(2000, 500).fadeOut(1000, function(){
+                $("#success-alert").fadeTo(2000, 500).fadeOut(1000, function(){
                     $(document).trigger("submit-success");
-                    $(".alert-success").alert('close');
+                    $("#success-alert").alert('close');
                 });
             }
             else{
@@ -888,7 +888,7 @@ function makeTimeSeriesMetaDataElementFormReadOnly(form_id, element_id){
 }
 
 function set_file_type_ajax_submit(url, folder_path) {
-    var $alert_success = '<div class="alert alert-success" id="error-alert"> \
+    var $alert_success = '<div class="alert alert-success" id="success-alert"> \
         <button type="button" class="close" data-dismiss="alert">x</button> \
         <strong>Success! </strong> \
         Selected content type creation was successful.\
@@ -906,8 +906,8 @@ function set_file_type_ajax_submit(url, folder_path) {
         success: function (result) {
             waitDialog.dialog("close");
             $("#fb-inner-controls").before($alert_success);
-            $(".alert-success").fadeTo(2000, 500).slideUp(1000, function(){
-                $(".alert-success").alert('close');
+            $("#success-alert").fadeTo(2000, 500).slideUp(1000, function(){
+                $("#success-alert").alert('close');
             });
         },
         error: function (xhr, textStatus, errorThrown) {
@@ -920,7 +920,7 @@ function set_file_type_ajax_submit(url, folder_path) {
 }
 
 function remove_aggregation_ajax_submit(url) {
-    var $alert_success = '<div class="alert alert-success" id="error-alert"> \
+    var $alert_success = '<div class="alert alert-success" id="success-alert"> \
         <button type="button" class="close" data-dismiss="alert">x</button> \
         <strong>Success! </strong> \
         Content type was removed successfully.\
@@ -936,8 +936,8 @@ function remove_aggregation_ajax_submit(url) {
         success: function (result) {
             waitDialog.dialog("close");
             $("#fb-inner-controls").before($alert_success);
-            $(".alert-success").fadeTo(2000, 500).slideUp(1000, function(){
-                $(".alert-success").alert('close');
+            $("#success-alert").fadeTo(2000, 500).slideUp(1000, function () {
+                $("#success-alert").alert('close');
             });
         },
         error: function (xhr, textStatus, errorThrown) {
@@ -1048,7 +1048,7 @@ function filetype_keyword_delete_ajax_submit(keyword, tag) {
 }
 
 function update_netcdf_file_ajax_submit() {
-    var $alert_success = '<div class="alert alert-success" id="error-alert"> \
+    var $alert_success = '<div class="alert alert-success" id="success-alert"> \
         <button type="button" class="close" data-dismiss="alert">x</button> \
         <strong>Success! </strong> \
         File update was successful.\
@@ -1065,8 +1065,8 @@ function update_netcdf_file_ajax_submit() {
                 $("#div-netcdf-file-update").hide();
                 $alert_success = $alert_success.replace("File update was successful.", json_response.message);
                 $("#fb-inner-controls").before($alert_success);
-                $(".alert-success").fadeTo(2000, 500).slideUp(1000, function(){
-                    $(".alert-success").alert('close');
+                $("#success-alert").fadeTo(2000, 500).slideUp(1000, function () {
+                    $("#success-alert").alert('close');
                 });
                 // refetch file metadata to show the updated header file info
                  showFileTypeMetadata(false, "");
@@ -1079,7 +1079,7 @@ function update_netcdf_file_ajax_submit() {
 }
 
 function update_sqlite_file_ajax_submit() {
-    var $alert_success = '<div class="alert alert-success" id="error-alert"> \
+    var $alert_success = '<div class="alert alert-success" id="success-alert"> \
         <button type="button" class="close" data-dismiss="alert">x</button> \
         <strong>Success! </strong> \
         File update was successful.\
@@ -1096,8 +1096,8 @@ function update_sqlite_file_ajax_submit() {
                 $("#div-sqlite-file-update").hide();
                 $alert_success = $alert_success.replace("File update was successful.", json_response.message);
                 $("#fb-inner-controls").before($alert_success);
-                $(".alert-success").fadeTo(2000, 500).slideUp(1000, function(){
-                    $(".alert-success").alert('close');
+                $("#success-alert").fadeTo(2000, 500).slideUp(1000, function () {
+                    $("#success-alert").alert('close');
                 });
                 // refetch file metadata to show the updated header file info
                 showFileTypeMetadata(false, "");


### PR DESCRIPTION
- Makes metadata alert persist until all required metadata is filled in
- Also adjusts positioning to correctly center the alert window.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
