### PR TITLE
[#3138] Correctly trigger removing self access in Manage Access panel

### DIFF
--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -364,7 +364,7 @@ function promptSelfRemovingAccess(form_id){
     var url = $form.attr('action');
     // check if we are unsharing a user or a group
     var isUserUnsharing = false;
-    if(url.split("/")[4] === "unshare-resource-with-user"){
+    if (url.indexOf("unshare-resource-with-user") > 0) {
         isUserUnsharing = true;
     }
     if(!isUserUnsharing){
@@ -407,7 +407,7 @@ function promptSelfRemovingAccess(form_id){
                 .addClass("btn btn-default");
 
             $(this).closest(".ui-dialog")
-                .find(".ui-dialog-buttonset button:nth-child(2)") // the first button
+                .find(".ui-dialog-buttonset button:nth-child(2)") // the second button
                 .addClass("btn btn-danger");
         }
     });

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -364,7 +364,7 @@ function promptSelfRemovingAccess(form_id){
     var url = $form.attr('action');
     // check if we are unsharing a user or a group
     var isUserUnsharing = false;
-    if(url.indexOf("unshare-resource-with-user") > 0){
+    if(url.split("/")[4] === "unshare-resource-with-user"){
         isUserUnsharing = true;
     }
     if(!isUserUnsharing){
@@ -379,7 +379,7 @@ function promptSelfRemovingAccess(form_id){
     }
 
     // close the manage access panel (modal)
-    $("#manage-access .btn-primary").click();
+    $("#manage-access ").modal("hide");
 
     // display remove access confirmation dialog
     $("#dialog-confirm-delete-self-access").dialog({

--- a/theme/templates/resource-landing-page/quota.html
+++ b/theme/templates/resource-landing-page/quota.html
@@ -43,7 +43,7 @@
 
                     <button type="button" class="btn btn-default" data-toggle="collapse"
                             data-target="#form-quota-holder">Cancel</button>
-                    <button type="submit" class="btn btn-primary btn-change-quota-holder"
+                    <button type="submit" class="btn btn-primary btn-change-quota-holder btn-disable-after-valid"
                     style="margin-left: 5px;">Save Changes</button>
                 </form>
             {% endif %}


### PR DESCRIPTION
This issue was caused by an error in a jquery selector introduced recently with the UI changes. 

Also disables the Quota change button after a request is triggered to prevent duplicate requests.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
