### PR TITLE
[#3045] - turn off hsws by default in settings.py

### DIFF
--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -719,3 +719,5 @@ SWAGGER_SETTINGS = {
 
 # detect test mode to turn off some features
 TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'
+
+HSWS_ACTIVATED = False


### PR DESCRIPTION
Just setting a default value of off to hsws so it doesn't break hydroshare if the setting is missing in local_settings.py