### PR TITLE
[#3264] Update logic to handle file browser's navigation state

### DIFF
--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -1114,13 +1114,11 @@ function onOpenFolder() {
 }
 
 function updateNavigationState() {
-    $("#fb-move-back").toggleClass("disabled", pathLogIndex == 1); // we are at the root folder
+    $("#fb-move-back").toggleClass("disabled", pathLogIndex == 0); // we are at the root folder
     $("#fb-move-forward").toggleClass("disabled", pathLogIndex >= pathLog.length - 1);
 
-    var upPath = $("#hs-file-browser").attr("data-current-path");
-    upPath = upPath.substr(0, upPath.lastIndexOf("/"));
-
-    $("#fb-move-up").toggleClass("disabled", upPath === "data");
+    let currentPath = $("#hs-file-browser").attr("data-current-path");
+    $("#fb-move-up").toggleClass("disabled", currentPath === "");    // The root path is an empty string
 }
 
 // Reload the current folder structure
@@ -1686,9 +1684,9 @@ $(document).ready(function () {
 
     // Move back
     $("#fb-move-back").click(function () {
-        if (pathLogIndex > 1) {
+        if (pathLogIndex > 0) {
             pathLogIndex--;
-            if (pathLogIndex == 1) {
+            if (pathLogIndex == 0) {
                 // we are at the root folder
                 $("#fb-move-back").addClass("disabled");
             }


### PR DESCRIPTION
This PR fixes the logic of navigation buttons in the resource landing page file browser. The error was caused by an outdated value predating work done recently which changed how we construct the file paths in the front end.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource.
2. Add various folders to the resource (including nested ones).
3. Navigate around in the file browser and confirm that navigation works as expected.
