### PR TITLE
disable isVersionOf editing

### DIFF
--- a/theme/templates/resource-landing-page/references.html
+++ b/theme/templates/resource-landing-page/references.html
@@ -164,15 +164,17 @@ Click this button to add a relationship to another resource, external website, o
                             {% endif %}
                         </td>
                         <td class="dataset-details">{{ relation.value|urlize }}</td>
-                        <td style="min-width: 120px;">
-                            <span data-toggle="modal" data-placement="auto" title="Edit"
-                               class="glyphicon glyphicon-pencil icon-blue icon-button table-icon"
-                               data-target="#edit-relation-dialog_{{ relation.id }}">
-                            </span>
-                            <span data-toggle="modal" data-placement="auto" title="Remove"
-                               class="glyphicon glyphicon-trash table-icon icon-button btn-remove"
-                               data-target="#delete-relation-element-dialog{{ relation.id }}"></span>
-                        </td>
+                        {% if relation.type != "isVersionOf" %}
+                            <td style="min-width: 120px;">
+                                <span data-toggle="modal" data-placement="auto" title="Edit"
+                                   class="glyphicon glyphicon-pencil icon-blue icon-button table-icon"
+                                   data-target="#edit-relation-dialog_{{ relation.id }}">
+                                </span>
+                                <span data-toggle="modal" data-placement="auto" title="Remove"
+                                   class="glyphicon glyphicon-trash table-icon icon-button btn-remove"
+                                   data-target="#delete-relation-element-dialog{{ relation.id }}"></span>
+                            </td>
+                        {% endif %}
                     </tr>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
This PR disables users from editing system-generated ```isVersionOf``` relation type from resource landing page to fix issue #3276 . I am trying to get this PR into RC 1.21 since without it, users would be able to manually edit this which would result in orphaned resources as detailed in issue #3276, which would be hard to track and fix, so it'd be good to prevent this in the first place.
