### PR TITLE
3292 colon in discover

### DIFF
--- a/hs_core/discovery_parser.py
+++ b/hs_core/discovery_parser.py
@@ -344,6 +344,6 @@ class ParseSQ(object):
                 self.handle_normal_query()
             elif self.query and self.query[0] == "(":
                 self.handle_brackets()
-            elif self.query:
-                self.query = self.query[1:]
+            else:
+                self.handle_normal_query()
         return self.sq

--- a/hs_core/discovery_parser.py
+++ b/hs_core/discovery_parser.py
@@ -189,7 +189,6 @@ class ParseSQ(object):
 
     # Paterns without more precise control of __exact keyword
     Pattern_Field_Query = re.compile(r"^(\w+)(:|[<>]=?)", re.U)
-    Pattern_Field_Query_Qualified = re.compile(r"^(\w+)(:|[<>]=?)(.)", re.U)
     Pattern_Normal_Query = re.compile(r"^(\w+)\s*", re.U)
     Pattern_Operator = re.compile(r"^(AND|OR|NOT|\-|\+)\s*", re.U)
     Pattern_Quoted_Text = re.compile(r"^\"([^\"]*)\"\s*", re.U)
@@ -216,21 +215,15 @@ class ParseSQ(object):
         return new_sq
 
     def handle_field_query(self):
-        mat = re.search(self.Pattern_Field_Query_Qualified, self.query)
-        if not mat:  # no text following field
-            print("detected normal query {}".format(self.query))
-            self.handle_normal_query()  # handle this as a keyword
-            return
-        search_field = mat.group(1)
+        mat = re.search(self.Pattern_Field_Query, self.query)
+        search_field = mat.group(1).lower()
         search_operator = mat.group(2)
-        next_character = mat.group(3)
-        if next_character == ' ': 
+        if search_field not in self.KNOWN_FIELDS:
             self.handle_normal_query()
             return
-        if search_field not in self.KNOWN_FIELDS:
-            raise FieldNotRecognizedError(
-                "Field name '{}' is not recognized."
-                .format(search_field))
+            # raise FieldNotRecognizedError(
+            #     "Field name '{}' is not recognized."
+            #     .format(search_field))
         if search_field in self.REPLACE_BY:
             search_field = self.REPLACE_BY[search_field]
 

--- a/hs_core/discovery_parser.py
+++ b/hs_core/discovery_parser.py
@@ -219,9 +219,8 @@ class ParseSQ(object):
         search_field = mat.group(1)
         search_operator = mat.group(2)
         if search_field not in self.KNOWN_FIELDS:
-            raise FieldNotRecognizedError(
-                "Field delimiter '{}' is not recognized."
-                .format(search_field))
+            self.handle_normal_query()  # treat as a keyword with colon intact
+
         if search_field in self.REPLACE_BY:
             search_field = self.REPLACE_BY[search_field]
 

--- a/hs_core/discovery_parser.py
+++ b/hs_core/discovery_parser.py
@@ -78,8 +78,9 @@ class ParseSQ(object):
     OP = {
         'AND': operator.and_,
         'OR': operator.or_,
-        'NOT': operator.inv,  # alias '-' removed 4/5/2019
-        # alias '+' (for include) removed 4/5/2019
+        'NOT': operator.inv,
+        # aliases '+' (for include) and '-' (for NOT) removed 4/5/2019
+        # due to potential collision with valid titles for resources.
     }
 
     # Translation table for inequalities
@@ -189,7 +190,8 @@ class ParseSQ(object):
     # Paterns without more precise control of __exact keyword
     Pattern_Field_Query = re.compile(r"^(\w+)(:|[<>]=?)", re.U)
     Pattern_Normal_Query = re.compile(r"^(\w+)\s*", re.U)
-    Pattern_Operator = re.compile(r"^(AND|OR|NOT)\s*", re.U)  # '-', '+' removed 4/5/2019
+    Pattern_Operator = re.compile(r"^(AND|OR|NOT)\s*", re.U)
+    # '-', '+' removed 4/5/2019 to avoid potential collision with valid resource titles
     Pattern_Quoted_Text = re.compile(r"^\"([^\"]*)\"\s*", re.U)
     Pattern_Unquoted_Text = re.compile(r"^(\w*)\s*", re.U)
 

--- a/hs_core/discovery_parser.py
+++ b/hs_core/discovery_parser.py
@@ -78,9 +78,8 @@ class ParseSQ(object):
     OP = {
         'AND': operator.and_,
         'OR': operator.or_,
-        'NOT': operator.inv,
-        '+': operator.and_,
-        '-': operator.inv,
+        'NOT': operator.inv,  # alias '-' removed 4/5/2019
+        # alias '+' (for include) removed 4/5/2019
     }
 
     # Translation table for inequalities
@@ -190,7 +189,7 @@ class ParseSQ(object):
     # Paterns without more precise control of __exact keyword
     Pattern_Field_Query = re.compile(r"^(\w+)(:|[<>]=?)", re.U)
     Pattern_Normal_Query = re.compile(r"^(\w+)\s*", re.U)
-    Pattern_Operator = re.compile(r"^(AND|OR|NOT|\-|\+)\s*", re.U)
+    Pattern_Operator = re.compile(r"^(AND|OR|NOT)\s*", re.U)  # '-', '+' removed 4/5/2019
     Pattern_Quoted_Text = re.compile(r"^\"([^\"]*)\"\s*", re.U)
     Pattern_Unquoted_Text = re.compile(r"^(\w*)\s*", re.U)
 
@@ -203,11 +202,11 @@ class ParseSQ(object):
 
     @current.setter
     def current(self, current):
-        self._prev = self._current if current in ['-', 'NOT'] else None
+        self._prev = self._current if current in ['NOT'] else None
         self._current = current
 
     def apply_operand(self, new_sq):
-        if self.current in ['-', 'NOT']:
+        if self.current in ['NOT']:
             new_sq = self.OP[self.current](new_sq)
             self.current = self._prev
         if self.sq:

--- a/hs_core/tests/api/native/test_discovery_parser.py
+++ b/hs_core/tests/api/native/test_discovery_parser.py
@@ -10,7 +10,6 @@ Test common search query syntax.
 from unittest import TestCase
 from haystack.query import SQ
 from hs_core.discovery_parser import ParseSQ, \
-    FieldNotRecognizedError, \
     MalformedDateError, \
     InequalityNotAllowedError, \
     MatchingBracketsNotFoundError
@@ -77,14 +76,14 @@ class SimpleTest(TestCase):
     def test_operators(self):
         testcase = {
             "note": str(SQ(content="note")),
-            "need -note": str(SQ(content="need") & ~SQ(content="note")),
-            "need +note": str(SQ(content="need") & SQ(content="note")),
-            "need+note": str(SQ(content="need+note")),
-            "iphone AND NOT subject:10": str(SQ(content="iphone") & ~SQ(
-                subject="10")),
+            # removed '-' 4/5/2019 "need -note": str(SQ(content="need") & ~SQ(content="note")),
+            # removed '+' 4/5/2019 "need +note": str(SQ(content="need") & SQ(content="note")),
+            # removed '+' 4/5/2019 "need+note": str(SQ(content="need+note")),
+            "iphone AND NOT subject:10": str(SQ(content="iphone") & ~SQ(subject="10")),
+            "iphone OR NOT subject:10": str(SQ(content="iphone") | ~SQ(subject="10")),
             "NOT subject:10": str(~SQ(subject="10")),
             "subject:10": str(SQ(subject="10")),
-            "-subject:10": str(~SQ(subject="10")),
+            # removed 4/5/2019 "-subject:10": str(~SQ(subject="10")),
             "subject:-10": str(SQ(subject="-10")),
         }
         parser = ParseSQ()
@@ -143,7 +142,7 @@ class SimpleTest(TestCase):
 
     def test_exceptions(self):
         testcase = {
-            "foo:bar": FieldNotRecognizedError,
+            # removed 4/5/2019 "foo:bar": FieldNotRecognizedError,
             "created:20170": MalformedDateError,
             "created:2017-30": MalformedDateError,
             "created:2017-12-64": MalformedDateError,

--- a/hs_core/tests/api/native/test_discovery_parser.py
+++ b/hs_core/tests/api/native/test_discovery_parser.py
@@ -77,18 +77,20 @@ class SimpleTest(TestCase):
         testcase = {
             # removed '+', '-' syntaxes 4/5/2019.
             # test cases modified accordingly.
-            "note": str(SQ(content="note")),
-            "need -note": str(SQ(content="need") & SQ(content="-note")),
-            "need +note": str(SQ(content="need") & SQ(content="+note")),
-            "need+note": str(SQ(content="need+note")),
-            "iphone AND NOT subject:10": str(SQ(content="iphone") & ~SQ(subject="10")),
-            "iphone OR NOT subject:10": str(SQ(content="iphone") | ~SQ(subject="10")),
-            "NOT subject:10": str(~SQ(subject="10")),
-            "subject:10": str(SQ(subject="10")),
-            "-subject:10": str(SQ(content='-') & SQ(subject="10")),
-            "subject:-10": str(SQ(subject="-10")),
+            'note': str(SQ(content='note')),
+            '"note"': str(SQ(content__exact='note')),
+            'need -note': str(SQ(content='need') & SQ(content='-note')),
+            '"need -note"': str(SQ(content__exact='need -note')),
+            'need +note': str(SQ(content='need') & SQ(content='+note')),
+            'need+note': str(SQ(content='need+note')),
+            'iphone AND NOT subject:10': str(SQ(content='iphone') & ~SQ(subject='10')),
+            'iphone OR NOT subject:10': str(SQ(content='iphone') | ~SQ(subject='10')),
+            'NOT subject:10': str(~SQ(subject='10')),
+            'subject:10': str(SQ(subject='10')),
+            '-subject:10': str(SQ(content='-subject:10')),
+            'subject:-10': str(SQ(subject='-10')),
             # all keywords accepted, non-matches are treated literally
-            "foo:bar": str(SQ(content="foo:bar")),
+            'foo:bar': str(SQ(content='foo:bar')),
         }
         parser = ParseSQ()
         for case in testcase.keys():

--- a/hs_core/tests/api/native/test_discovery_parser.py
+++ b/hs_core/tests/api/native/test_discovery_parser.py
@@ -75,16 +75,20 @@ class SimpleTest(TestCase):
 
     def test_operators(self):
         testcase = {
+            # removed '+', '-' syntaxes 4/5/2019.
+            # test cases modified accordingly.
             "note": str(SQ(content="note")),
-            # removed '-' 4/5/2019 "need -note": str(SQ(content="need") & ~SQ(content="note")),
-            # removed '+' 4/5/2019 "need +note": str(SQ(content="need") & SQ(content="note")),
-            # removed '+' 4/5/2019 "need+note": str(SQ(content="need+note")),
+            "need -note": str(SQ(content="need") & SQ(content="-note")),
+            "need +note": str(SQ(content="need") & SQ(content="+note")),
+            "need+note": str(SQ(content="need+note")),
             "iphone AND NOT subject:10": str(SQ(content="iphone") & ~SQ(subject="10")),
             "iphone OR NOT subject:10": str(SQ(content="iphone") | ~SQ(subject="10")),
             "NOT subject:10": str(~SQ(subject="10")),
             "subject:10": str(SQ(subject="10")),
-            # removed 4/5/2019 "-subject:10": str(~SQ(subject="10")),
+            "-subject:10": str(SQ(content='-') & SQ(subject="10")),
             "subject:-10": str(SQ(subject="-10")),
+            # all keywords accepted, non-matches are treated literally
+            "foo:bar": str(SQ(content="foo:bar")),
         }
         parser = ParseSQ()
         for case in testcase.keys():
@@ -142,7 +146,7 @@ class SimpleTest(TestCase):
 
     def test_exceptions(self):
         testcase = {
-            # removed 4/5/2019 "foo:bar": FieldNotRecognizedError,
+            # This exception removed 4/5/2019: "foo:bar": FieldNotRecognizedError,
             "created:20170": MalformedDateError,
             "created:2017-30": MalformedDateError,
             "created:2017-12-64": MalformedDateError,


### PR DESCRIPTION
This code modifies the discovery command parser in three ways: 

1. Eliminate error messages for invalid fields in `foo:bar` kinds of queries. Parse invalid keyword entries, e.g., `foo:bar` as literals to be searched for. 
3. Eliminate parsing of `-` and `+` synonyms for `NOT` and include. 

Note that the special keywords `AND`, `OR`, `NOT` are still present and the expressive power of the query engine has not been reduced. Only shorthand syntaxes have been eliminated. 

This makes the strange long names in the CZO use case more easily discoverable. 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Type discovery request with colons and invalid keyword, e.g., `foo:bar`. Error is not returned. Instead, this is searched for literally. 
2. Type a discovery request `-couch` or `+couch`. This should be interpreted literally, and not as `NOT couch`. 
