### PR TITLE
Remove dead code for table readability and sharing across resource views

### DIFF
--- a/theme/templates/pages/group.html
+++ b/theme/templates/pages/group.html
@@ -27,8 +27,7 @@
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span
                                 aria-hidden="true">&times;</span></button>
                         This group is set to <strong>inactive.</strong> Only owners of the group have access. Resources
-                        cannot
-                        be shared with the group and other users cannot be invited.
+                        cannot be shared with the group and other users cannot be invited.
                         <hr>
                         <span class="glyphicon glyphicon-question-sign"></span>
                         <small> Click on the restore button ( <span class="glyphicon glyphicon-retweet"></span> ) below
@@ -633,57 +632,18 @@
                                                 <td>{{ res.first_creator.name }}</td>
                                             {% endif %}
                                             {# Date Created #}
-                                            <td>{{ res.created|date:"M d, Y" }} at {{ res.created|time }}</td>
+                                            <td>{{ res.created|date:"d M, Y" }} {{ res.created|time }}</td>
                                             {# Last Modified #}
-                                            <td>{{ res.updated|date:"M d, Y" }} at {{ res.updated|time }}</td>
-                                            <td>
-                                                {% for kw in res.metadata.subjects.all %}
-                                                    {% if forloop.counter0 > 0 %},{% endif %}{{ kw.value }}
-                                                {% endfor %}
-                                            </td>
-                                            <td>
-                                                {% for creator in res.metadata.creators.all %}
-                                                    {% if forloop.counter0 != 0 %}<span> · </span>{% endif %}
-                                                    {% if creator.description %}
-                                                        <a href="{{ creator.description }}">{{ creator.name }}</a>
-                                                    {% else %}
-                                                        <span>{{ creator.name }}</span>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </td>
-                                            {% if res.owned %}
-                                                <td>Owned</td>
-                                            {% elif res.editable %}
-                                                <td>Editable</td>
-                                            {% elif res.viewable %}
-                                                <td>Viewable</td>
-                                            {% else %}
-                                                <td></td>
-                                            {% endif %}
-                                            <td class="col-labels">
-                                                {% for label in res.labels %}
-                                                    {% if forloop.counter0 > 0 %},{% endif %}{{ label }}
-                                                {% endfor %}
-                                            </td>
-                                            <td class="col-is-favorite">
-                                                {% if res.is_favorite %}
-                                                    Favorite
-                                                {% endif %}
-                                            </td>
+                                            <td>{{ res.updated|date:"d M, Y" }} {{ res.updated|time }}</td>
+                                            <td><!-- Needed for datatable to function properly --></td>
+                                            <td><!-- Needed for datatable to function properly --></td>
+                                            <td><!-- Needed for datatable to function properly --></td>
+                                            <td><!-- Needed for datatable to function properly --></td>
+                                            <td><!-- Needed for datatable to function properly --></td>
                                             <td>{{ res.updated|date:"U" }}</td>
-                                            <td>
-                                                {% if res.raccess.published %}
-                                                    Published
-                                                {% elif res.raccess.public %}
-                                                    Public
-                                                {% elif res.raccess.discoverable %}
-                                                    Discoverable
-                                                {% else %}
-                                                    Private
-                                                {% endif %}
-                                            </td>
+                                            <td><!-- Needed for datatable to function properly --></td>
                                             <td>{{ res.created|date:"U" }}</td>
-                                            <td>{{ res.grantor.id }}</td>
+                                            <td><!-- Needed for datatable to function properly --></td>
                                         </tr>
                                     {% endfor %}
                                 </tbody>
@@ -907,6 +867,5 @@
     {{ block.super }}
     <script type="text/javascript" charset="utf8" src="{{ STATIC_URL }}js/jquery.dataTables.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}js/group.js"></script>
-{#    <script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>#}
     <script type="text/javascript" src="{{ STATIC_URL }}js/hs_resource_table.js"></script>
 {% endblock %}

--- a/theme/templates/pages/group.html
+++ b/theme/templates/pages/group.html
@@ -632,9 +632,9 @@
                                                 <td>{{ res.first_creator.name }}</td>
                                             {% endif %}
                                             {# Date Created #}
-                                            <td>{{ res.created|date:"d M, Y" }} {{ res.created|time }}</td>
+                                            <td>{{ res.created|date:"d M Y" }} {{ res.created|time }}</td>
                                             {# Last Modified #}
-                                            <td>{{ res.updated|date:"d M, Y" }} {{ res.updated|time }}</td>
+                                            <td>{{ res.updated|date:"d M Y" }} {{ res.updated|time }}</td>
                                             <td><!-- Needed for datatable to function properly --></td>
                                             <td><!-- Needed for datatable to function properly --></td>
                                             <td><!-- Needed for datatable to function properly --></td>


### PR DESCRIPTION
This is necessary to start sharing code/UI component across Resource Views, instead of copy/pasting code and repeating/maintaining in 3-5 separate areas and/or having identical UI components have slightly different formatting.

### Issues Addressed
Fixes https://github.com/hydroshare/hydroshare/issues/3313

### Positive Test Case
1. Share a Resource with a Group
2. View Resources for the group in the Resources tab


![image](https://user-images.githubusercontent.com/45397838/56299213-9427ab00-6101-11e9-907c-6e67636f71c4.png)

