### PR TITLE
[2756] delete metadata confirm

### DIFF
--- a/theme/static/js/generic-resource.js
+++ b/theme/static/js/generic-resource.js
@@ -242,18 +242,18 @@ function showRemoveExtraMetaPopup(row_id_str) {
     // get the row object via the row_id_str passed in
     let row_to_delete = t.row("#" + row_id_str);
 
-    // get the row content - name and value
-    let name = row_to_delete.data()[0];
-    let value = row_to_delete.data()[1];
+    // get the row content - meta_name and meta_value
+    let meta_name = row_to_delete.data()[0];
+    let meta_value = row_to_delete.data()[1];
 
     // this is a hidden HTML element to store the row_id_str
     $("#delete_extra_meta_row_id").val(row_id_str);
 
-    $("#old_extra_meta_name").val(name);
+    $("#old_extra_meta_name").val(meta_name);
 
-    // set the value. readonly is set in the modal element, not here
-    $("#delete_extra_meta_name_input").val(name);
-    $("#delete_extra_meta_value_input").val(value);
+    // set the meta_value.
+    $("#delete_extra_meta_name_input").val(meta_name);
+    $("#delete_extra_meta_value_input").val(meta_value);
 
     $('#deleteExtraMetaDialog').modal('show');
 }

--- a/theme/static/js/generic-resource.js
+++ b/theme/static/js/generic-resource.js
@@ -233,6 +233,34 @@ function showAddEditExtraMetaPopup(edit, row_id_str) {
     $('#extraMetaDialog').modal('show');
 }
 
+
+
+function showRemoveExtraMetaPopup(row_id_str) {
+    $("#edit_extra_meta_row_id").val('');
+    $("#old_extra_meta_name").val('');
+    $("#extra_meta_name_input").val('');
+    $("#extra_meta_value_input").val('');
+
+    // Restore validation UI state
+    $("#extra_meta_msg").hide();
+    $("#extra_meta_name_input").removeClass("form-invalid");
+
+    // retrieving values from underlying data table
+        var t = $('#extraMetaTable').DataTable();
+        var row_to_edit = t.row("#" + row_id_str);
+        var oldname = row_to_edit.data()[0];
+        var oldvalue = row_to_edit.data()[1];
+        $("#edit_extra_meta_row_id").val(row_id_str);
+        $("#old_extra_meta_name").val(oldname);
+        $("#delete_extra_meta_name_input").val(oldname);
+        $("#delete_extra_meta_value_input").val(oldvalue);
+
+    $('#removeExtraMetaDialog').modal('show');
+
+    // removeExtraMetadataFromTable(row_id_str);
+    // saveExtraMetadata();
+}
+
 function addEditExtraMeta2Table() {
     // Restore validation UI state
     $("#extra_meta_msg").hide();
@@ -286,6 +314,15 @@ function addEditExtraMeta2Table() {
 
     $("#extraMetaTable [data-toggle='tooltip']").tooltip();
     $("#extraMetaDialog").modal('hide');
+    saveExtraMetadata();
+}
+
+function removeExtraMetaTable(table) {
+    var t = $('#extraMetaTable').DataTable();
+    var edit_extra_meta_row_id = $("#edit_extra_meta_row_id").val().trim();
+    var row_to_edit = t.row("#" + edit_extra_meta_row_id);
+    removeExtraMetadataFromTable(edit_extra_meta_row_id);
+    $("#removeExtraMetaDialog").modal('hide');
     saveExtraMetadata();
 }
 
@@ -743,8 +780,7 @@ $(document).ready(function () {
 
     $("#extraMetaTable").on("click", ".btn-remove-extra-metadata", function () {
         var loopCounter = $(this).attr("data-loop-counter");
-        removeExtraMetadataFromTable(loopCounter);
-        saveExtraMetadata();
+        showRemoveExtraMetaPopup(loopCounter);
     });
 
     $("#extraMetaTable").on("click", ".btn-edit-extra-metadata", function () {

--- a/theme/static/js/generic-resource.js
+++ b/theme/static/js/generic-resource.js
@@ -236,29 +236,26 @@ function showAddEditExtraMetaPopup(edit, row_id_str) {
 
 
 function showRemoveExtraMetaPopup(row_id_str) {
-    $("#edit_extra_meta_row_id").val('');
-    $("#old_extra_meta_name").val('');
-    $("#extra_meta_name_input").val('');
-    $("#extra_meta_value_input").val('');
-
-    // Restore validation UI state
-    $("#extra_meta_msg").hide();
-    $("#extra_meta_name_input").removeClass("form-invalid");
-
     // retrieving values from underlying data table
-        var t = $('#extraMetaTable').DataTable();
-        var row_to_edit = t.row("#" + row_id_str);
-        var oldname = row_to_edit.data()[0];
-        var oldvalue = row_to_edit.data()[1];
-        $("#edit_extra_meta_row_id").val(row_id_str);
-        $("#old_extra_meta_name").val(oldname);
-        $("#delete_extra_meta_name_input").val(oldname);
-        $("#delete_extra_meta_value_input").val(oldvalue);
+    let t = $('#extraMetaTable').DataTable();
 
-    $('#removeExtraMetaDialog').modal('show');
+    // get the row object via the row_id_str passed in
+    let row_to_delete = t.row("#" + row_id_str);
 
-    // removeExtraMetadataFromTable(row_id_str);
-    // saveExtraMetadata();
+    // get the row content - name and value
+    let name = row_to_delete.data()[0];
+    let value = row_to_delete.data()[1];
+
+    // this is a hidden HTML element to store the row_id_str
+    $("#delete_extra_meta_row_id").val(row_id_str);
+
+    $("#old_extra_meta_name").val(name);
+
+    // set the value. readonly is set in the modal element, not here
+    $("#delete_extra_meta_name_input").val(name);
+    $("#delete_extra_meta_value_input").val(value);
+
+    $('#deleteExtraMetaDialog').modal('show');
 }
 
 function addEditExtraMeta2Table() {
@@ -318,11 +315,9 @@ function addEditExtraMeta2Table() {
 }
 
 function removeExtraMetaTable(table) {
-    var t = $('#extraMetaTable').DataTable();
-    var edit_extra_meta_row_id = $("#edit_extra_meta_row_id").val().trim();
-    var row_to_edit = t.row("#" + edit_extra_meta_row_id);
-    removeExtraMetadataFromTable(edit_extra_meta_row_id);
-    $("#removeExtraMetaDialog").modal('hide');
+    $("#deleteExtraMetaDialog").modal('hide');
+
+    removeExtraMetadataFromTable($("#delete_extra_meta_row_id").val().trim());
     saveExtraMetadata();
 }
 

--- a/theme/static/js/modals.js
+++ b/theme/static/js/modals.js
@@ -90,6 +90,7 @@ $(document).ready(function() {
     });
 
     $("#btn-confirm-extended-metadata").click(addEditExtraMeta2Table);
+    $("#btn-confirm-delete-extended-metadata").click(removeExtraMetaTable);
 
     $("#btn-confirm-add-access").click(function () {
         var formID = $(this).closest("form").attr("id");

--- a/theme/templates/resource-landing-page/modals.html
+++ b/theme/templates/resource-landing-page/modals.html
@@ -572,7 +572,7 @@
         </div>
     </div>
 
-    <div class="modal fade in" id="removeExtraMetaDialog" tabindex="-1" role="dialog" aria-labelledby="add-extra-meta" aria-hidden="true">
+    <div class="modal fade in" id="deleteExtraMetaDialog" tabindex="-1" role="dialog" aria-labelledby="add-extra-meta" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <form enctype="multipart/form-data">
@@ -586,14 +586,14 @@
                             <input id="delete_extra_meta_row_id" type="hidden" />
                             <input id="old_extra_meta_name" type="hidden" />
                             <div id="div_extra_meta_name" class="control-group">
-                                <label for="extra_meta_name" class="control-label requiredField">Name</label>
+                                <label for="delete_extra_meta_name" class="control-label requiredField">Name</label>
                                 <div class="controls">
                                     <input class="form-control input-sm textinput textInput" readonly required
                                            id="delete_extra_meta_name_input" maxlength="100" name="name" type="text">
                                 </div>
                             </div>
                             <div id="div_extra_meta_value" class="control-group">
-                                <label for="extra_meta_value" class="control-label">Value</label>
+                                <label for="delete_extra_meta_value" class="control-label">Value</label>
                                 <div class="controls">
                                     <textarea readonly required class="form-control input-sm textarea" cols="40"
                                                         id="delete_extra_meta_value_input" name="value"
@@ -605,7 +605,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                        <button id="btn-confirm-delete-extended-metadata" type="button" class="btn btn-danger">Delete Changes</button>
+                        <button id="btn-confirm-delete-extended-metadata" type="button" class="btn btn-danger">Delete</button>
                     </div>
                 </form>
             </div>

--- a/theme/templates/resource-landing-page/modals.html
+++ b/theme/templates/resource-landing-page/modals.html
@@ -572,6 +572,46 @@
         </div>
     </div>
 
+    <div class="modal fade in" id="removeExtraMetaDialog" tabindex="-1" role="dialog" aria-labelledby="add-extra-meta" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form enctype="multipart/form-data">
+                    <input name="resource-mode" type="hidden" value="edit">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                        <h4 class="modal-title" id="extra_meta_title"> Delete Extended Metadata </h4>
+                    </div>
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <input id="delete_extra_meta_row_id" type="hidden" />
+                            <input id="old_extra_meta_name" type="hidden" />
+                            <div id="div_extra_meta_name" class="control-group">
+                                <label for="extra_meta_name" class="control-label requiredField">Name</label>
+                                <div class="controls">
+                                    <input class="form-control input-sm textinput textInput" readonly required
+                                           id="delete_extra_meta_name_input" maxlength="100" name="name" type="text">
+                                </div>
+                            </div>
+                            <div id="div_extra_meta_value" class="control-group">
+                                <label for="extra_meta_value" class="control-label">Value</label>
+                                <div class="controls">
+                                    <textarea readonly required class="form-control input-sm textarea" cols="40"
+                                                        id="delete_extra_meta_value_input" name="value"
+                                                        rows="10"></textarea>
+                                </div>
+                            </div>
+                            <div id="extra_meta_msg" style="display: None"></div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        <button id="btn-confirm-delete-extended-metadata" type="button" class="btn btn-danger">Delete Changes</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <div class="modal fade in" id="create-folder-dialog" tabindex="-1" role="dialog"
      aria-labelledby="create-folder" aria-hidden="false">
     <div class="modal-dialog">
@@ -2031,17 +2071,17 @@
     </div>
     {#======= Manage access modal  window ends =======#}
 
-    <div id="dialog-confirm-delete-self-access" class="access-dialog-title" title="Warning! Loss of access"> 
+    <div id="dialog-confirm-delete-self-access" class="access-dialog-title" title="Warning! Loss of access">
         <p><span class="ui-icon ui-icon-alert access-warning"></span>
             This action will remove your access to this resource and you will no longer be able to
             access it without someone else sharing it with you again. This is not reversible,
             so <strong>Remove</strong> with caution.
         </p>
     </div>
-    
+
     <div id="dialog-confirm-change-share-permission" class="access-dialog-title" title="Warning! Loss of owner access">
         <p><span class="ui-icon ui-icon-alert access-warning"></span>
-        This action will remove your owner access to this resource. This removal is not reversible. Owner 
+        This action will remove your owner access to this resource. This removal is not reversible. Owner
         access can only be retrieved by another owner later granting you owner access. <strong>Remove</strong> with caution.
         </p>
     </div>


### PR DESCRIPTION
#2756 
Deleting a pair of extra metadata requires a confirmation dialog. The fix provides the same behavior as deleting a file metadata. 

<img width="585" alt="image" src="https://user-images.githubusercontent.com/35352595/56994025-f3f36c80-6b6b-11e9-8487-2d93c9ce32cd.png">

### Regarding code to add this confimration dialog:
The existent code design was to just combine Add and Edit into one dialog. Method signatures reflects this. `showAddEditExtraMetaPopup(edit:false, ''");` The button to commit is always “Save Changes”. 

I don’t want to pollute the original design with the new delete dialog as it might introduce regression for this minor fix. So the bug fix is separated from the existent Add/Edit modal dialog. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Add new key/value pairs of extra metadata.
2. Click on the trash can.
3. Delete confirmation dialog pops up, the same look and feel as file metadata deletion.
4. Click the red "Delete" button.
5. The meta data row is deleted.
