### PR TITLE
3371 add mechanism for exposing public resources of a single group

### DIFF
--- a/hs_access_control/management/commands/community_public.py
+++ b/hs_access_control/management/commands/community_public.py
@@ -8,8 +8,8 @@ from hs_access_control.management.utilities import community_from_name_or_id
 
 
 def usage():
-    print("public usage:")
-    print("  public {community-name-or-id}")
+    print("community_public usage:")
+    print("  community_public {community-name-or-id}")
     print("Where:")
     print("  {community-name-or-id} is a community name or numeric id.")
 

--- a/hs_access_control/management/commands/group_public.py
+++ b/hs_access_control/management/commands/group_public.py
@@ -1,0 +1,76 @@
+"""
+This prints a list of publicly accessible resources in a group
+
+"""
+
+from django.core.management.base import BaseCommand
+from hs_access_control.management.utilities import group_from_name_or_id
+
+
+def usage():
+    print("group_public usage:")
+    print("  group_public {group-name-or-id}")
+    print("Where:")
+    print("  {group-name-or-id} is a group name or numeric id.")
+
+
+def shorten(title, length):
+    if len(title) <= length:
+        return title
+    else:
+        return title[0:19]+'...'
+
+
+def access_type(thing):
+    if thing['published']:
+        return 'published'
+    elif thing['public']:
+        return 'public'
+    elif thing['discoverable']:
+        return 'discoverable'
+    else:
+        return 'private'
+
+
+class Command(BaseCommand):
+    help = """List public resources."""
+
+    def add_arguments(self, parser):
+
+        # a command to execute
+        parser.add_argument('arguments', nargs='*', type=str)
+
+    def handle(self, *args, **options):
+
+        if len(options['arguments']) != 1:
+            usage()
+            exit(1)
+
+        group_name = options['arguments'][0]
+
+        group = group_from_name_or_id(group_name)
+        if group is None:
+            usage()
+            exit(1)
+
+        print("group is {} (id={})".format(group.name, group.id))
+        stuff = group.gaccess.public_resources
+        for r in stuff:
+            print(("{} '{}' '{}' type='{}' group='{}' (id={}) published={} public={} " +
+                  "discoverable={} created='{}' updated='{}' first author='{}'")
+                  .format(r.short_id,
+                          shorten(r.title, 20),
+                          # equivalently: shorten(r.content_object._title.first().value, 20),
+                          shorten(r.description, 20),
+                          # equivalently: shorten(r.content_object._description.first().value, 20),
+                          r.resource_type,
+                          r.group_name,
+                          r.group_id,
+                          r.published,
+                          r.public,
+                          r.discoverable,
+                          r.created,
+                          r.updated,
+                          r.first_creator
+                          # equivalently: r.content_object.creators.filter(order=1).first()
+                          ))

--- a/hs_access_control/models/group.py
+++ b/hs_access_control/models/group.py
@@ -1,10 +1,11 @@
 from django.contrib.auth.models import User, Group
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, F
 
 from hs_core.models import BaseResource
 from hs_access_control.models.privilege import PrivilegeCodes, UserGroupPrivilege
 from hs_access_control.models.community import Community
+from django.contrib.contenttypes.models import ContentType
 
 #############################################
 # Group access data.
@@ -359,3 +360,60 @@ class GroupAccess(models.Model):
             return p.privilege
         except UserGroupPrivilege.DoesNotExist:
             return PrivilegeCodes.NONE
+
+    @property
+    def public_resources(self):
+        """
+        prepare a list of everything that gets displayed about each resource in a group.
+
+        Based upon hs_access_control/models/community.py:Community:public_resources
+        """
+        res = BaseResource.objects.filter(r2grp__group__gaccess=self,
+                                          r2grp__group__gaccess__active=True)\
+                                  .filter(Q(raccess__public=True) |
+                                          Q(raccess__published=True) |
+                                          Q(raccess__discoverable=True))\
+                                  .annotate(group_name=F("r2grp__group__name"),
+                                            group_id=F("r2grp__group__id"),
+                                            public=F("raccess__public"),
+                                            published=F("raccess__published"),
+                                            discoverable=F("raccess__discoverable"))
+
+        res = res.only('title', 'resource_type', 'created', 'updated')
+
+        # # Can't do the following because the content model is polymorphic.
+        # # This is documented as only working for monomorphic content_type
+        # res = res.prefetch_related("content_object___title",
+        #                            "content_object___description",
+        #                            "content_object__creators")
+        # We want something that is not O(# resources + # content types).
+        # O(# content types) is sufficiently faster.
+        # The following strategy is documented here:
+        # https://blog.roseman.org.uk/2010/02/22/django-patterns-part-4-forwards-generic-relations/
+
+        # collect generics from resources
+        generics = {}
+        for item in res:
+            generics.setdefault(item.content_type.id, set()).add(item.object_id)
+
+        # fetch all content types in one query
+        content_types = ContentType.objects.in_bulk(generics.keys())
+
+        # build a map between content types and the objects that use them.
+        relations = {}
+        for ct, fk_list in generics.items():
+            ct_model = content_types[ct].model_class()
+            relations[ct] = ct_model.objects.in_bulk(list(fk_list))
+
+        # force-populate the cache of content type objects.
+        for item in res:
+            setattr(item, '_content_object_cache',
+                    relations[item.content_type.id][item.object_id])
+
+        # Detailed notes:
+        # This subverts chained lookup by pre-populating the content object cache
+        # that is populated by an object reference. It is very dependent upon the
+        # implementation of GenericRelation and its pre-fetching strategy.
+        # Thus it is quite brittle and vulnerable to major revisions of Generics.
+
+        return res

--- a/hs_access_control/tests/test_group_public.py
+++ b/hs_access_control/tests/test_group_public.py
@@ -1,0 +1,86 @@
+from django.test import TestCase
+from django.contrib.auth.models import Group
+
+from hs_access_control.models import PrivilegeCodes
+
+from hs_core import hydroshare
+from hs_core.testing import MockIRODSTestCaseMixin
+
+from hs_access_control.tests.utilities import global_reset, is_equal_to_as_set
+
+
+class T09GroupPublic(MockIRODSTestCaseMixin, TestCase):
+
+    def setUp(self):
+        super(T09GroupPublic, self).setUp()
+        global_reset()
+        self.group, _ = Group.objects.get_or_create(name='Hydroshare Author')
+        self.admin = hydroshare.create_account(
+            'admin@gmail.com',
+            username='admin',
+            first_name='administrator',
+            last_name='couch',
+            superuser=True,
+            groups=[]
+        )
+
+        self.dog = hydroshare.create_account(
+            'dog@gmail.com',
+            username='dog',
+            first_name='a little arfer',
+            last_name='last_name_dog',
+            superuser=False,
+            groups=[]
+        )
+
+        self.squirrels = hydroshare.create_resource(
+            resource_type='GenericResource',
+            owner=self.dog,
+            title='all about chasing squirrels',
+            metadata=[],
+        )
+
+        self.holes = hydroshare.create_resource(
+            resource_type='GenericResource',
+            owner=self.dog,
+            title='all about storing bones in holes',
+            metadata=[],
+        )
+
+        # dog owns canines group
+        self.canines = self.dog.uaccess.create_group(
+            title='canines', description="We are the canines")
+
+    def test_public_resources(self):
+        """ public resources contain those resources that are public and discoverable """
+
+        res = self.canines.gaccess.public_resources
+        self.assertTrue(is_equal_to_as_set(res, []))
+        self.dog.uaccess.share_resource_with_group(self.squirrels, self.canines,
+                                                   PrivilegeCodes.VIEW)
+        self.dog.uaccess.share_resource_with_group(self.holes, self.canines,
+                                                   PrivilegeCodes.VIEW)
+        res = self.canines.gaccess.public_resources
+        self.assertTrue(is_equal_to_as_set(res, []))
+        self.holes.raccess.public = True
+        self.holes.raccess.discoverable = True
+        self.holes.raccess.save()  # this avoids regular requirements for "public"
+        res = self.canines.gaccess.public_resources
+        self.assertTrue(is_equal_to_as_set(res, [self.holes]))
+        for r in res:
+            self.assertEqual(r.public, r.raccess.public)
+            self.assertEqual(r.discoverable, r.raccess.discoverable)
+            self.assertEqual(r.published, r.raccess.published)
+            self.assertEqual(r.group_name, self.canines.name)
+            self.assertEqual(r.group_id, self.canines.id)
+        self.squirrels.raccess.discoverable = True
+        self.squirrels.raccess.save()
+        res = self.canines.gaccess.public_resources
+        self.assertTrue(is_equal_to_as_set(res, [self.holes, self.squirrels]))
+        for r in res:
+            self.assertEqual(r.public, r.raccess.public)
+            self.assertEqual(r.discoverable, r.raccess.discoverable)
+            self.assertEqual(r.published, r.raccess.published)
+            self.assertEqual(r.group_name, self.canines.name)
+            self.assertEqual(r.group_id, self.canines.id)
+


### PR DESCRIPTION
This adds the backend utility function GroupAccess.public_resources parallel to the existing Community.public_resources, for the purpose of building better public group pages.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. running ./hsctl groups_public {id or name of group} lists public resources shared with that group. 
