### PR TITLE
Folder create - show folder exists message

### DIFF
--- a/hs_core/tests/api/rest/test_folders.py
+++ b/hs_core/tests/api/rest/test_folders.py
@@ -42,9 +42,9 @@ class TestFolders(HSRESTTestCase):
         response = self.client.put(url2, {})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        # should be able to create it again
+        # should not be able to create the same folder again
         response = self.client.put(url2, {})
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         # list that folder: should work, should be empty
         response = self.client.get(url2, {})

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -1074,6 +1074,9 @@ def create_folder(res_id, folder_path):
         raise ValidationError("Folder creation is not allowed here. "
                               "The target folder seems to contain aggregation(s)")
 
+    # check for duplicate folder path
+    if istorage.exists(coll_path):
+        raise ValidationError("Folder already exists")
     istorage.session.run("imkdir", None, '-p', coll_path)
 
 

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -1481,6 +1481,7 @@ function create_irods_folder_ajax_submit(res_id, folder_path) {
             folder_path: folder_path
         },
         success: function (result) {
+            $("#fb-alerts .upload-failed-alert").remove();
             var new_folder_rel_path = result.new_folder_rel_path;
             if (new_folder_rel_path.length > 0) {
                 $('#create-folder-dialog').modal('hide');


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a folder (e.g. folder-1) in any resource. Try to create another folder (at same directory path) with the same folder name (e.g. folder-1), you should see a message 'Folder already exists' and the 2nd folder won't be created. 