### PR TITLE
[#3226] IE11 Workaround for default function parameter values

### DIFF
--- a/theme/static/js/generic-resource.js
+++ b/theme/static/js/generic-resource.js
@@ -568,8 +568,8 @@ $(document).ready(function () {
     });
 
     $("#list-roles a").click(onRoleSelect);
-    $("#add-access-form #id_user-autocomplete, #add-access-form #user-autocomplete").attr("placeholder", "Search by name or username").addClass("form-control");
-    $("#id_group-autocomplete").attr("placeholder", "Search by group name").addClass("form-control");
+    $("input[name='user-autocomplete']").attr("placeholder", "Search by name or username").addClass("form-control");
+    $("input[name='group-autocomplete']").attr("placeholder", "Search by group name").addClass("form-control");
 
     var file_types = $("#supported-file-types").attr('value');
     if (file_types != ".*") {

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -468,10 +468,13 @@ function isSharePermissionPromptRequired(form_id) {
     }
     return NOT_REQUIRED;
 }
-function change_share_permission_ajax_submit(form_id, check_permission=true) {
+function change_share_permission_ajax_submit(form_id, check_permission) {
+    if (check_permission === undefined) {
+        check_permission = true;
+    }
     if (check_permission && isSharePermissionPromptRequired(form_id)) {
-	promptChangeSharePermission(form_id);
-	return;
+        promptChangeSharePermission(form_id);
+        return;
     }
 
     $form = $('#' + form_id);


### PR DESCRIPTION
IE11 does not behave well with default parameter values in JavaScript functions. A workaround has been implemented to prevent the script from crashing.

![image](https://user-images.githubusercontent.com/2448568/57311608-2e4b9500-70a9-11e9-9517-dfbf9113834b.png)

This PR also updates the selectors of autocomplete inputs. This way their placeholder values will now properly read "Search by name or user name" or "Search by group name".

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource
2. Use the Manage Access window to add access to some user.
3. Verify that autocomplete inputs respond correctly to user input.
