### PR TITLE
Limit exposed public resources to be owned by a group member.

### DIFF
--- a/hs_access_control/models/group.py
+++ b/hs_access_control/models/group.py
@@ -373,6 +373,8 @@ class GroupAccess(models.Model):
                                   .filter(Q(raccess__public=True) |
                                           Q(raccess__published=True) |
                                           Q(raccess__discoverable=True))\
+                                  .filter(r2urp__privilege=PrivilegeCodes.OWNER,
+                                          r2urp__user__u2ugp__group=self.group)\
                                   .annotate(group_name=F("r2grp__group__name"),
                                             group_id=F("r2grp__group__id"),
                                             public=F("raccess__public"),


### PR DESCRIPTION
This is an expedient modification of `public_resources` -- for both communities and groups -- that eliminates the anomaly described in #3382. More than this is probably necessary, eventually. I expect that we'll need to institute an `exhibit` flag that indicates which resources to show in group and community public listings. This expedient change will satisfy the purposes of the CZOs, however. 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. List community resources. They contain only resources owned by community members. 
