### PR TITLE
[#3434] Prevent clicking on list items dismissing the modal window

### DIFF
--- a/theme/static/js/custom.js
+++ b/theme/static/js/custom.js
@@ -422,6 +422,17 @@ $(document).ready(function () {
         this.box.insertAfter(this.input).css({top: 35, left: 0});
     };
 
+    // Prevent clicking on list items dismissing the modal window
+    let autoCompletes = $(".autocomplete-light-widget > input.autocomplete");
+    if (autoCompletes.length) {
+        autoCompletes.each(function (i, el) {
+            $(el).yourlabsAutocomplete()
+                .input.bind('selectChoice', function (e, choice, autocomplete) {
+                e.stopPropagation();
+            });
+        });
+    }
+
     // Can be used to obtain an element's HTML including itself and not just its content
     jQuery.fn.outerHTML = function () {
         return jQuery('<div />').append(this.eq(0).clone()).html();

--- a/theme/static/js/custom.js
+++ b/theme/static/js/custom.js
@@ -424,14 +424,12 @@ $(document).ready(function () {
 
     // Prevent clicking on list items dismissing the modal window
     let autoCompletes = $(".autocomplete-light-widget > input.autocomplete");
-    if (autoCompletes.length) {
-        autoCompletes.each(function (i, el) {
-            $(el).yourlabsAutocomplete()
-                .input.bind('selectChoice', function (e, choice, autocomplete) {
-                e.stopPropagation();
-            });
+    autoCompletes.each(function (i, el) {
+        $(el).yourlabsAutocomplete()
+            .input.bind('selectChoice', function (e, choice, autocomplete) {
+            e.stopPropagation();
         });
-    }
+    });
 
     // Can be used to obtain an element's HTML including itself and not just its content
     jQuery.fn.outerHTML = function () {

--- a/theme/static/js/custom.js
+++ b/theme/static/js/custom.js
@@ -423,8 +423,7 @@ $(document).ready(function () {
     };
 
     // Prevent clicking on list items dismissing the modal window
-    let autoCompletes = $(".autocomplete-light-widget > input.autocomplete");
-    autoCompletes.each(function (i, el) {
+    $(".autocomplete-light-widget > input.autocomplete").each(function (i, el) {
         $(el).yourlabsAutocomplete()
             .input.bind('selectChoice', function (e, choice, autocomplete) {
             e.stopPropagation();


### PR DESCRIPTION
Addresses https://github.com/hydroshare/hydroshare/issues/3434#issuecomment-501670986

In Firefox, when using User Autocomplete widget, the modal window would get dismissed if clicking on autocomplete items hovering outside the modal window. This occurred for modal windows used in Add Author, Add Contributor, Manage Access, and Send Group Invitation.

This PR fixes this behavior for all instances described above.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. In Firefox, navigate to a Group page for which you can invite users.
2. In the Members tab, click on Invite People.
3. Start typing a name in the autocomplete.
4. Try selecting a name which hovers outside the area of the modal window.
5. Verify that the modal window does not get dismissed upon selection.
6. Repeat steps 3 to 5 for the following actions in resource landing page: Add Author, Add Contributor, Manage Access,
7. Repeat the steps above for other browsers.
