### PR TITLE
fixed issue #3431: fixed the dashboard home page issue for resources when the first crea…

### DIFF
--- a/theme/templates/pages/dashboard.html
+++ b/theme/templates/pages/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block meta_title %}Home{% endblock %}
-{% load mezzanine_tags static blog_tags accounts_tags dashboard_tags i18n %}
+{% load mezzanine_tags static blog_tags accounts_tags dashboard_tags i18n hydroshare_tags %}
 
 {% comment %}
 
@@ -85,7 +85,7 @@ timestamp should go with a template tags to convert to a human readble day.
                                 {% resource_link_builder r.title r.short_id %}
                             {% endautoescape %}
                         </td>
-                        <td>{{ r.first_creator }}</td>
+                        <td>{{ r|resource_first_author }}</td>
                         <td>
                             {% autoescape off %}
                                 {% resource_verbose_name_builder r.resource_type %}


### PR DESCRIPTION
…tor field is None

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
Applied the fix on beta and dashboard home page now works with the fix. The problem was caused by first creator field being empty while an organization was set as the first author. Thanks to @sblack-usu for identifying the problem with first creator field being empty.
