### PR TITLE
[RC 1.24][#3439] fixed rendering issue when first author is an organization

### DIFF
--- a/hs_core/templatetags/hydroshare_tags.py
+++ b/hs_core/templatetags/hydroshare_tags.py
@@ -139,7 +139,7 @@ def name_without_commas(name):
     If a name without commas is passed it is returned unchanged.
     """
 
-    if "," in name:
+    if name and "," in name:
         name_parts = name.split(",")
 
         if len(name_parts) == 2:


### PR DESCRIPTION
Discovered a template rendering issue when verifying a bug fix on beta for RC 1.24. Have verified on inactive worker on beta that this PR would fix the resource landing page rendering issue for this resource: https://beta.hydroshare.org/resource/1bb3210918414e13b077e87798d4a696/
