### PR TITLE
3481 speed up access control

### DIFF
--- a/hs_access_control/models/community.py
+++ b/hs_access_control/models/community.py
@@ -145,7 +145,7 @@ class Community(models.Model):
 
         # if user is a member, member privileges apply regardless of superuser privileges
         # (superusers only obtain member privileges over every group in the community)
-        if user in group.gaccess.members or self.is_superuser(user):
+        if group.gaccess.members.filter(id=user.id).exists() or self.is_superuser(user):
             if privilege == PrivilegeCodes.CHANGE:
                 return BaseResource.objects.filter(raccess__immutable=False,
                                                    r2grp__group=group,

--- a/hs_access_control/models/user.py
+++ b/hs_access_control/models/user.py
@@ -1665,7 +1665,7 @@ class UserAccess(models.Model):
                 privilege=PrivilegeCodes.CHANGE,
                 community__c2gcp__group=this_group,
                 group__g2ugp__user=self.user).exists() and\
-           not this_group.gaccess.members.filter(id=self.user).exists() and\
+           not this_group.gaccess.members.filter(id=self.user.id).exists() and\
            not self.user.is_superuser:
             raise PermissionDenied("User is not a member of the group and not an admin")
 


### PR DESCRIPTION
@sblack-usu @pkdash This is a performance upgrade for the access control system. 
Unbeknownst to me, the syntax `foo in queryset` is no longer converted automatically to `queryset.filter(id=foo.id).exists()`. This made all of access control run slower. This PR converts all slow syntaxes to their fast equivalents, across all of access control. This does not change function at all. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here] There are no differences in behavior. The difference is in speed. Fetches of a resource landing page now take 3 seconds. Formerly they took 10-15 seconds. 

This completely addresses #3481 . 

Note that SQL `AND` is commutative in SQL queries, so that django `&` is commutative in django queries, so that the initial proposal of writing a new query with the new condition first was unnecessary. Instead, I rewrote all `x in queryset` expressions with more efficient syntax. 
