### PR TITLE
HOTFIX issue 3481 speed up access control by 3x.

### DIFF
--- a/hs_access_control/models/community.py
+++ b/hs_access_control/models/community.py
@@ -145,7 +145,7 @@ class Community(models.Model):
 
         # if user is a member, member privileges apply regardless of superuser privileges
         # (superusers only obtain member privileges over every group in the community)
-        if user in group.gaccess.members or self.is_superuser(user):
+        if group.gaccess.members.filter(id=user.id).exists() or self.is_superuser(user):
             if privilege == PrivilegeCodes.CHANGE:
                 return BaseResource.objects.filter(raccess__immutable=False,
                                                    r2grp__group=group,

--- a/hs_access_control/models/user.py
+++ b/hs_access_control/models/user.py
@@ -69,9 +69,9 @@ class UserAccess(models.Model):
             raise PermissionDenied("Group is not active")
 
         if this_user is None:
-            if self.user in this_group.gaccess.members:
+            if this_group.gaccess.members.filter(id=self.user.id).exists():
                 raise PermissionDenied("You are already a member of this group")
-        elif this_user in this_group.gaccess.members:
+        elif this_group.gaccess.members.filter(id=this_user.id).exists():
                 raise PermissionDenied("User is already a member of this group")
 
         # user (self) requesting to join a group
@@ -437,7 +437,7 @@ class UserAccess(models.Model):
         if self.user.is_superuser:
             return True
 
-        return self.user in this_group.gaccess.edit_users
+        return this_group.gaccess.edit_users.filter(id=self.user.id).exists()
 
     def can_view_group(self, this_group):
         """
@@ -472,7 +472,7 @@ class UserAccess(models.Model):
         access_group = this_group.gaccess
 
         return self.user.is_superuser or access_group.public \
-            or self.user in this_group.gaccess.view_users
+            or this_group.gaccess.view_users.filter(id=self.user.id).exists()
 
     def can_view_group_metadata(self, this_group):
         """
@@ -889,7 +889,7 @@ class UserAccess(models.Model):
     def __check_unshare_group_with_user(self, this_group, this_user):
         """ Check whether an unshare of a group with a user is permitted. """
 
-        if this_user not in this_group.gaccess.members:
+        if not this_group.gaccess.members.filter(id=this_user.id).exists():
             raise PermissionDenied("User is not a member of the group")
 
         # Check for sufficient privilege
@@ -930,7 +930,7 @@ class UserAccess(models.Model):
             g = some_group
             u = some_user
             unshare_users = request_user.get_group_unshare_users(g)
-            if u in unshare_users:
+            if unshare_users.filter(id=u.id).exists():
                 self.unshare_group_with_user(g, u)
         """
         if __debug__:  # during testing only, check argument types and preconditions
@@ -958,7 +958,7 @@ class UserAccess(models.Model):
                 return access_group.members
 
         # unprivileged user can only remove grants to self, if any
-        elif self.user in access_group.members:
+        elif access_group.members.filter(id=self.user.id).exists():
             if access_group.owners.count() == 1:
                 # if self is not an owner,
                 if not UserGroupPrivilege.objects.filter(user=self.user,
@@ -1026,8 +1026,7 @@ class UserAccess(models.Model):
         unlike GroupAccess.view_groups and GroupAccess.edit_groups.
 
         This can be subqueried in returns, because it is lazily evaluated.
-        e.g., resource in self.uaccess.view_resources runs efficiently, because it
-        is equivalent to self.uaccess.view_resources.filter(id=resource).exists()
+        e.g., self.uaccess.view_resources.filter(id=resource.id).exists()
         """
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
@@ -1370,7 +1369,7 @@ class UserAccess(models.Model):
         if access_resource.immutable:
             return False
 
-        if this_resource in self.edit_resources:
+        if self.edit_resources.filter(id=this_resource.id).exists():
             return True
 
         return False
@@ -1429,7 +1428,7 @@ class UserAccess(models.Model):
         if access_resource.public or self.user.is_superuser:
             return True
 
-        if this_resource in self.view_resources:
+        if self.view_resources.filter(id=this_resource.id).exists():
             return True
 
         return False
@@ -1666,7 +1665,7 @@ class UserAccess(models.Model):
                 privilege=PrivilegeCodes.CHANGE,
                 community__c2gcp__group=this_group,
                 group__g2ugp__user=self.user).exists() and\
-           self.user not in this_group.gaccess.members and\
+           not this_group.gaccess.members.filter(id=self.user.id).exists() and\
            not self.user.is_superuser:
             raise PermissionDenied("User is not a member of the group and not an admin")
 
@@ -1796,7 +1795,7 @@ class UserAccess(models.Model):
 -       Note that can_unshare_X is parallel to unshare_X and returns False exactly
 -       when __check_unshare_X and unshare_X will raise an exception.
         """
-        if this_user not in this_resource.raccess.view_users:
+        if not this_resource.raccess.view_users.filter(id=this_user.id).exists():
             raise PermissionDenied("User does not have access to the group")
 
         # Check for sufficient privilege
@@ -1922,7 +1921,7 @@ class UserAccess(models.Model):
 
     def __check_unshare_resource_with_group(self, this_resource, this_group):
         """ check that one can unshare a group with a resource, raise PermissionDenied if not """
-        if not (this_group in this_resource.raccess.view_groups):
+        if not this_resource.raccess.view_groups.filter(id=this_group.id).exists():
             raise PermissionDenied("Group does not have access to resource")
 
         # TODO: also authorize owners of the group and members of peer groups in communities
@@ -1970,7 +1969,7 @@ class UserAccess(models.Model):
                 return access_resource.view_users
 
         # unprivileged user can only remove grants to self, if any
-        elif self.user in access_resource.view_users:
+        elif access_resource.view_users.filter(id=self.user.id).exists():
             if access_resource.owners.count() == 1:
                 # if self is not an owner,
                 if not UserResourcePrivilege.objects\
@@ -2094,7 +2093,7 @@ class UserAccess(models.Model):
         if not this_user.is_active:
             raise PermissionDenied("User is not active")
 
-        return this_user in self.__get_group_undo_users(this_group)
+        return self.__get_group_undo_users(this_group).filter(id=this_user.id).exists()
 
     def undo_share_group_with_user(self, this_group, this_user):
         """
@@ -2132,12 +2131,12 @@ class UserAccess(models.Model):
             raise PermissionDenied("User is not active")
 
         qual_undo = self.__get_group_undo_users(this_group)
-        if this_user in qual_undo:
+        if qual_undo.filter(id=this_user.id).exists():
             UserGroupPrivilege.undo_share(group=this_group, user=this_user, grantor=self.user)
         else:
             # determine which exception to raise.
             raw_undo = UserGroupPrivilege.get_undo_users(group=this_group, grantor=self.user)
-            if this_user in raw_undo:
+            if raw_undo.filter(id=this_user.id).exists():
                 raise PermissionDenied("Cannot remove last owner of group")
             else:
                 raise PermissionDenied("User did not grant last privilege")
@@ -2197,7 +2196,7 @@ class UserAccess(models.Model):
         if not this_user.is_active:
             raise PermissionDenied("User is not active")
 
-        return this_user in self.__get_resource_undo_users(this_resource)
+        return self.__get_resource_undo_users(this_resource).filter(id=this_user.id).exists()
 
     def undo_share_resource_with_user(self, this_resource, this_user):
         """
@@ -2233,7 +2232,7 @@ class UserAccess(models.Model):
             raise PermissionDenied("User is not active")
 
         qual_undo = self.__get_resource_undo_users(this_resource)
-        if this_user in qual_undo:
+        if qual_undo.filter(id=this_user.id).exists():
             UserResourcePrivilege.undo_share(resource=this_resource,
                                              user=this_user,
                                              grantor=self.user)
@@ -2241,7 +2240,7 @@ class UserAccess(models.Model):
             # determine which exception to raise.
             raw_undo = UserResourcePrivilege.get_undo_users(resource=this_resource,
                                                             grantor=self.user)
-            if this_user in raw_undo:
+            if raw_undo.filter(id=this_user.id).exists():
                 raise PermissionDenied("Cannot remove last owner of resource")
             else:
                 raise PermissionDenied("User did not grant last privilege")
@@ -2266,7 +2265,7 @@ class UserAccess(models.Model):
             r = some_resource
             g = some_group
             undo_groups = request_user.__get_resource_undo_groups(r)
-            if u in undo_groups:
+            if undo_groups.filter(id=u.id).exists():
                 request_user.undo_share_resource_with_group(r,g)
 
         """
@@ -2289,7 +2288,7 @@ class UserAccess(models.Model):
         if not this_group.gaccess.active:
             raise PermissionDenied("Group is not active")
 
-        return this_group in self.__get_resource_undo_groups(this_resource)
+        return self.__get_resource_undo_groups(this_resource).filter(id=this_group.id).exists()
 
     def undo_share_resource_with_group(self, this_resource, this_group):
         """
@@ -2325,7 +2324,7 @@ class UserAccess(models.Model):
             raise PermissionDenied("Group is not active")
 
         qual_undo = self.__get_resource_undo_groups(this_resource)
-        if this_group in qual_undo:
+        if qual_undo.filter(id=this_group.id).exists():
             GroupResourcePrivilege.undo_share(resource=this_resource,
                                               group=this_group,
                                               grantor=self.user)
@@ -2534,7 +2533,7 @@ class UserAccess(models.Model):
         if self.user.is_superuser:
             return True
 
-        return this_community in self.edit_communities
+        return self.edit_communities.filter(id=this_community.id).exists()
 
     def can_view_community(self, this_community):
         """
@@ -2564,7 +2563,7 @@ class UserAccess(models.Model):
             return True
 
         return self.user.is_superuser or \
-                this_community in self.view_communities
+                self.view_communities.filter(id=this_community.id).exists()
 
     def can_view_community_metadata(self, this_community):
         """
@@ -2919,7 +2918,7 @@ class UserAccess(models.Model):
             c = some_community
             u = some_user
             unshare_users = request_user.get_community_unshare_users(c)
-            if u in unshare_users:
+            if unshare_users.filter(id=u.id).exists():
                 self.unshare_community_with_user(c, u)
         """
         if __debug__:  # during testing only, check argument types and preconditions
@@ -2945,7 +2944,7 @@ class UserAccess(models.Model):
                 return access_community.members
 
         # unprivileged user can only remove grants to self, if any
-        elif self.user in access_community.members:
+        elif access_community.members.filter(id=self.user.id).exists():
             if access_community.owners.count() == 1:
                 # if self is not an owner,
                 if not UserCommunityPrivilege.objects.filter(user=self.user,
@@ -3196,7 +3195,7 @@ class UserAccess(models.Model):
             c = some_community
             g = some_group
             unshare_groups = self.get_community_unshare_groups(c)
-            if g in unshare_groups:
+            if unshare_groups.filter(id=g.id).exists():
                 self.unshare_community_with_group(c, g)
         """
         if __debug__:  # during testing only, check argument types and preconditions
@@ -3277,7 +3276,7 @@ class UserAccess(models.Model):
         if not this_user.is_active:
             raise PermissionDenied("Grantee user is not active")
 
-        return this_user in self.__get_community_undo_users(this_community)
+        return self.__get_community_undo_users(this_community).filter(id=this_user.id).exists()
 
     def undo_share_community_with_user(self, this_community, this_user):
         """
@@ -3313,7 +3312,7 @@ class UserAccess(models.Model):
             raise PermissionDenied("Grantee user is not active")
 
         qual_undo = self.__get_community_undo_users(this_community)
-        if this_user in qual_undo:
+        if qual_undo.filter(id=this_user.id).exists():
             UserCommunityPrivilege.undo_share(user=this_user, community=this_community,
                                               grantor=self.user)
         else:
@@ -3370,7 +3369,7 @@ class UserAccess(models.Model):
         if not this_group.gaccess.active:
             raise PermissionDenied("Group is not active")
 
-        return this_group in self.__get_community_undo_groups(this_community)
+        return self.__get_community_undo_groups(this_community).filter(id=this_group.id).exists()
 
     def undo_share_community_with_group(self, this_community, this_group):
         """
@@ -3406,7 +3405,7 @@ class UserAccess(models.Model):
             raise PermissionDenied("Group is not active")
 
         qual_undo = self.__get_community_undo_groups(this_community)
-        if this_group in qual_undo:
+        if qual_undo.filter(id=this_group.id).exists():
             GroupCommunityPrivilege.undo_share(group=this_group, community=this_community,
                                                grantor=self.user)
         else:


### PR DESCRIPTION
@sblack-usu @pkdash @phuongdm @martinseul 

HOTFIX This is a performance upgrade for the access control system. 
Unbeknownst to me, the syntax `foo in queryset` is no longer converted automatically to `queryset.filter(id=foo.id).exists()`. This made all of access control run slower. 

This PR converts all slow syntaxes to their fast equivalents, across all of access control. This does not change function at all. 

This completely addresses #3481 . Gain in performance is so substantive that it is proposed as a HOTFIX. This is a rebasing of PR #3483.

Many thanks to @pkdash and @sblack-usu for their help in finding this. 
 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here] Nothing changes, but each resource landing page requires at least 7 seconds less to load. Pages that took 10 seconds take 3-4 seconds. 

