### PR TITLE
3478 Expose settings.DEBUG in templates and insert noindex in DEBUG

### DIFF
--- a/hydroshare/defaults.py
+++ b/hydroshare/defaults.py
@@ -1,0 +1,11 @@
+# make the DEBUG setting available to templates in hydroshare
+
+from mezzanine.conf import register_setting
+
+register_setting(
+    name="TEMPLATE_ACCESSIBLE_SETTINGS",
+    description=("Sequence of setting names available within templates."),
+    editable=True,
+    default=("DEBUG",),
+    append=True,
+)

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -3,7 +3,7 @@
 {% load pages_tags mezzanine_tags i18n staticfiles theme_tags hydroshare_tags %}
 {% get_site_conf as siteconf %}
 <head>
-
+{% if settings.DEBUG == True %}<meta name="robots" content="noindex">{% endif %}
 <meta http-equiv="Content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width">
 <meta name="keywords" content="{% block meta_keywords %}{% endblock %}">


### PR DESCRIPTION
This addresses #3478 by exposing `settings.DEBUG` in mezzanine templates and then 
generating a `noindex` meta-tag whenever in `DEBUG` mode.
* `hydroshare/defaults.py` adds `DEBUG` to mezzanine `TEMPLATE_ACCESSIBLE_SETTINGS`.
* `theme/templates/base.html` generates a `noindex` directive if `settings.DEBUG` is `True`
* This inserts the tag into every page in HydroShare on a dev server. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. In production (`DEBUG=False`), all page sources appear as usual. 
2. In dev mode (`DEBUG=True`), all page headers contain
```<meta name="robots" content="noindex">```
to prevent google and other indexing of the pages. This is site wide. 
