### PR TITLE
fixed open with button display issue for web apps with appkey extra m…

### DIFF
--- a/hs_tools_resource/app_launch_helper.py
+++ b/hs_tools_resource/app_launch_helper.py
@@ -13,8 +13,8 @@ def resource_level_tool_urls(resource_obj, request_obj):
     resource_level_app_counter = 0
 
     # associate resources with app tools using extended metadata name-value pair with 'appkey' key
-    filterd_res_obj = BaseResource.objects.filter(short_id=resource_obj.short_id,
-                                                  extra_metadata__has_key=tool_app_key).first()
+    filterd_res_obj = BaseResource.objects.exclude(resource_type='ToolResource').filter(
+        short_id=resource_obj.short_id, extra_metadata__has_key=tool_app_key).first()
     if filterd_res_obj:
         # check appkey matching with web app tool resources
         appkey_dict = {tool_app_key: filterd_res_obj.extra_metadata[tool_app_key]}


### PR DESCRIPTION
…etadata

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
This fixes the issue that Open with button shows up on web app resources when an appkey key-value pair is defined as extra metadata for the web app resources. This issue is a regression due to logic changes on the front end with respect to when to display open with button. Fixed this issue by tightening up the backend view function to not return tool list for a web app resource.
