### PR TITLE
revert merge conflict resolution in 4712e160ad1841e72063f1e16687890ac…

### DIFF
--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -17,7 +17,6 @@ from hs_core.tasks import create_bag_by_irods, create_temp_zip, delete_zip
 from hs_core.views.utils import authorize, ACTION_TO_AUTHORIZE
 from . import models as m
 from .icommands import Session, GLOBAL_SESSION
-from hs_core.models import ResourceFile
 from drf_yasg.utils import swagger_auto_schema
 
 import logging
@@ -68,7 +67,8 @@ def download(request, path, rest_call=False, use_async=True, use_reverse_proxy=T
     is_bag_download = False
     is_zip_download = False
     is_zip_request = request.GET.get('zipped', "False").lower() == "true"
-    is_sf_agg_file = False
+    is_aggregation_request = request.GET.get('aggregation', "False").lower() == "true"
+    aggregation_name = None
     is_sf_request = False
 
     if split_path_strs[0] == 'bags':
@@ -113,6 +113,30 @@ def download(request, path, rest_call=False, use_async=True, use_reverse_proxy=T
     irods_output_path = irods_path
     # folder requests are automatically zipped
     if not is_bag_download and not is_zip_download:  # path points into resource: should I zip it?
+        # check for aggregations
+        if is_aggregation_request and res.resource_type == "CompositeResource":
+            prefix = res.short_id + "/data/contents/"
+            if path.startswith(prefix):
+                aggregation_name = path[len(prefix):]
+            aggregation = res.get_aggregation_by_aggregation_name(aggregation_name)
+            if not is_zip_request:
+                download_url = request.GET.get('url_download', 'false').lower()
+                if download_url == 'false':
+                    # redirect to referenced url in the url file instead
+                    if hasattr(aggregation, 'redirect_url'):
+                        return HttpResponseRedirect(aggregation.redirect_url)
+            # point to the main file path
+            path = aggregation.get_main_file.url[len("/resource/"):]
+            is_zip_request = True
+            daily_date = datetime.datetime.today().strftime('%Y-%m-%d')
+            output_path = "zips/{}/{}/{}.zip".format(daily_date, uuid4().hex, path)
+            if res.is_federated:
+                irods_path = os.path.join(res.resource_federation_path, path)
+                irods_output_path = os.path.join(res.resource_federation_path, output_path)
+            else:
+                irods_path = path
+                irods_output_path = output_path
+
         store_path = u'/'.join(split_path_strs[1:])  # data/contents/{path-to-something}
         if res.is_folder(store_path):  # automatically zip folders
             is_zip_request = True
@@ -129,27 +153,6 @@ def download(request, path, rest_call=False, use_async=True, use_reverse_proxy=T
                 logger.debug("request for single file {}".format(path))
             is_sf_request = True
 
-            # check for single file aggregations
-            if "data/contents/" in path:  # not a metadata file
-                for f in ResourceFile.objects.filter(object_id=res.id):
-                    if path == f.storage_path:
-                        is_sf_agg_file = True
-                        if not is_zip_request and f.has_logical_file and \
-                                f.logical_file.is_single_file_aggregation:
-                            download_url = request.GET.get('url_download', 'false').lower()
-                            if download_url == 'false':
-                                # redirect to referenced url in the url file instead
-                                try:
-                                    redirect_url = f.logical_file.redirect_url
-                                except AttributeError:
-                                    redirect_url = None
-                                if redirect_url:
-                                    return HttpResponseRedirect(redirect_url)
-                        if __debug__:
-                            logger.debug(
-                                "request for single file aggregation {}".format(path))
-                        break
-
             if is_zip_request:
                 daily_date = datetime.datetime.today().strftime('%Y-%m-%d')
                 output_path = "zips/{}/{}/{}.zip".format(daily_date, uuid4().hex, path)
@@ -160,7 +163,7 @@ def download(request, path, rest_call=False, use_async=True, use_reverse_proxy=T
 
     # After this point, we have valid path, irods_path, output_path, and irods_output_path
     # * is_zip_request: signals download should be zipped, folders are always zipped
-    # * is_sf_agg_file: path is a single-file aggregation in Composite Resource
+    # * aggregation: aggregation object if the path matches an aggregation
     # * is_sf_request: path is a single-file
     # flags for download:
     # * is_bag_download: download a bag in format bags/{rid}.zip
@@ -201,7 +204,7 @@ def download(request, path, rest_call=False, use_async=True, use_reverse_proxy=T
 
         if use_async:
             task = create_temp_zip.apply_async((res_id, irods_path, irods_output_path,
-                                                is_sf_agg_file, is_sf_request))
+                                                aggregation_name, is_sf_request))
             delete_zip.apply_async((irods_output_path, ),
                                    countdown=(60 * 60 * 24))  # delete after 24 hours
 
@@ -223,7 +226,7 @@ def download(request, path, rest_call=False, use_async=True, use_reverse_proxy=T
 
         else:  # synchronous creation of download
             ret_status = create_temp_zip(res_id, irods_path, irods_output_path,
-                                         is_sf_agg_file, is_sf_request)
+                                         aggregation_name, is_sf_request)
             delete_zip.apply_async((irods_output_path, ),
                                    countdown=(60 * 60 * 24))  # delete after 24 hours
             if not ret_status:

--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -115,9 +115,10 @@ def download(request, path, rest_call=False, use_async=True, use_reverse_proxy=T
     if not is_bag_download and not is_zip_download:  # path points into resource: should I zip it?
         # check for aggregations
         if is_aggregation_request and res.resource_type == "CompositeResource":
-            prefix = res.short_id + "/data/contents/"
+            prefix = res.file_path
             if path.startswith(prefix):
-                aggregation_name = path[len(prefix):]
+                # +1 to remove trailing slash
+                aggregation_name = path[len(prefix)+1:]
             aggregation = res.get_aggregation_by_aggregation_name(aggregation_name)
             if not is_zip_request:
                 download_url = request.GET.get('url_download', 'false').lower()


### PR DESCRIPTION
a merge conflict resolution reverted necessary changes for zipping bags and aggregations.  Without these changes any resources with aggregations won't be able to create a bag nor zip an aggregation. 

This is the merge conflict resolution that is corrected in this PR
https://github.com/hydroshare/hydroshare/commit/4712e160ad1841e72063f1e16687890acea6ed6b