### PR TITLE
[#3564] Show out of sync messages only to users who can edit the resource

### DIFF
--- a/hs_composite_resource/page_processors.py
+++ b/hs_composite_resource/page_processors.py
@@ -15,35 +15,38 @@ def landing_page(request, page):
 
     """
     content_model = page.get_content_model()
-    netcdf_logical_files = content_model.get_logical_files('NetCDFLogicalFile')
-    for lf in netcdf_logical_files:
-        if lf.metadata.is_dirty:
-            msg = "One or more NetCDF files are out of sync with metadata changes."
-            # prevent same message being displayed more than once
-            msg_exists = False
-            storage = get_messages(request)
-            for message in storage:
-                if message.message == msg:
-                    msg_exists = True
-                    break
-            if not msg_exists:
-                messages.info(request, msg)
-            break
 
-    timeseries_logical_files = content_model.get_logical_files('TimeSeriesLogicalFile')
-    for lf in timeseries_logical_files:
-        if lf.metadata.is_dirty:
-            msg = "One or more SQLite files are out of sync with metadata changes."
-            # prevent same message being displayed more than once
-            msg_exists = False
-            storage = get_messages(request)
-            for message in storage:
-                if message.message == msg:
-                    msg_exists = True
-                    break
-            if not msg_exists:
-                messages.info(request, msg)
-            break
+    # These messages are only relevant to users who can edit the resource
+    if request.user.is_authenticated() and request.user.uaccess.can_change_resource_flags(content_model):
+        netcdf_logical_files = content_model.get_logical_files('NetCDFLogicalFile')
+        for lf in netcdf_logical_files:
+            if lf.metadata.is_dirty:
+                msg = "One or more NetCDF files are out of sync with metadata changes."
+                # prevent same message being displayed more than once
+                msg_exists = False
+                storage = get_messages(request)
+                for message in storage:
+                    if message.message == msg:
+                        msg_exists = True
+                        break
+                if not msg_exists:
+                    messages.info(request, msg)
+                break
+
+        timeseries_logical_files = content_model.get_logical_files('TimeSeriesLogicalFile')
+        for lf in timeseries_logical_files:
+            if lf.metadata.is_dirty:
+                msg = "One or more SQLite files are out of sync with metadata changes."
+                # prevent same message being displayed more than once
+                msg_exists = False
+                storage = get_messages(request)
+                for message in storage:
+                    if message.message == msg:
+                        msg_exists = True
+                        break
+                if not msg_exists:
+                    messages.info(request, msg)
+                break
 
     edit_resource = page_processors.check_resource_mode(request)
     context = page_processors.get_page_context(page, request.user, resource_edit=edit_resource,

--- a/hs_composite_resource/page_processors.py
+++ b/hs_composite_resource/page_processors.py
@@ -17,7 +17,7 @@ def landing_page(request, page):
     content_model = page.get_content_model()
 
     # These messages are only relevant to users who can edit the resource
-    if request.user.is_authenticated() and request.user.uaccess.can_change_resource_flags(content_model):
+    if request.user.is_authenticated() and request.user.uaccess.can_change_resource(content_model):
         netcdf_logical_files = content_model.get_logical_files('NetCDFLogicalFile')
         for lf in netcdf_logical_files:
             if lf.metadata.is_dirty:


### PR DESCRIPTION
https://github.com/hydroshare/hydroshare/issues/3564 Adds conditionals to prevent out of sync messages from being shown to anonymous users or users who do not have Edit permission on the resource.
 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a Composite resource and add a .nc file to it so an aggregation is created.
2. Edit the resource and change the NetCDF aggregation metadata to make it out of sync. For example, you can edit the spatial coverage.
3. Refresh the page, and verify that the out of sync message shows up at the top of the page.
4. Verify that this message doesn't show up for anonymous users or users with no Edit permission on the resource.
