### PR TITLE
[#3569] Allow switching timeseries to view metadata in view mode

### DIFF
--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -873,6 +873,16 @@ function showFileTypeMetadata(file_type_time_series, url){
              }
          });
 
+        if (logical_type === 'TimeSeriesLogicalFile') {
+            $("#series_id_file_type").change(function () {
+                var $url = $(this.form).attr('action');
+                $url = $url.replace('series_id', $(this).val());
+                $url = $url.replace('resource_mode', resource_mode);
+                // make a recursive call to this function
+                showFileTypeMetadata(true, $url);
+            });
+        }
+
         if (RESOURCE_MODE === "Edit") {
              $("#lst-tags-filetype").find(".icon-remove").click(onRemoveKeywordFileType);
              $("#id-update-netcdf-file").click(update_netcdf_file_ajax_submit);
@@ -905,13 +915,6 @@ function showFileTypeMetadata(file_type_time_series, url){
                  $endDateElement.css('pointer-events', 'none');
              }
              if (logical_type === 'TimeSeriesLogicalFile') {
-                 $("#series_id_file_type").change(function () {
-                     var $url = $(this.form).attr('action');
-                     $url = $url.replace('series_id', $(this).val());
-                     $url = $url.replace('resource_mode', resource_mode);
-                     // make a recursive call to this function
-                     showFileTypeMetadata(true, $url);
-                 });
                  if ($("#metadata-dirty").val() !== 'True' || $("#can-update-sqlite-file").val() !== 'True'){
                      $("#div-sqlite-file-update").hide();
                  }


### PR DESCRIPTION
Minor script modification to correctly bind select event in resource view mode.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a Composite Resource with a timeseries aggregation that has multiple sites. 
2. Verify that the dropdown listing the timeseries can be used to view metadata for each dropdown item.


