### PR TITLE
[#3558] Add media query overrides for collapse breakpoint

### DIFF
--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1863,6 +1863,85 @@ a.tag:hover {
 	background-color: #333;
 }
 
+/* Media query overrides for bootstrap 3 collapse breakpoint */
+/* Extended from https://stackoverflow.com/a/36289507/3288102 */
+@media (max-width: 992px) {
+	.navbar-right .visible-xs {
+		display: block !important;
+	}
+
+	.container > .navbar-collapse {
+		margin-right: -15px;
+		margin-left: -15px;
+	}
+
+	.navbar-nav {
+		margin: 7.5px -15px;
+	}
+
+	.navbar-right.hidden-xs {
+		display: none !important;
+	}
+
+	.navbar-nav .open .dropdown-menu {
+		position: static;
+		float: none;
+		width: auto;
+		margin-top: 0;
+		background-color: transparent;
+		border: 0;
+		box-shadow: none;
+	}
+
+	.navbar > .container {
+		width: 100%;
+	}
+
+	.navbar-header {
+		float: none;
+	}
+
+	.navbar-left, .navbar-right {
+		float: none !important;
+	}
+
+	.navbar-toggle {
+		display: block;
+	}
+
+	.navbar-collapse {
+		border-top: 1px solid transparent;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+	}
+
+	.navbar-fixed-top {
+		top: 0;
+		border-width: 0 0 1px;
+	}
+
+	.navbar-collapse.collapse {
+		display: none !important;
+	}
+
+	.navbar-nav {
+		float: none !important;
+		margin-top: 7.5px;
+	}
+
+	.navbar-nav > li {
+		float: none;
+	}
+
+	.navbar-nav > li > a {
+		padding-top: 10px;
+		padding-bottom: 10px;
+	}
+
+	.collapse.in {
+		display: block !important;
+	}
+}
+
 @media (max-width: 768px) {
     #sharing-status {
         border-left: 0
@@ -2032,13 +2111,6 @@ a.tag:hover {
   .bs-sidebar.affix-bottom,
   .bs-sidebar.affix {
     width: 360px;
-  }
-}
-
-@media(min-width: 767px) and (max-width: 991px){
-  /* Add extra padding to push down the text */
-  .page-tip {
-    padding: 50px 0px 15px;
   }
 }
 


### PR DESCRIPTION
#3558 These adjustments allow the navbar to collapse at 992px, so that the items don't shift to the bottom, sometimes overlapping page content.

Before: 
------------
![image](https://user-images.githubusercontent.com/4822372/63869572-575ca200-c986-11e9-887b-501d24a19086.png)

After:
------------
![image](https://user-images.githubusercontent.com/2448568/65819055-25cd3580-e1d5-11e9-81fe-b92f9e30aa17.png)



<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
