### PR TITLE
[#3592] Fix rendering issue for comma separated keywords input

### DIFF
--- a/theme/templates/resource-landing-page/subject.html
+++ b/theme/templates/resource-landing-page/subject.html
@@ -29,6 +29,7 @@
                     {% else %}
                         <div id="cv-add-keyword-wrapper" class="input-group">
                             <input v-model="newKeyword" id="txt-keyword" type="text" class="form-control"
+                                   ref="newKeyword"
                                    @keyup.enter="addKeyword('{{ cm.short_id }}')"
                                    placeholder="Examples: Hydrologic_modeling, USU, land use">
                             <span class="input-group-btn">


### PR DESCRIPTION
[#3592 ] Adds a reference attribute to the keywords input to fix an issue where comma separated keywords would not render until page reload.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource
2. Try to add comma separated keywords. I.e: "one, two, three".
3. Verify that all keywords are rendered correctly upon submit and that all subsequent operations work as expected (add, delete)
