### PR TITLE
3623 discovery improvements

### DIFF
--- a/hs_core/management/commands/solr_update.py
+++ b/hs_core/management/commands/solr_update.py
@@ -36,7 +36,15 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
 
-        # a list of resource id's: none does nothing.
+        # Named (optional) arguments
+        parser.add_argument(
+            '--force',
+            action='store_true',  # True for presence, False for absence
+            dest='force',  # value is options['log']
+            help='force refresh for unchanged resources',
+        )
+
+        # a list of resource id's: none acts on everything.
         parser.add_argument('resource_ids', nargs='*', type=str)
 
     def handle(self, *args, **options):
@@ -88,7 +96,8 @@ class Command(BaseCommand):
                 # # This is likely a Haystack bug.
                 # elif ind.should_update(r):
                 # update everything to be safe.
-                    print("{} {} needs SOLR update: updating in index".format(
+                elif options['force']:
+                    print("{} {}: refreshing index (forced)".format(
                           r.short_id, resource.discovery_content_type))
                     ind.update_object(r)
                     django_refreshed += 1

--- a/hs_core/management/commands/solr_update.py
+++ b/hs_core/management/commands/solr_update.py
@@ -87,10 +87,11 @@ class Command(BaseCommand):
                 # # This always returns True whether or not SOLR needs updating
                 # # This is likely a Haystack bug.
                 # elif ind.should_update(r):
-                #     print("{} {} needs SOLR update: updating in index".format(
-                #             r.short_id, resource.discovery_content_type))
-                #     ind.update_object(r)
-                #     refreshed += 1
+                # update everything to be safe.
+                    print("{} {} needs SOLR update: updating in index".format(
+                          r.short_id, resource.discovery_content_type))
+                    ind.update_object(r)
+                    django_refreshed += 1
 
             print("{} resources in Django refreshed in SOLR".format(django_refreshed))
             print("Django contains {} discoverable resources and {} replaced resources"

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3213,7 +3213,7 @@ class BaseResource(Page, AbstractResource):
 
     collections = models.ManyToManyField('BaseResource', related_name='resources')
 
-    discovery_content_type = 'Generic'  # used during discovery
+    discovery_content_type = 'Generic Resource'  # used during discovery
 
     class Meta:
         """Define meta properties for BaseResource model."""
@@ -3494,7 +3494,7 @@ class GenericResource(BaseResource):
         """Return True always."""
         return True
 
-    discovery_content_type = 'Generic'  # used during discovery
+    discovery_content_type = 'Generic Resource'  # used during discovery
 
     class Meta:
         """Define meta properties for GenericResource model."""

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -109,7 +109,9 @@ extension_content_types = {
 
 
 def get_extension_content_types(res):
-    """ return a set of content types matching extensions in a resource """
+    """ return a set of content types matching extensions in a resource.
+        These include content types of logical files, as well as the generic
+        content types 'Document', 'Spreadsheet', 'Presentation'.  """
 
     resource = res.get_content_model()  # enable full logical file interface
 
@@ -118,19 +120,16 @@ def get_extension_content_types(res):
 
     # categorize logical files by type, and files without a logical file by extension.
     for f in resource.files.all():
-        if not f.has_logical_file:
-            candidate_type = 'Generic Data'
-        else:
+        if f.has_logical_file:
             candidate_type = type(f.logical_file).get_discovery_content_type()
-        if candidate_type == "Generic Data":
+            types.add(candidate_type)
+        else:  # collect extensions of files not corresponding to logical metadata
             path = f.short_path
             path = path.split(".")  # determine last extension
             if len(path) > 1:
                 ext = path[len(path)-1]
                 if len(ext) <= 5:  # skip obviously non-MIME extensions
                     exts.add(ext.lower())
-        else:
-            types.add(candidate_type)
 
     # categorize common extensions that are not part of logical files.
     for ext_type in extension_content_types:

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from nameparser import HumanName
 import probablepeople
 from string import maketrans
+from django.conf import settings
 import logging
 import re
 
@@ -100,18 +101,6 @@ def normalize_name(name):
     return normalized.strip()
 
 
-# What extensions indicate each kind of high-level content type
-extension_content_types = {
-    'Document': set(['doc', 'docx', 'pdf', 'odt', 'rtf', 'tex', 'latex']),
-    'Spreadsheet': set(['csv', 'xls', 'xlsx', 'ods']),
-    'Presentation': set(['ppt', 'pptx', 'odp']),
-    'Jupyter Notebook': set(['ipynb']),
-    'Image': set(['gif', 'jpg', 'jpeg', 'tif', 'tiff', 'png']),
-    'Multidimensional (NetCDF)': set(['nc']),
-    'Multidimensional (HDF)': set(['hdf']),
-}
-
-
 def get_content_types(res):
     """ return a set of content types matching extensions in a resource.
         These include content types of logical files, as well as the generic
@@ -139,10 +128,10 @@ def get_content_types(res):
                     exts.add(ext.lower())
 
     # categorize common extensions that are not part of logical files.
-    for ext_type in extension_content_types:
-        if exts & extension_content_types[ext_type]:
+    for ext_type in settings.DISCOVERY_EXTENSION_CONTENT_TYPES:
+        if exts & settings.DISCOVERY_EXTENSION_CONTENT_TYPES[ext_type]:
             types.add(ext_type)
-            exts -= extension_content_types[ext_type]
+            exts -= settings.DISCOVERY_EXTENSION_CONTENT_TYPES[ext_type]
 
     if exts:  # if there is anything left over, then mark as Generic
         types.add('Generic Data')

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -629,8 +629,7 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
         names = []
         if hasattr(obj, 'raccess'):
             for owner in obj.raccess.owners.all():
-                name = normalize_name(owner.first_name.capitalize() +
-                                      ' ' + owner.last_name.capitalize())
+                name = normalize_name(owner.first_name + ' ' + owner.last_name)
                 names.append(name)
         return names
 
@@ -642,8 +641,7 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
         output2 = []
         if hasattr(obj, 'raccess'):
             for owner in obj.raccess.owners.all():
-                name = normalize_name(owner.first_name.capitalize() +
-                                      ' ' + owner.last_name.capitalize())
+                name = normalize_name(owner.first_name + ' ' + owner.last_name)
                 output0.append(name)
 
         if hasattr(obj, 'metadata'):

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -102,10 +102,13 @@ def normalize_name(name):
 
 # What extensions indicate each kind of high-level content type
 extension_content_types = {
-    'Document': set(['doc', 'docx', 'pdf', 'odt', 'rtf']),
+    'Document': set(['doc', 'docx', 'pdf', 'odt', 'rtf', 'tex', 'latex']),
     'Spreadsheet': set(['csv', 'xls', 'xlsx', 'ods']),
     'Presentation': set(['ppt', 'pptx', 'odp']),
-    'Jupyter Notebook': set(['ipynb'])
+    'Jupyter Notebook': set(['ipynb']),
+    'Image': set(['gif', 'jpg', 'jpeg', 'tif', 'tiff', 'png']),
+    'Multidimensional (NetCDF)': set(['nc']),
+    'Multidimensional (HDF)': set(['hdf']),
 }
 
 

--- a/hs_core/search_indexes.py
+++ b/hs_core/search_indexes.py
@@ -137,7 +137,7 @@ def get_extension_content_types(res):
         exts -= set(presentations)
     if exts:
         types.add('Generic Data')
-        return types
+    return types
 
 
 class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
@@ -645,7 +645,7 @@ class BaseResourceIndex(indexes.SearchIndex, indexes.Indexable):
             output = set()
             for f in obj.logical_files:
                 output.add(f.get_discovery_content_type())
-            output += get_extension_content_types(obj)
+            output |= get_extension_content_types(obj)
             if len(output) == 0:
                 output.add("Generic Data")
             return list(output)

--- a/hs_core/tests/api/native/test_content_types.py
+++ b/hs_core/tests/api/native/test_content_types.py
@@ -55,7 +55,7 @@ class TestContentTypes(MockIRODSTestCaseMixin,
             os.remove(f)
 
     def test_generic_data_classification(self):
-        """ a file of type .txt is classified as generic data. """
+        """ files with recognized extensions are classified properly """
         # resource should not have any files at this point
         self.assertEqual(self.res.files.all().count(), 0,
                          msg="resource file count didn't match")

--- a/hs_core/tests/api/native/test_content_types.py
+++ b/hs_core/tests/api/native/test_content_types.py
@@ -49,18 +49,27 @@ class TestContentTypes(MockIRODSTestCaseMixin,
             test_file = open(f, 'w')
             test_file.close()
 
+        # create empty files with non-conforming extensions
+        self.weird_filenames = ['file.foo', 'file.bar']
+        self.weird_extensions = ['foo', 'bar']
+        for f in self.weird_filenames:
+            test_file = open(f, 'w')
+            test_file.close()
+
     def tearDown(self):
         super(TestContentTypes, self).tearDown()
         for f in self.filenames:
             os.remove(f)
+        for f in self.weird_filenames:
+            os.remove(f)
 
-    def test_generic_data_classification(self):
+    def test_file_extension_classification(self):
         """ files with recognized extensions are classified properly """
         # resource should not have any files at this point
         self.assertEqual(self.res.files.all().count(), 0,
                          msg="resource file count didn't match")
 
-        # add one file to the resource
+        # add all files to the resource
         for f in self.filenames:
             test_file_handle = open(f, 'r')
             hydroshare.add_resource_files(self.res.short_id, test_file_handle)
@@ -75,6 +84,92 @@ class TestContentTypes(MockIRODSTestCaseMixin,
                              'Jupyter Notebook']))
 
         self.assertTrue(is_equal_to_as_set(types[1], []))  # no left-over extensions
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)
+
+    def test_pdf_classification(self):
+        """ files with recognized extensions are classified properly """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        # add one file to the resource
+        test_file_handle = open(self.filenames[0], 'r')
+        hydroshare.add_resource_files(self.res.short_id, test_file_handle)
+
+        self.assertEqual(self.res.files.all().count(), 1,
+                         msg="resource file count didn't match")
+
+        types = get_content_types(self.res)
+        self.assertTrue(is_equal_to_as_set(types[0], ['Composite', self.content_types[0]]))
+
+        self.assertTrue(is_equal_to_as_set(types[1], []))  # no left-over extensions
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)
+
+    def test_ppt_classification(self):
+        """ files with recognized extensions are classified properly """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        # add one file to the resource
+        test_file_handle = open(self.filenames[2], 'r')
+        hydroshare.add_resource_files(self.res.short_id, test_file_handle)
+
+        self.assertEqual(self.res.files.all().count(), 1,
+                         msg="resource file count didn't match")
+
+        types = get_content_types(self.res)
+        self.assertTrue(is_equal_to_as_set(types[0], ['Composite', self.content_types[2]]))
+
+        self.assertTrue(is_equal_to_as_set(types[1], []))  # no left-over extensions
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)
+
+    def test_csv_classification(self):
+        """ files with recognized extensions are classified properly """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        # add one file to the resource
+        test_file_handle = open(self.filenames[3], 'r')
+        hydroshare.add_resource_files(self.res.short_id, test_file_handle)
+
+        self.assertEqual(self.res.files.all().count(), 1,
+                         msg="resource file count didn't match")
+
+        types = get_content_types(self.res)
+        self.assertTrue(is_equal_to_as_set(types[0], ['Composite', self.content_types[3]]))
+
+        self.assertTrue(is_equal_to_as_set(types[1], []))  # no left-over extensions
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)
+
+    def test_weird_extensions(self):
+        """ files with unrecognized extensions are classified properly """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        # add all files to the resource
+        for f in self.weird_filenames:
+            test_file_handle = open(f, 'r')
+            hydroshare.add_resource_files(self.res.short_id, test_file_handle)
+
+        self.assertEqual(self.res.files.all().count(), 2,
+                         msg="resource file count didn't match")
+
+        types = get_content_types(self.res)
+        # no extensions match content types
+        self.assertTrue(is_equal_to_as_set(types[0], ['Composite', 'Generic Data']))
+        # extensions are flagged as not matching
+        self.assertTrue(is_equal_to_as_set(types[1], self.weird_extensions))
 
         # delete resources to clean up
         hydroshare.delete_resource(self.res.short_id)

--- a/hs_core/tests/api/native/test_content_types.py
+++ b/hs_core/tests/api/native/test_content_types.py
@@ -1,0 +1,80 @@
+# Test discovery content types as inferred from resource contents.
+import os
+
+from django.test import TransactionTestCase
+from django.contrib.auth.models import Group
+
+from hs_core import hydroshare
+from hs_core.testing import MockIRODSTestCaseMixin, TestCaseCommonUtilities
+from hs_core.search_indexes import get_content_types
+
+
+def is_equal_to_as_set(l1, l2):
+    """ return true if two lists contain the same content
+    :param l1: first list
+    :param l2: second list
+    :return: whether lists match
+    """
+    # Note specifically that set(l1) == set(l2) does not work as expected.
+    return len(set(l1) & set(l2)) == len(set(l1)) and \
+           len(set(l1) | set(l2)) == len(set(l1))
+
+
+class TestContentTypes(MockIRODSTestCaseMixin,
+                       TestCaseCommonUtilities, TransactionTestCase):
+    def setUp(self):
+        super(TestContentTypes, self).setUp()
+        self.hydroshare_author_group, _ = Group.objects.get_or_create(name='Hydroshare Author')
+        # create a user to be used for creating the resource
+        self.user = hydroshare.create_account(
+            'creator@usu.edu',
+            username='creator',
+            first_name='Creator_FirstName',
+            last_name='Creator_LastName',
+            superuser=False,
+            groups=[]
+        )
+
+        self.res = hydroshare.create_resource(
+            'CompositeResource',
+            self.user,
+            'My Test Resource'
+        )
+
+        # create empty files with appropriate extensions
+        self.filenames = ['file.pdf', 'file.doc', 'file.ppt', 'file.csv', 'file.ipynb']
+        self.content_types = ['Document', 'Document', 'Presentation', 'Spreadsheet',
+                              'Jupyter Notebook']
+        for f in self.filenames:
+            test_file = open(f, 'w')
+            test_file.close()
+
+    def tearDown(self):
+        super(TestContentTypes, self).tearDown()
+        for f in self.filenames:
+            os.remove(f)
+
+    def test_generic_data_classification(self):
+        """ a file of type .txt is classified as generic data. """
+        # resource should not have any files at this point
+        self.assertEqual(self.res.files.all().count(), 0,
+                         msg="resource file count didn't match")
+
+        # add one file to the resource
+        for f in self.filenames:
+            test_file_handle = open(f, 'r')
+            hydroshare.add_resource_files(self.res.short_id, test_file_handle)
+
+        self.assertEqual(self.res.files.all().count(), 5,
+                         msg="resource file count didn't match")
+
+        types = get_content_types(self.res)
+        self.assertTrue(is_equal_to_as_set(
+                            types[0],
+                            ['Composite', 'Document', 'Presentation', 'Spreadsheet',
+                             'Jupyter Notebook']))
+
+        self.assertTrue(is_equal_to_as_set(types[1], []))  # no left-over extensions
+
+        # delete resources to clean up
+        hydroshare.delete_resource(self.res.short_id)

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -696,6 +696,17 @@ HSWS_ACTIVATED = False
 
 COMMUNITIES_ENABLED = False
 
+# Categorization in discovery of content types 
+# according to file extension of otherwise unaggregated files. 
+DISCOVERY_EXTENSION_CONTENT_TYPES = { 
+    'Document': set(['doc', 'docx', 'pdf', 'odt', 'rtf', 'tex', 'latex']),
+    'Spreadsheet': set(['csv', 'xls', 'xlsx', 'ods']),
+    'Presentation': set(['ppt', 'pptx', 'odp']),
+    'Jupyter Notebook': set(['ipynb']),
+    'Image': set(['gif', 'jpg', 'jpeg', 'tif', 'tiff', 'png']),
+    'Multidimensional (NetCDF)': set(['nc'])
+} 
+
 ####################################
 # DO NOT PLACE SETTINGS BELOW HERE #
 ####################################


### PR DESCRIPTION
1. Don't mangle names of organzations, e.g., "CZO Luquillo" stays as it is when used as an owner. 
2. Arrange for solr_update to refresh all records, not just non-existent ones.
3. Categorize the contained content type of composite resources containing files that correspond to common MIME file types -- and are otherwise undocumented by aggregations -- as higher-level characterizations `Document`, `Spreadsheet`, or `Presentation`, respectively. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. In names of users, organizations -- e.g., "CZO Luquillo" -- are not mangled by discover page after re-indexing. Owners show up as "First Last" rather than "Last, First".
2. Create a resource containing a `.csv`. Discovery by content type lists it as containing a`Spreadsheet`.
3, Create a resource with a `.doc` or `.pdf` file. Discover by content type lists it as containing a `Document`. 
4. Create a resource containing a `.ppt` or `.pptx` file. Discovery by content type lists it as containing a `Presentation`. 
 5. Refreshing the index with management command `solr_update --force` updates all records, in case any are stale.