### PR TITLE
3625 bulk add owner

### DIFF
--- a/hs_core/management/commands/add_owner.py
+++ b/hs_core/management/commands/add_owner.py
@@ -1,0 +1,32 @@
+""" Add an owner to a resource or resources
+"""
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from hs_core.hydroshare.utils import get_resource_by_shortkey
+from hs_access_control.models.privilege import UserResourcePrivilege, PrivilegeCodes
+
+
+class Command(BaseCommand):
+    help = "add owner to resource"
+
+    def add_arguments(self, parser):
+
+        parser.add_argument('new_owner', type=str)
+        # a list of resource id's: none does nothing.
+        parser.add_argument('resource_ids', nargs='*', type=str)
+
+    def handle(self, *args, **options):
+        user = User.objects.get(username=options['new_owner'])
+        admin = User.objects.get(username='admin')
+
+        if len(options['resource_ids']) > 0:  # an array of resource short_id to check.
+
+            for rid in options['resource_ids']:
+                resource = get_resource_by_shortkey(rid)
+                UserResourcePrivilege.share(user=user,
+                                            resource=resource,
+                                            privilege=PrivilegeCodes.OWNER,
+                                            grantor=admin)
+        else:
+            print("No resource list specified.")

--- a/hs_core/management/commands/add_owner.py
+++ b/hs_core/management/commands/add_owner.py
@@ -5,6 +5,7 @@ Usage: add_owner {username} {resource list}
 
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
+from hs_core.models import BaseResource
 from hs_core.hydroshare.utils import get_resource_by_shortkey
 from hs_access_control.models.privilege import UserResourcePrivilege, PrivilegeCodes
 
@@ -15,12 +16,30 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
 
         parser.add_argument('new_owner', type=str)
+
+        parser.add_argument(
+            '--owned_by',
+            dest='owned_by',
+            help='prior owner of the resources'
+        )
+
         # a list of resource id's: none does nothing.
         parser.add_argument('resource_ids', nargs='*', type=str)
 
     def handle(self, *args, **options):
         user = User.objects.get(username=options['new_owner'])
         admin = User.objects.get(username='admin')
+
+        if options['owned_by'] is not None:
+            prior = User.objects.get(username=options['owned_by'])
+            for res in BaseResource.objects.filter(r2urp__user=prior,
+                                                   r2urp__privilege=PrivilegeCodes.OWNER):
+                resource = get_resource_by_shortkey(res.short_id)
+                UserResourcePrivilege.share(user=user,
+                                            resource=resource,
+                                            privilege=PrivilegeCodes.OWNER,
+                                            grantor=admin)
+                print("added owner {} to {}".format(options['new_owner'], resource.short_id))
 
         if len(options['resource_ids']) > 0:  # an array of resource short_id to check.
 
@@ -31,5 +50,3 @@ class Command(BaseCommand):
                                             privilege=PrivilegeCodes.OWNER,
                                             grantor=admin)
                 print("added owner {} to {}".format(options['new_owner'], rid))
-        else:
-            print("No resource list specified.")

--- a/hs_core/management/commands/add_owner.py
+++ b/hs_core/management/commands/add_owner.py
@@ -1,4 +1,6 @@
 """ Add an owner to a resource or resources
+
+Usage: add_owner {username} {resource list}
 """
 
 from django.core.management.base import BaseCommand
@@ -28,5 +30,6 @@ class Command(BaseCommand):
                                             resource=resource,
                                             privilege=PrivilegeCodes.OWNER,
                                             grantor=admin)
+                print("added owner {} to {}".format(options['new_owner'], rid))
         else:
             print("No resource list specified.")


### PR DESCRIPTION
New management command `add_owner`
```
python manage.py add_owner dtarb 5d53e61cb25f4b89a7a28bd38ec01f6b
```
makes David an owner of one of my test resources. 'admin' is listed as the grantor. 
```
python manage.py add_owner --owned_by=alvacouch dtarb
```
makes *all* resources owned by `alvacouch` also owned by `dtarb`.

1. This command works even with resources that have no owner, and can be used to fix ownership botches. 
2. The command is idempotent: adding an owner who is already an owner does nothing. 
3. option --set_quota_holder sets the quota holder to the new owner. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Run management command `python manage.py add_owner {username} {resource}`, display resource, verify that new owner has been added. 
2. Repeat management command exactly. Should do nothing. 
3. Add `--set_quota_holder`, verify that quota holder has changed.
4. Make up a resource owned by a specific user {user}, then run `python manage.py add_owner --owned_by={user} {new_owner} {resource}`. Should add an owner to all of the resources owned by {user}.   
