### PR TITLE
Hydro flower

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hydroshare/hs_docker_base:release-1.9.9
+FROM hydroshare/hs_docker_base:hydro-flower
 MAINTAINER Phuong Doan pdoan@cuahsi.org
 
 # inplaceedit in pip doesn't seem compatible with Django 1.11 yet...

--- a/config/hydroshare-config.yaml
+++ b/config/hydroshare-config.yaml
@@ -51,7 +51,7 @@ IRODS_USER_URI: irods-user
 IRODS_CACHE_URI: irods-cache
 
 # sets the concurrency of the celery worker
-CELERY_CONCURRENCY = 4
+CELERY_CONCURRENCY: 4
 
 ### REQUIRES BLANK LINE AFTER LAST VARIABLE DEFINITION ###
 

--- a/config/hydroshare-config.yaml
+++ b/config/hydroshare-config.yaml
@@ -50,5 +50,8 @@ IRODS_DATA_URI: irods-data
 IRODS_USER_URI: irods-user
 IRODS_CACHE_URI: irods-cache
 
+# sets the concurrency of the celery worker
+CELERY_CONCURRENCY = 4
+
 ### REQUIRES BLANK LINE AFTER LAST VARIABLE DEFINITION ###
 

--- a/hsctl
+++ b/hsctl
@@ -202,6 +202,7 @@ preflight_hs() {
     cp -rf ${HS_PATH}/scripts/templates/init-hydroshare.template ${HS_PATH}/init-hydroshare
     sed -i $SED_EXT 's!HS_SERVICE_UID!'${HS_SERVICE_UID}'!g' ${HS_PATH}/init-hydroshare
     sed -i $SED_EXT 's!HS_SERVICE_GID!'${HS_SERVICE_GID}'!g' ${HS_PATH}/init-hydroshare
+    sed -i $SED_EXT 's!CELERY_CONCURRENCY!'${CELERY_CONCURRENCY}'!g' ${HS_PATH}/init-hydroshare
     if [ "${USE_SSL}" = true ]; then
         if [ "${USE_NGINX}" = false ]; then
             echo "ERROR: Invalid USE_NGINX setting for USE_SSL = true in hydroshare-config.yaml"

--- a/hsctl
+++ b/hsctl
@@ -202,7 +202,6 @@ preflight_hs() {
     cp -rf ${HS_PATH}/scripts/templates/init-hydroshare.template ${HS_PATH}/init-hydroshare
     sed -i $SED_EXT 's!HS_SERVICE_UID!'${HS_SERVICE_UID}'!g' ${HS_PATH}/init-hydroshare
     sed -i $SED_EXT 's!HS_SERVICE_GID!'${HS_SERVICE_GID}'!g' ${HS_PATH}/init-hydroshare
-    sed -i $SED_EXT 's!CELERY_CONCURRENCY!'${CELERY_CONCURRENCY}'!g' ${HS_PATH}/init-hydroshare
     if [ "${USE_SSL}" = true ]; then
         if [ "${USE_NGINX}" = false ]; then
             echo "ERROR: Invalid USE_NGINX setting for USE_SSL = true in hydroshare-config.yaml"
@@ -235,6 +234,7 @@ preflight_hs() {
     cp -rf ${HS_PATH}/scripts/templates/init-defaultworker.template ${HS_PATH}/init-defaultworker
     sed -i $SED_EXT 's!HS_SERVICE_UID!'${HS_SERVICE_UID}'!g' ${HS_PATH}/init-defaultworker
     sed -i $SED_EXT 's!HS_SERVICE_GID!'${HS_SERVICE_GID}'!g' ${HS_PATH}/init-defaultworker
+    sed -i $SED_EXT 's!CELERY_CONCURRENCY!'${CELERY_CONCURRENCY}'!g' ${HS_PATH}/init-defaultworker
     # Check security settings
     if [ "${USE_SECURITY}" = true ]; then
         sed -i $SED_EXT 's/\<USE_SECURITY = False\>/USE_SECURITY = True/g' ${HS_PATH}/hydroshare/settings.py

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -696,6 +696,8 @@ HSWS_ACTIVATED = False
 
 COMMUNITIES_ENABLED = False
 
+CELERY_CONCURRENCY = 4
+
 ####################################
 # DO NOT PLACE SETTINGS BELOW HERE #
 ####################################

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -699,9 +699,6 @@ HSWS_ACTIVATED = False
 
 COMMUNITIES_ENABLED = False
 
-# sets the concurrency of the celery worker
-CELERY_CONCURRENCY = 4
-
 FRESHLY_ASSETS_EXTENTIONS = [
      'css', 'js'
  ]

--- a/scripts/templates/docker-compose.template
+++ b/scripts/templates/docker-compose.template
@@ -64,6 +64,8 @@ defaultworker:
     POSTGIS_DB: postgres
     PGPASSWORD: postgres
     C_FORCE_ROOT: 1
+  ports:
+    - "5555:5555"
   volumes_from:
     - hydroshare
   volumes:

--- a/scripts/templates/init-defaultworker.template
+++ b/scripts/templates/init-defaultworker.template
@@ -9,6 +9,6 @@ userdel hydro-service \
  && chmod -R 3777 /hs_tmp /shared_tmp /tmp 
 
 celery beat -A hydroshare -s /hydroshare/celery/celerybeat-schedule &
-celery worker -A hydroshare -E -Q default --concurrency=4 &
+celery worker -A hydroshare -E -Q default --concurrency=CELERY_CONCURRENCY &
 celery flower --address=0.0.0.0 --broker=amqp://guest:guest@rabbitmq:5672//
 

--- a/scripts/templates/init-defaultworker.template
+++ b/scripts/templates/init-defaultworker.template
@@ -9,4 +9,6 @@ userdel hydro-service \
  && chmod -R 3777 /hs_tmp /shared_tmp /tmp 
 
 celery beat -A hydroshare -s /hydroshare/celery/celerybeat-schedule &
-celery worker -A hydroshare -E -Q default
+celery worker -A hydroshare -E -Q default --concurrency=4 &
+celery flower --address=0.0.0.0 --broker=amqp://guest:guest@rabbitmq:5672//
+


### PR DESCRIPTION
You can see an example of flower running on hydroshare (I like to call it hydro flower) at http://dev-hs-1.cuahsi.org:8080/

Flower runs on port 5555 and will only be accessible via vpn.  For testing, @phuongdm added a firewall rule for dev-hs-1 to map 5555 with the port 8080, allowing us to browse without being on the vpn.  This rule will not and should not be added to the production environment.  Developers may choose to expose flower on there dev machines.

This PR also starts celery with a concurrency of 4.