### PR TITLE
Add group object to unauthenticated output.

### DIFF
--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -1833,17 +1833,19 @@ class GroupView(TemplateView):
             g.join_request = g.gaccess.group_membership_requests.filter(invitation_to=u).first()
 
             return {
-                'profile_user': u,
                 'group': g,
                 'view_users': g.gaccess.get_users_with_explicit_access(PrivilegeCodes.VIEW),
                 'group_resources': group_resources,
                 'add_view_user_form': AddUserForm(),
-                'communities_enabled': settings.COMMUNITIES_ENABLED
+                'communities_enabled': settings.COMMUNITIES_ENABLED,
+                'profile_user': u
             }
         else:
-            public_group_resources = [r for r in group_resources if r.raccess.public]
+            public_group_resources = [r for r in group_resources 
+                                      if r.raccess.public or r.raccess.discoverable]
 
             return {
+                'group': g,
                 'view_users': g.gaccess.get_users_with_explicit_access(PrivilegeCodes.VIEW),
                 'group_resources': public_group_resources,
                 'add_view_user_form': AddUserForm(),


### PR DESCRIPTION
This fixes a bug in the CZO code. Somehow the group object wasn't being passed to the template when the user was unauthenticated. This means things couldn't be fetched from the user profile. 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Browse to group with an image in unauthenticated mode. Image should appear. Browse in authenticated mode. Image should be the same. 
