### PR TITLE
Serialize add_owner database updates with transactions.

### DIFF
--- a/hs_core/management/commands/add_owner.py
+++ b/hs_core/management/commands/add_owner.py
@@ -9,6 +9,7 @@ from hs_core.models import BaseResource
 from hs_core.hydroshare.utils import get_resource_by_shortkey
 from hs_access_control.models.privilege import UserResourcePrivilege, PrivilegeCodes
 from django_irods.icommands import SessionException
+from django.db import transaction
 
 
 def set_quota_holder(resource, user):
@@ -61,27 +62,29 @@ class Command(BaseCommand):
             prior = User.objects.get(username=options['owned_by'])
             for res in BaseResource.objects.filter(r2urp__user=prior,
                                                    r2urp__privilege=PrivilegeCodes.OWNER):
-                resource = get_resource_by_shortkey(res.short_id)
-                UserResourcePrivilege.share(user=user,
-                                            resource=resource,
-                                            privilege=PrivilegeCodes.OWNER,
-                                            grantor=admin)
-                print("added owner {} to {}".format(options['new_owner'], resource.short_id))
-                if options['set_quota_holder']:
-                    set_quota_holder(resource, user)
-                    print("set quota holder to {} for {}".format(options['new_owner'],
-                          resource.short_id))
+                with transaction.atomic():
+                    resource = res.get_content_model()
+                    UserResourcePrivilege.share(user=user,
+                                                resource=resource,
+                                                privilege=PrivilegeCodes.OWNER,
+                                                grantor=admin)
+                    print("added owner {} to {}".format(options['new_owner'], resource.short_id))
+                    if options['set_quota_holder']:
+                        set_quota_holder(resource, user)
+                        print("set quota holder to {} for {}".format(options['new_owner'],
+                              resource.short_id))
 
         if len(options['resource_ids']) > 0:  # an array of resource short_id to check.
 
             for rid in options['resource_ids']:
-                resource = get_resource_by_shortkey(rid)
-                UserResourcePrivilege.share(user=user,
-                                            resource=resource,
-                                            privilege=PrivilegeCodes.OWNER,
-                                            grantor=admin)
-                print("added owner {} to {}".format(options['new_owner'], rid))
-                if options['set_quota_holder']:
-                    set_quota_holder(resource, user)
-                    print("set quota holder to {} for {}".format(options['new_owner'],
-                          resource.short_id))
+                resource = get_resource_by_shortkey(rid, or_404=False)
+                with transaction.atomic():
+                    UserResourcePrivilege.share(user=user,
+                                                resource=resource,
+                                                privilege=PrivilegeCodes.OWNER,
+                                                grantor=admin)
+                    print("added owner {} to {}".format(options['new_owner'], rid))
+                    if options['set_quota_holder']:
+                        set_quota_holder(resource, user)
+                        print("set quota holder to {} for {}".format(options['new_owner'],
+                              resource.short_id))


### PR DESCRIPTION
The add_owner script previously trashed the PostgreSQL server due to a PostgreSQL misconfiguration. 
This fixes that, by serializing the updates and prohibiting the fast parallel updates that swamped the server. 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. add owner of czo_national to czo_boulder resources doesn't crash PostgreSQL. :)
