### PR TITLE
update local dev to use 9.4.7 postgres image

### DIFF
--- a/Dockerfile-postgis
+++ b/Dockerfile-postgis
@@ -1,3 +1,3 @@
-FROM hydroshare/hs_postgres:9.5.0
+FROM hydroshare/hs_postgres:9.4.7
 
 COPY ./pg.development.sql /app/pg.development.sql

--- a/local-dev.yml
+++ b/local-dev.yml
@@ -80,7 +80,7 @@ services:
     stdin_open: true
     tty: true
   postgis:
-    image: hydroshare/hs_postgres:9.5.0
+    image: hydroshare/hs_postgres:9.4.7
     container_name: postgis
     hostname: postgis
     volumes:


### PR DESCRIPTION
9.5.0 has been removed and was only used by the local dev setup... This change updates local dev configuration to use 9.4.7