### PR TITLE
add check in solr_update for None metadata

### DIFF
--- a/hs_core/management/commands/solr_update.py
+++ b/hs_core/management/commands/solr_update.py
@@ -80,6 +80,9 @@ class Command(BaseCommand):
             for r in dqs:
                 resource = get_resource_by_shortkey(r.short_id)
                 repl = False
+                if hasattr(resource, 'metadata') and resource.metadata is None:
+                    print("skipping {} resource in Django, metadata is None".format(r.short_id))
+                    continue
                 if hasattr(resource, 'metadata') and resource.metadata is not None:
                     repl = resource.metadata.relations.filter(type='isReplacedBy').exists()
                 if not repl:


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [NA] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [NA] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Run the solr_update management command against a recent production data copy.  Confirm the command runs successfully and the "skipping <resource_id> resource in Django, metadata is None" message shows for 2 or 3 resources.