### PR TITLE
Support unauthenticated use case

### DIFF
--- a/hs_communities/views/communities.py
+++ b/hs_communities/views/communities.py
@@ -38,8 +38,11 @@ class CommunityView(TemplateView):
 
         groups = sorted(groups, key=lambda key: key['name'])
 
-        u = User.objects.get(pk=self.request.user.id)
-        is_admin = u.username == 'czo_national'
+        try:
+            u = User.objects.get(pk=self.request.user.id)
+            is_admin = u.username == 'czo_national'
+        except:
+            is_admin = False
 
         return {
             'community_resources': community_resources,


### PR DESCRIPTION
Current develop branch does not support unauthenticated use case. This allows unauthenticated users to view Public Communities, while also determining that the Admin tab should not display for those users.

Manual Verification:
Log out go to Communities page