### PR TITLE
Community landing page for owner and unauthenticated user

### DIFF
--- a/hs_communities/views/communities.py
+++ b/hs_communities/views/communities.py
@@ -42,9 +42,10 @@ class CommunityView(TemplateView):
         try:
             u = User.objects.get(pk=self.request.user.id)
             # user must own the community to get admin privilege
-            is_admin = UserCommunityPrivilege(user=u,
-                                              community=community,
-                                              privilege=PrivilegeCodes.OWNER).exists()
+            is_admin = UserCommunityPrivilege.objects.filter(user=u,
+                                                             community=community,
+                                                             privilege=PrivilegeCodes.OWNER)\
+                                                     .exists()
         except:
             is_admin = False
 

--- a/hs_communities/views/communities.py
+++ b/hs_communities/views/communities.py
@@ -11,6 +11,7 @@ from django.views.generic import TemplateView
 
 from hs_access_control.management.utilities import community_from_name_or_id
 from hs_access_control.models.community import Community
+from hs_access_control.models.privilege import UserCommunityPrivilege, PrivilegeCodes
 from hs_communities.models import Topic
 
 
@@ -40,7 +41,10 @@ class CommunityView(TemplateView):
 
         try:
             u = User.objects.get(pk=self.request.user.id)
-            is_admin = u.username == 'czo_national'
+            # user must own the community to get admin privilege
+            is_admin = UserCommunityPrivilege(user=u,
+                                              community=community,
+                                              privilege=PrivilegeCodes.OWNER).exists()
         except:
             is_admin = False
 

--- a/hs_communities/views/communities.py
+++ b/hs_communities/views/communities.py
@@ -38,8 +38,11 @@ class CommunityView(TemplateView):
 
         groups = sorted(groups, key=lambda key: key['name'])
 
-        u = User.objects.get(pk=self.request.user.id)
-        is_admin = u.username == 'czo_national'
+        try:
+            u = User.objects.get(pk=self.request.user.id)
+            is_admin = u.username == 'czo_national'
+        except:
+            is_admin = False
 
         return {
             'community_resources': community_resources,


### PR DESCRIPTION
This simple PR adds the "admin" tab to the community page of any community owner. Additionally, it allows users who are not logged in to browse community data. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
Login as community owner. Admin tab should be shown. 
Go to community page without login. Tab should not be shown. 
Go to community page as non-owner. Tab should not be shown. 