### PR TITLE
Add --owned_by option to list_resources to debug CZO resources

### DIFF
--- a/hs_core/management/commands/list_resources.py
+++ b/hs_core/management/commands/list_resources.py
@@ -6,8 +6,10 @@
 """
 
 from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
 from hs_core.models import BaseResource
 from hs_core.hydroshare.utils import get_resource_by_shortkey
+from hs_access_control.models import PrivilegeCodes
 
 
 def has_subfolders(resource):
@@ -81,10 +83,23 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
+            '--owned_by',
+            dest='owned_by',
+            help='limit to resources owned by specific user'
+        )
+
+        parser.add_argument(
             '--has_subfolders',
             action='store_true',  # True for presence, False for absence
             dest='has_subfolders',  # value is options['has_subfolders']
-            help='limit to resources with subfolders',
+            help='limit to resources with subfolders'
+        )
+
+        parser.add_argument(
+            '--brief',
+            action='store_true',  # True for presence, False for absence
+            dest='brief',  # value is options['brief']
+            help='create brief listing (resource id only)'
         )
 
     def measure_filtered_resource(self, resource, options):
@@ -95,13 +110,22 @@ class Command(BaseCommand):
            (options['access'] != 'private' or not resource.raccess.discoverable) and \
            (not options['has_subfolders'] or has_subfolders(resource)):
             storage = resource.get_irods_storage()
-            if storage.exists(resource.root_path):
-                measure_resource(resource.short_id)
+            if options['brief']:
+                print(resource.short_id)
             else:
-                print("{} does not exist in iRODS".format(resource.short_id))
+                if storage.exists(resource.root_path):
+                    measure_resource(resource.short_id)
+                else:
+                    print("{} does not exist in iRODS".format(resource.short_id))
 
     def handle(self, *args, **options):
-        if len(options['resource_ids']) > 0:  # an array of resource short_id to check.
+        if options['owned_by'] is not None:
+            owner = User.objects.get(username=options['owned_by'])
+            for r in BaseResource.objects.filter(r2urp__user=owner,
+                                                 r2urp__privilege=PrivilegeCodes.OWNER):
+                self.measure_filtered_resource(r, options)
+
+        elif len(options['resource_ids']) > 0:  # an array of resource short_id to check.
             for rid in options['resource_ids']:
                 resource = get_resource_by_shortkey(rid)
                 self.measure_filtered_resource(resource, options)


### PR DESCRIPTION
There are a number of operations that need to be done on CZO resources. Notably, they aren't being discovered properly. This allows one to list them for use in other commands. For example
```
python manage.py list_resources --brief --owned_by czo_national
```
creates a list of resource ids that can be fed into another command to accomplish things like: 
```
python manage.py repair_solr `python manage.py list_resources --brief --owned_by czo_national`
```
which will try to repair all of them in SOLR. Additionally, 
```
python manage.py prepare_solr `python manage.py list_resources --brief --owned_by czo_national`
```
reports bugs in SOLR preparation code that are not reported by the script above. 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
After running the commands above, CZO resources are visible in discovery. 

