### PR TITLE
[#3629] Improve Collaborate page layout

### DIFF
--- a/hs_core/templates/pages/groups-authenticated.html
+++ b/hs_core/templates/pages/groups-authenticated.html
@@ -49,6 +49,8 @@
                                 </div>
                                 <div class="group-description"><p>{{ group.gaccess.description|linebreaks }}</p></div>
 
+                                <div class="spacer"></div>
+
                                 <div class="text-center group-thumbnail-footer">
                                     {% if group.gaccess.public %}
                                         <div class="users-joined height-fix">

--- a/hs_core/templates/pages/groups-unauthenticated.html
+++ b/hs_core/templates/pages/groups-unauthenticated.html
@@ -51,6 +51,8 @@
                                     <div class="group-description"><p>{{ group.gaccess.description|linebreaks }}</p>
                                     </div>
 
+                                    <div class="spacer"></div>
+
                                     <div class="text-center group-thumbnail-footer">
                                         {% if group.gaccess.public %}
                                             <div class="users-joined height-fix">

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3749,13 +3749,19 @@ button.no-style:focus {
 }
 
 .group-thumbnail {
-	display: block;
 	padding: 4px;
 	margin-bottom: 20px;
 	line-height: 1.42857143;
 	background-color: #fff;
 	border: 1px solid #ddd;
 	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+div.group-thumbnails {
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .group-container {
@@ -3768,7 +3774,14 @@ button.no-style:focus {
 }
 
 .group-caption {
-    padding: 10px;
+	padding: 10px;
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+}
+
+.spacer {
+	flex: 1 1 auto;
 }
 
 .users-joined {
@@ -3966,9 +3979,6 @@ button.no-style:focus {
 }
 
 .group-thumbnail-footer {
-	padding-top: 10px;
-	position: absolute;
-	bottom: 14px;
 }
 
 .group-thumbnail-footer .btn-ask-to-join {

--- a/theme/static/js/collaborate.js
+++ b/theme/static/js/collaborate.js
@@ -53,28 +53,6 @@ function act_on_request_ajax_submit() {
     return false;
 }
 
-// Makes all group preview containers have the same height.
-function fixViewPort(current) {
-    if (!current) {
-        return;
-    }
-
-    $('.group-thumbnails').find('div.group-container').height("initial");   // Reset height
-
-    var containers = $('.group-thumbnails').find('div.group-container');
-
-    var maxHeight = 0;
-    for (var i = 0; i < containers.length; i++) {
-        maxHeight = Math.max($(containers[i]).height() + $(containers[i]).find(".group-thumbnail-footer").height(), maxHeight);
-    }
-
-    // set to new max height
-    for (var i = 0; i < containers.length; i++) {
-        $(containers[i]).height(maxHeight);
-        $(containers[i]).find(".group-thumbnail-footer").width($(containers[i]).find(".group-description").width())
-    }
-}
-
 // File name preview for picture field, change method
 $(document).on('change', '.btn-file :file', function () {
     var input = $(this);
@@ -126,19 +104,3 @@ function show_not_found(searchString) {
     let not_found_message = "We couldn't find anything for <strong>" + searchString + "</strong>.";
     $("#id-Group-Search-Result-Msg").html(not_found_message);
 }
-
-
-// Uses bootstrap toolkit to trigger FixViewPort on bootstrap responsive breakpoints
-(function ($, viewport) {
-    $(document).ready(function () {
-        // Executes when page loads
-        fixViewPort(viewport.current());
-
-        // Executes each time window size changes
-        $(window).resize(
-            viewport.changed(function () {
-                fixViewPort(viewport.current());
-            })
-        );
-    });
-})(jQuery, ResponsiveBootstrapToolkit);

--- a/theme/templates/pages/group.html
+++ b/theme/templates/pages/group.html
@@ -404,8 +404,10 @@
                                         <div class="panel-body">
                                             <div class="list-group">
                                                 <ul class="list-group inputs-group">
-                                                    <i class="list-group-item no-items-found">No resources have been
-                                                        shared with this group yet.</i>
+                                                    <i class="list-group-item no-items-found">
+                                                        <h5>No resources have been
+                                                        shared with this group yet.</h5>
+                                                    </i>
                                                 </ul>
                                             </div>
 


### PR DESCRIPTION
#3629 Makes use of CSS flex to correctly display group cards at all times in Collaborate page.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Go to the Find Groups page
2. Clear your browser's cache so that group images get loaded upon next refresh.
3. Refresh the page and confirm that while it's loading all group cards are displayed correctly and their content does not overlap.

