### PR TITLE
[#3534] Improve conditional to prevent comparing group ids against user ids

### DIFF
--- a/theme/static/js/hs-vue/manage-access-app.js
+++ b/theme/static/js/hs-vue/manage-access-app.js
@@ -142,7 +142,7 @@ let manageAccessApp = new Vue({
             }
 
             ddClass.disabled = !ddClass.active && (ddClass.disabled || user.access === 'owner' &&
-                this.hasOnlyOneOwner || user.id === this.quotaHolder.id);
+                this.hasOnlyOneOwner || user.user_type === 'user' && user.id === this.quotaHolder.id);
 
             return ddClass;
         },

--- a/theme/templates/includes/access-row.html
+++ b/theme/templates/includes/access-row.html
@@ -1,7 +1,7 @@
 {% load hydroshare_tags %}
 
 <tr v-for="(user, index) in this.users" v-bind:key="user.id"
-    :class="{ 'hide-actions': selfAccessLevel !== 'owner' && (user.access === 'owner' && hasOnlyOneOwner || user.id === quotaHolder.id), loading: user.loading}">
+    :class="{ 'hide-actions': selfAccessLevel !== 'owner' && (user.access === 'owner' && hasOnlyOneOwner || user.user_type === 'user' && user.id === quotaHolder.id), loading: user.loading}">
     <td>
         <table class="user-scope">
             <tr v-if="user.user_type === 'user'">

--- a/theme/templates/resource-landing-page/manage-access.html
+++ b/theme/templates/resource-landing-page/manage-access.html
@@ -62,6 +62,7 @@
                     <div class="panel-heading">
                         <h3 class="panel-title">Give access</h3>
                     </div>
+
                     <div id="div-invite-people" class="panel-body">
                         <div id="invite-flag" class="btn-group space-bottom" role="group"
                              aria-label="Share with users or groups">
@@ -74,7 +75,6 @@
                                     @click="isInviteUsers = false; if (selectedAccess === 'owner') {selectedAccess = 'view'}"
                                     data-value="groups">Groups</button>
                         </div>
-
 
                         <div class="row">
                             <div v-show="isInviteUsers" class="add-view-user-form col-xs-12">


### PR DESCRIPTION
[#3534] This fixes a bug where users who are quota holders for a resource cannot change access of a group that has their same Id for the resource.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. I tested this locally and it seemed to work correctly, but @dtarb will need to verify this fix by reproducing the steps outlined in #3534 
