### PR TITLE
[#3710] - enforce openwithlist and file extension and agg types for w…

### DIFF
--- a/hs_tools_resource/app_launch_helper.py
+++ b/hs_tools_resource/app_launch_helper.py
@@ -101,8 +101,6 @@ def _get_app_tool_info(request_obj, resource_obj, tool_res_obj, open_with=False)
                   'url': tool_url_resource_new,
                   'url_aggregation': tool_url_agg_new,
                   'url_file': tool_url_file_new,
-                  'openwithlist': is_open_with_app,
-                  'approved': is_approved_app,
                   'agg_types': agg_types,
                   'file_extensions': file_extensions
                   }

--- a/hs_tools_resource/app_launch_helper.py
+++ b/hs_tools_resource/app_launch_helper.py
@@ -24,12 +24,11 @@ def resource_level_tool_urls(resource_obj, request_obj):
                     _check_user_can_view_app(request_obj, tool_res_obj) and \
                     _check_app_supports_resource_sharing_status(resource_obj,
                                                                 tool_res_obj):
-                is_open_with_app, tl = _get_app_tool_info(request_obj, resource_obj,
-                                                          tool_res_obj, open_with=True)
+                tl = _get_app_tool_info(request_obj, resource_obj, tool_res_obj, open_with=True)
                 if tl:
                     tool_list.append(tl)
                     tool_res_id_list.append(tl['res_id'])
-                    if is_open_with_app and tl['url']:
+                    if tl['url']:
                         resource_level_app_counter += 1
 
     for choice_obj in SupportedResTypeChoices.objects.filter(description__iexact=res_type_str):
@@ -40,10 +39,10 @@ def resource_level_tool_urls(resource_obj, request_obj):
                     _check_user_can_view_app(request_obj, tool_res_obj) and \
                     _check_app_supports_resource_sharing_status(resource_obj, tool_res_obj):
 
-                is_open_with_app, tl = _get_app_tool_info(request_obj, resource_obj, tool_res_obj)
+                tl = _get_app_tool_info(request_obj, resource_obj, tool_res_obj)
                 if tl:
                     tool_list.append(tl)
-                    if is_open_with_app and tl['url']:
+                    if tl['url']:
                         resource_level_app_counter += 1
 
     if len(tool_list) > 0:
@@ -92,24 +91,25 @@ def _get_app_tool_info(request_obj, resource_obj, tool_res_obj, open_with=False)
     if tool_res_obj.metadata.supported_file_extensions:
         file_extensions = tool_res_obj.metadata.supported_file_extensions.value
 
-    if (tool_url_resource_new is not None) or \
-            (tool_url_agg_new is not None) or \
-            (tool_url_file_new is not None):
-        tl = {'title': str(tool_res_obj.metadata.title.value),
-              'res_id': tool_res_obj.short_id,
-              'icon_url': tool_icon_url,
-              'url': tool_url_resource_new,
-              'url_aggregation': tool_url_agg_new,
-              'url_file': tool_url_file_new,
-              'openwithlist': is_open_with_app,
-              'approved': is_approved_app,
-              'agg_types': agg_types,
-              'file_extensions': file_extensions
-              }
+    if is_open_with_app or is_approved_app:
+        if (tool_url_resource_new is not None) or \
+                (tool_url_agg_new is not None) or \
+                (tool_url_file_new is not None):
+            tl = {'title': str(tool_res_obj.metadata.title.value),
+                  'res_id': tool_res_obj.short_id,
+                  'icon_url': tool_icon_url,
+                  'url': tool_url_resource_new,
+                  'url_aggregation': tool_url_agg_new,
+                  'url_file': tool_url_file_new,
+                  'openwithlist': is_open_with_app,
+                  'approved': is_approved_app,
+                  'agg_types': agg_types,
+                  'file_extensions': file_extensions
+                  }
 
-        return is_open_with_app, tl
+            return tl
     else:
-        return False, {}
+        return {}
 
 
 def get_app_dict(user, resource):

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -11,7 +11,7 @@ from hs_core import hydroshare
 from hs_tools_resource.models import RequestUrlBase, ToolVersion, SupportedResTypes, ToolResource, \
     ToolIcon, AppHomePageUrl, SupportedSharingStatus, \
     RequestUrlBaseAggregation, SupportedFileExtensions, \
-    SupportedAggTypes, RequestUrlBaseFile, ShowOnOpenWithList
+    SupportedAggTypes, RequestUrlBaseFile
 from hs_tools_resource.receivers import metadata_element_pre_create_handler, \
     metadata_element_pre_update_handler
 from hs_core.hydroshare import create_empty_resource, copy_resource

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -355,8 +355,6 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(tc, 1, msg='open with app counter ' + str(tc) + ' is not 1')
         tl = relevant_tools['tool_list'][0]
         self.assertEqual(tl['res_id'], self.resWebApp.short_id)
-        self.assertFalse(tl['approved'])
-        self.assertTrue(tl['openwithlist'])
         self.assertEqual(tl['agg_types'], '')
         self.assertEqual(tl['file_extensions'], '')
 
@@ -516,8 +514,6 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(0, tc)
         tl = relevant_tools['tool_list'][0]
         self.assertEqual(self.resWebApp.short_id, tl['res_id'])
-        self.assertFalse(tl['approved'])
-        self.assertTrue(tl['openwithlist'])
         self.assertEqual('GeoRasterLogicalFile', tl['agg_types'])
         self.assertEqual('', tl['file_extensions'])
 
@@ -576,8 +572,6 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(0, tc)
         tl = relevant_tools['tool_list'][0]
         self.assertEqual(self.resWebApp.short_id, tl['res_id'])
-        self.assertFalse(tl['approved'])
-        self.assertTrue(tl['openwithlist'])
         self.assertEqual('', tl['agg_types'])
         self.assertEqual('.tif', tl['file_extensions'])
 

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -11,7 +11,7 @@ from hs_core import hydroshare
 from hs_tools_resource.models import RequestUrlBase, ToolVersion, SupportedResTypes, ToolResource, \
     ToolIcon, AppHomePageUrl, SupportedSharingStatus, \
     RequestUrlBaseAggregation, SupportedFileExtensions, \
-    SupportedAggTypes, RequestUrlBaseFile
+    SupportedAggTypes, RequestUrlBaseFile, ShowOnOpenWithList
 from hs_tools_resource.receivers import metadata_element_pre_create_handler, \
     metadata_element_pre_update_handler
 from hs_core.hydroshare import create_empty_resource, copy_resource
@@ -521,6 +521,13 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual('GeoRasterLogicalFile', tl['agg_types'])
         self.assertEqual('', tl['file_extensions'])
 
+        # Remove appkey to turn off openwithlist for this resource
+        self.resWebApp.extra_metadata = {}
+        self.resWebApp.save()
+
+        relevant_tools = resource_level_tool_urls(self.resComposite, request)
+        self.assertIsNone(relevant_tools, msg='relevant_tools should have no approved resources')
+
     def test_file_extensions(self):
         # set url launching pattern for aggregations
         metadata = [
@@ -573,6 +580,13 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertTrue(tl['openwithlist'])
         self.assertEqual('', tl['agg_types'])
         self.assertEqual('.tif', tl['file_extensions'])
+
+        # Remove appkey to turn off openwithlist for this resource
+        self.resWebApp.extra_metadata = {}
+        self.resWebApp.save()
+
+        relevant_tools = resource_level_tool_urls(self.resComposite, request)
+        self.assertIsNone(relevant_tools, msg='relevant_tools should have no approved resources')
 
     def test_copy(self):
 

--- a/theme/static/js/hs-vue/relevant-tools.js
+++ b/theme/static/js/hs-vue/relevant-tools.js
@@ -56,7 +56,7 @@ let relevantToolsApp = new Vue({
                 });
 
                 vue.openWithTools = vue.tools.filter(function(tool) {
-                    return tool.url && tool.openwithlist;
+                    return tool.url;
                 });
 
                 // Append menu items to right click menu in file browser


### PR DESCRIPTION
…eb apps

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a Composite resource with an aggregation.  Create a Web App Resource with launching patterns for file extension and aggregations that match your new Composite Resource's files.  Do not add the web app to your open with list.  Right click on the files and aggregations, ensure that the new Web app does not show.
2.  Now add the Web App to your open with list, go back to the new Composite resource and right click on both files and aggregations that match the launching patterns.  Ensure the web app resource is an option to launch with.
