### PR TITLE
3713 irods delete trap

### DIFF
--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -28,19 +28,19 @@ def delete_files_and_bag(resource):
     istorage = resource.get_irods_storage()
 
     # delete resource directory first to remove all generated bag-related files for the resource
-    if istorage.exists(resource.root_path):
-        try:
+    try:
+        if istorage.exists(resource.root_path):
             istorage.delete(resource.root_path)
-        except Exception as e:
-            logger = logging.getLogger(__name__)
-            logger.error("cannot remove {}: {}".format(resource.root_path, e))
+    except Exception as e:
+        logger = logging.getLogger(__name__)
+        logger.error("cannot remove {}: {}".format(resource.root_path, e))
 
-    if istorage.exists(resource.bag_path):
-        try:
+    try:
+        if istorage.exists(resource.bag_path):
             istorage.delete(resource.bag_path)
-        except Exception as e:
-            logger = logging.getLogger(__name__)
-            logger.error("cannot remove {}: {}".format(resource.bag_path, e))
+    except Exception as e:
+        logger = logging.getLogger(__name__)
+        logger.error("cannot remove {}: {}".format(resource.bag_path, e))
 
     # TODO: delete this whole mechanism; redundant.
     # delete the bags table

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -4,6 +4,7 @@ import errno
 import tempfile
 import mimetypes
 import zipfile
+import logging
 
 from foresite import utils, Aggregation, AggregatedResource, RdfLibSerializer
 from rdflib import Namespace, URIRef
@@ -28,10 +29,18 @@ def delete_files_and_bag(resource):
 
     # delete resource directory first to remove all generated bag-related files for the resource
     if istorage.exists(resource.root_path):
-        istorage.delete(resource.root_path)
+        try:
+            istorage.delete(resource.root_path)
+        except Exception as e:
+            logger = logging.getLogger(__name__)
+            logger.error("cannot remove {}: {}".format(resource.root_path, e))
 
     if istorage.exists(resource.bag_path):
-        istorage.delete(resource.bag_path)
+        try:
+            istorage.delete(resource.bag_path)
+        except Exception as e:
+            logger = logging.getLogger(__name__)
+            logger.error("cannot remove {}: {}".format(resource.bag_path, e))
 
     # TODO: delete this whole mechanism; redundant.
     # delete the bags table


### PR DESCRIPTION
When deleting a resource, this protects against crashes that leave Django in an inconsistent state, by logging and then ignoring iRODS errors. The Django record is reliably deleted even if iRODS fails. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. This is terribly difficult to test, in the sense that it only kicks in when iRODS fails for some reason. 
