### PR TITLE
Fix solr_update crash when SOLR resource is not in Django

### DIFF
--- a/hs_core/management/commands/solr_update.py
+++ b/hs_core/management/commands/solr_update.py
@@ -68,73 +68,73 @@ class Command(BaseCommand):
                                               Q(raccess__public=True))
             print("Django count = {}".format(dqs.count()))
 
-            # what is in Django that isn't in SOLR:
-            found = set()
+            # what is in Django that isn't in SOLR
+            found_in_solr = set()
             for r in list(sqs):
-                found.add(r.short_id)
-                # resource = get_resource_by_shortkey(r.short_id)
-                # print("{} {} found".format(r.short_id, resource.discovery_content_type))
-            in_django = 0
+                found_in_solr.add(r.short_id)  # enable fast matching
+
+            django_indexed = 0
             django_replaced = 0
             django_refreshed = 0
-            for r in dqs:
-                resource = get_resource_by_shortkey(r.short_id)
-                repl = False
-                if hasattr(resource, 'metadata') and resource.metadata is None:
-                    print("skipping {} resource in Django, metadata is None".format(r.short_id))
-                    continue
-                if hasattr(resource, 'metadata') and resource.metadata is not None:
-                    repl = resource.metadata.relations.filter(type='isReplacedBy').exists()
-                if not repl:
-                    in_django += 1
-                else:
-                    django_replaced += 1
 
-                if r.short_id not in found:
+            for r in dqs:
+                try:
+                    resource = get_resource_by_shortkey(r.short_id, or_404=False)
+                    repl = False
+                    if hasattr(resource, 'metadata') and resource.metadata is not None:
+                        repl = resource.metadata.relations.filter(type='isReplacedBy').exists()
+                    if not repl:
+                        django_indexed += 1
+                    else:
+                        django_replaced += 1
+                except BaseResource.DoesNotExist:
+                    # race condition in processing while in production
+                    print("resource {} no longer found in Django.".format(r.short_id))
+                    continue
+
+                if r.short_id not in found_in_solr:
                     print("{} {} NOT FOUND in SOLR: adding to index".format(
                             r.short_id, resource.discovery_content_type))
                     ind.update_object(r)
                     django_refreshed += 1
+
                 # # This always returns True whether or not SOLR needs updating
                 # # This is likely a Haystack bug.
                 # elif ind.should_update(r):
                 # update everything to be safe.
+
                 elif options['force']:
                     print("{} {}: refreshing index (forced)".format(
                           r.short_id, resource.discovery_content_type))
                     ind.update_object(r)
                     django_refreshed += 1
 
-            print("{} resources in Django refreshed in SOLR".format(django_refreshed))
             print("Django contains {} discoverable resources and {} replaced resources"
-                  .format(in_django, django_replaced))
+                  .format(django_indexed, django_replaced))
+            print("{} resources in Django refreshed in SOLR".format(django_refreshed))
 
             # what is in SOLR that isn't in Django:
             sqs = SearchQuerySet().all()  # refresh for changes from above
-            found = set()
-            in_solr = 0
-            solr_deleted = 0
+            solr_indexed = 0
             solr_replaced = 0
-            for r in list(dqs):
-                found.add(r.short_id)
-                # resource = get_resource_by_shortkey(r.short_id)
-                # print("{} {} found".format(r.short_id, resource.discovery_content_type))
+            solr_deleted = 0
             for r in sqs:
-                if r.short_id not in found:
-                    resource = get_resource_by_shortkey(r.short_id)
-                    print("{} {} NOT FOUND in Django; removing from SOLR".format(
-                            r.short_id, resource.discovery_content_type))
-                    ind.remove_object(r)
-                    solr_deleted += 1
-                else:
-                    resource = get_resource_by_shortkey(r.short_id)
+                try:
+                    resource = get_resource_by_shortkey(r.short_id, or_404=False)
                     repl = False
                     if hasattr(resource, 'metadata') and resource.metadata is not None:
                         repl = resource.metadata.relations.filter(type='isReplacedBy').exists()
                     if not repl:
-                        in_solr += 1
+                        solr_indexed += 1
                     else:
                         solr_replaced += 1
-            print("{} resources not in Django removed from SOLR".format(solr_deleted))
+                except BaseResource.DoesNotExist:
+                    print("SOLR resource {} ({}) NOT FOUND in Django; removing from SOLR"
+                          .format(r.short_id, resource.discovery_content_type))
+                    ind.remove_object(r)
+                    solr_deleted += 1
+                    continue
+
             print("SOLR contains {} discoverable resources and {} replaced resources"
-                  .format(in_solr, solr_replaced))
+                  .format(solr_indexed, solr_replaced))
+            print("{} resources not in Django removed from SOLR".format(solr_deleted))


### PR DESCRIPTION
Same as hotfix, for develop. Solr_update should not crash when a SOLR resource is no longer in Django. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. solr_update deletes the SOLR entry for any resource no longer in Django. 
