### PR TITLE
add geoserver web app key for aggregations

### DIFF
--- a/hs_core/templates/pages/metadata_terms.html
+++ b/hs_core/templates/pages/metadata_terms.html
@@ -1486,6 +1486,7 @@
                 <ul>
                     <li> <strong>${HS_AGG_PATH}</strong>: Path of an aggregation in HydroShare</li>
                     <li> <strong>${HS_MAIN_FILE}</strong>: The main file name of an aggregation</li>
+                    <li> <strong>${HS_AGG_GEOSERVER}</strong>: An aggregation path formatted as a geoserver name. ("path/to/aggregation.shp" -> "path to aggregation")</li>
                 </ul>
             </ul>
                 An example:<br>

--- a/hs_tools_resource/app_launch_helper.py
+++ b/hs_tools_resource/app_launch_helper.py
@@ -117,6 +117,7 @@ def get_app_dict(user, resource):
     # HS_JS_AGG_KEY and HS_JS_FILE_KEY are overwritten by jquery to launch the url specific to each
     # file
     hs_term_dict_file["HS_AGG_PATH"] = "HS_JS_AGG_KEY"
+    hs_term_dict_file["HS_AGG_GEOSERVER"] = "HS_JS_GEOSERVER_KEY"
     hs_term_dict_file["HS_FILE_PATH"] = "HS_JS_FILE_KEY"
     hs_term_dict_file["HS_MAIN_FILE"] = "HS_JS_MAIN_FILE_KEY"
     return [resource.get_hs_term_dict(), hs_term_dict_user, hs_term_dict_file]

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -157,6 +157,7 @@ class AppAggregationLevelUrlValidationForm(forms.Form):
         term_dict["HS_USR_NAME"] = "c"
         term_dict["HS_AGG_PATH"] = "d"
         term_dict["HS_MAIN_FILE"] = "e"
+        term_dict["HS_AGG_GEOSERVER"] = "f"
         parsed = parse_app_url_template(cleaned_url, [term_dict])
 
         if not parsed:

--- a/hs_tools_resource/tests/test_web_app_validation.py
+++ b/hs_tools_resource/tests/test_web_app_validation.py
@@ -130,7 +130,8 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
                    '&res_id=${HS_RES_TYPE}' \
                    '&usr=${HS_USR_NAME}' \
                    '&fil=${HS_AGG_PATH}' \
-                   '&main=${HS_MAIN_FILE}'
+                   '&main=${HS_MAIN_FILE}' \
+                   '$geoserver=${HS_AGG_GEOSERVER}'
 
         post_data = {'value': good_url}
         url_params = {'element_name': "requesturlbaseaggregation",
@@ -170,7 +171,8 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
                    '&res_id=${HS_RES_TYPE}' \
                    '&usr=${HS_USR_NAME}' \
                    '&fil=${HS_AGG_PATH}' \
-                   '&main=${HS_MAIN_FILE}'
+                   '&main=${HS_MAIN_FILE}' \
+                   '$geoserver=${HS_AGG_GEOSERVER}'
 
         post_data = {'value': good_url}
         url_params = {'element_name': "requesturlbaseaggregation",

--- a/theme/static/js/hs-vue/relevant-tools.js
+++ b/theme/static/js/hs-vue/relevant-tools.js
@@ -111,6 +111,7 @@ let relevantToolsApp = new Vue({
                     let fullURL;
                     if ($(this).attr("data-url-aggregation")) {
                         fullURL = $(this).attr("data-url-aggregation").replace("HS_JS_AGG_KEY", path);
+                        // geoserver key is the path with spaces for separator and the extension removed
                         var geoserverID = path.replace("\/", " ");
                         geoserverID = geoserverID.replace(/\.[^/.]+$/, "");
                         fullURL = $(this).attr("data-url-aggregation").replace("HS_JS_GEOSERVER_KEY", geoserverID);

--- a/theme/static/js/hs-vue/relevant-tools.js
+++ b/theme/static/js/hs-vue/relevant-tools.js
@@ -111,6 +111,9 @@ let relevantToolsApp = new Vue({
                     let fullURL;
                     if ($(this).attr("data-url-aggregation")) {
                         fullURL = $(this).attr("data-url-aggregation").replace("HS_JS_AGG_KEY", path);
+                        var geoserverID = path.replace("\/", " ");
+                        geoserverID = geoserverID.replace(/\.[^/.]+$/, "");
+                        fullURL = $(this).attr("data-url-aggregation").replace("HS_JS_GEOSERVER_KEY", geoserverID);
                         if (file.children('span.fb-file-type').text() === 'File Folder') {
                             // TODO: populate main_file value in aggregation object of structure response
                             fullURL = fullURL.replace("HS_JS_MAIN_FILE_KEY", file.attr("data-main-file"));


### PR DESCRIPTION
Adds a geoserver web app key.  They key allows a web app to build a url that uses the aggregation name formatted in a way the hydroshare geoserver names aggregations.

More info on building geoserver urls is available here.
https://docs.geoserver.org/stable/en/user/tutorials/wmsreflector.html

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a web app and add an aggregation level url with the key HS_AGG_GEOSERVER.  Open a qualifying aggregation with the web app and validate the url replaces HS_AGG_GEOSERVER a string that modifies the aggregation path.  ("path/to/aggregation.shp" -> "path to aggregation")
