### PR TITLE
Remove debugging display

### DIFF
--- a/hs_communities/templates/hs_communities/community.html
+++ b/hs_communities/templates/hs_communities/community.html
@@ -194,7 +194,6 @@
                                     {% endfor %}
                                     </tbody>
                                 </table>
-                                {{ community_resources | length }} Resources
                                 {% include "includes/legend.html" %}
                             </div>
                         </div>


### PR DESCRIPTION
A redundant total resource display was created for migration debugging. Now that Production migration is complete, this can be removed, as the filters display a resource count per Group.

Fixes https://github.com/hydroshare/hydroshare/issues/3738

### Positive Test Case
1. Log in as czo_sierra czone123
2. Create resource, make public, share with CZO Sierra Group
3. View resource in Community page and note there is no total resource count at bottom of page
