### PR TITLE
[#3741] Allow metadata UI update after single file upload

### DIFF
--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -1276,6 +1276,15 @@ function refreshFileBrowser(name) {
     });
 }
 
+function onUploadSuccess(file, response) {
+    // uploaded files can affect metadata in composite resource.
+    // Use the json data returned from backend to update UI
+    if (RES_TYPE === 'Composite Resource') {
+        updateResourceUI();
+    }
+    showCompletedMessage(response);
+}
+
 $(document).ready(function () {
     if (!$("#hs-file-browser").length) {
         return;
@@ -1360,18 +1369,8 @@ $(document).ready(function () {
             error: function (file, response) {
                 // console.log(response);
             },
-            success: function (file, response) {
-                // console.log(response);
-            },
-            successmultiple: function (files, response) {
-                // uploaded files can affect metadata in composite resource.
-                // Use the json data returned from backend to update UI
-                const resourceType = $("#resource-type").val();
-                if (resourceType === 'Composite Resource') {
-                    updateResourceUI();
-                }
-                showCompletedMessage(response);
-            },
+            success: onUploadSuccess,
+            successmultiple: onUploadSuccess,
             init: function () {
                 // The user dragged a file onto the Dropzone
                 this.on("dragenter", function (file) {


### PR DESCRIPTION
[#3741] Extends logic to allow UI metadata update after auto extracting metadata from single file upload.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource.
2. Upload a .nc file.
3. Verify that the extracted metadata is correctly rendered in the rest of the page (title, abstract, etc) upon file upload without refreshing the page.
