### PR TITLE
make iquest more restrictive so as not to pick up temporary zips coll…

### DIFF
--- a/django_irods/storage.py
+++ b/django_irods/storage.py
@@ -29,6 +29,18 @@ class IrodsStorage(Storage):
         # return a unique temporary path under IRODS_ROOT directory
         return os.path.join(getattr(settings, 'IRODS_ROOT', '/tmp'), uuid4().hex)
 
+    @staticmethod
+    def get_absolute_path(path):
+        """
+        Get absolute path of the input path for the HydroShare iRODS data zone, which is useful for iquest
+        :param path: input path to be converted to absolute path if needed
+        :return: absolute logical path of the input path
+        """
+        if os.path.isabs(path):
+            # iRODS federated logical path which is already absolute path
+            return path
+        return os.path.join(settings.IRODS_HOME_COLLECTION, path)
+
     def set_user_session(self, username=None, password=None, host=settings.IRODS_HOST,
                          port=settings.IRODS_PORT, def_res=None, zone=settings.IRODS_ZONE,
                          userid=0, sess_id=None):
@@ -288,7 +300,7 @@ class IrodsStorage(Storage):
         # the query below returns name and size (separated in comma) of all data
         # objects/files under the path collection/directory
         qrystr = "select DATA_NAME, DATA_SIZE where DATA_REPL_STATUS != '0' AND " \
-                 "COLL_NAME like '%{}'".format(path)
+                 "COLL_NAME = '{}'".format(IrodsStorage.get_absolute_path(path))
         stdout = self.session.run("iquest", None, "--no-page", "%s,%s",
                                   qrystr)[0].split("\n")
 
@@ -310,7 +322,8 @@ class IrodsStorage(Storage):
         subdir_list = []
         # the query below returns name of all sub-collections/sub-directories
         # under the path collection/directory
-        qrystr = "select COLL_NAME where COLL_PARENT_NAME like '%{}'".format(path)
+
+        qrystr = "select COLL_NAME where COLL_PARENT_NAME = '{}'".format(IrodsStorage.get_absolute_path(path))
         stdout = self.session.run("iquest", None, "--no-page", "%s",
                                   qrystr)[0].split("\n")
         for i in range(len(stdout)):
@@ -339,7 +352,7 @@ class IrodsStorage(Storage):
 
         # check first whether the path is an iRODS collection/directory or not, and if not, need
         # to raise SessionException, and if yes, can proceed to get files and sub-dirs under it
-        qrystr = "select COLL_NAME where COLL_NAME like '%{}'".format(path)
+        qrystr = "select COLL_NAME where COLL_NAME = '{}'".format(IrodsStorage.get_absolute_path(path))
         stdout = self.session.run("iquest", None, "%s", qrystr)[0]
         if "CAT_NO_ROWS_FOUND" in stdout:
             raise SessionException(-1, '', 'folder {} does not exist'.format(path))
@@ -365,7 +378,7 @@ class IrodsStorage(Storage):
         coll_name = file_info[0]
         file_name = file_info[1]
         qrystr = "select DATA_SIZE where DATA_REPL_STATUS != '0' AND " \
-                 "COLL_NAME like '%{}' AND DATA_NAME = '{}'".format(coll_name, file_name)
+                 "COLL_NAME = '{}' AND DATA_NAME = '{}'".format(IrodsStorage.get_absolute_path(coll_name), file_name)
         stdout = self.session.run("iquest", None, "%s",
                                   qrystr)[0]
 

--- a/hs_core/testing.py
+++ b/hs_core/testing.py
@@ -172,6 +172,13 @@ class TestCaseCommonUtilities(object):
         store = istorage.listdir(res_path)
         self.assertIn('sub_test_dir', store[0], msg='resource does not contain created sub-folder')
 
+        # create a temporary zips folder to make sure no duplicate folders are returned from listdir()
+        zip_res_coll_path = os.path.join('zips', '2020-02-03', res.short_id, 'data', 'contents', 'sub_test_dir')
+        istorage.session.run("imkdir", None, '-p', zip_res_coll_path)
+        store = istorage.listdir(res_path)
+        self.assertEqual(store[0].count('sub_test_dir'), 1, msg='duplicate folder: sub_test_dir occurred more '
+                                                                'than once')
+
         # rename the third file in file_name_list
         move_or_rename_file_or_folder(user, res.short_id,
                                       'data/contents/' + file_name_list[2],


### PR DESCRIPTION
…ections

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. The fix should make iquest related queries for listing directories in iRODS more restrictive so as not to pick up potential directory entries in the temporary zips collection. Created this PR against master targeting it as a hotfix since duplicate folder issues could happen again if temporary zipped folders were created and not cleaned up properly. 
