### PR TITLE
[#3766] - stand up modified_time in api

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2740,6 +2740,10 @@ class ResourceFile(ResourceFileIRODSMixin):
             self.calculate_size()
         return self._size
 
+    @property
+    def modified_time(self):
+        return self.resource_file.storage.get_modified_time(self.resource_file.name)
+
     # TODO: write unit test
     @property
     def exists(self):

--- a/hs_core/tests/api/native/test_get_resource_file.py
+++ b/hs_core/tests/api/native/test_get_resource_file.py
@@ -39,8 +39,9 @@ class TestGetResourceFile(MockIRODSTestCaseMixin, TestCase):
 
     def test_get_file(self):
         # test if the added test file is obtained
-        res_file_object = hydroshare.get_resource_file(self.res.short_id,
-                                                       self.file.name).resource_file
+        res_file = hydroshare.get_resource_file(self.res.short_id,
+                                                       self.file.name)
+        res_file_object = res_file.resource_file
         self.assertEqual(
             self.file.name,
             os.path.basename(res_file_object.name),
@@ -48,7 +49,5 @@ class TestGetResourceFile(MockIRODSTestCaseMixin, TestCase):
         )
 
         # test if the last modified time for the file can be obtained
-        istorage = self.res.get_irods_storage()
-        time = istorage.get_modified_time(res_file_object.name)
         # assert time is not None without iRODS Session Exception being raised
-        self.assertTrue(time)
+        self.assertTrue(res_file.modified_time)

--- a/hs_core/tests/api/rest/test_resource_file.py
+++ b/hs_core/tests/api/rest/test_resource_file.py
@@ -5,6 +5,7 @@ import tempfile
 import shutil
 
 from rest_framework import status
+from datetime import datetime
 
 from hs_core.hydroshare import resource
 from hs_core.tests.api.utils import MyTemporaryUploadedFile
@@ -72,6 +73,7 @@ class TestResourceFile(HSRESTTestCase):
                         os.path.basename(content['results'][1]['url'])]
         self.assertIn(self.txt_file_name, content_list)
         self.assertIn(self.raster_file_name, content_list)
+        self.assertTrue(content['results'][0]['modified_time'])
 
     def test_get_resource_file(self):
         files = (MyTemporaryUploadedFile(file=open(self.txt_file_path, 'rb'), name=self.txt_file_path))

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -88,6 +88,7 @@ class ResourceFileToListItemMixin(object):
         fsize = f.size
         logical_file_type = f.logical_file_type_name
         file_name = os.path.basename(f.resource_file.name)
+        modified_time = f.modified_time
         # trailing slash confuses mime guesser
         mimetype = mimetypes.guess_type(url)
         if mimetype[0]:
@@ -98,7 +99,8 @@ class ResourceFileToListItemMixin(object):
                                                                file_name=file_name,
                                                                size=fsize,
                                                                content_type=ftype,
-                                                               logical_file_type=logical_file_type)
+                                                               logical_file_type=logical_file_type,
+                                                               modified_time=modified_time)
         return resource_file_info_item
 
 
@@ -732,13 +734,15 @@ class ResourceFileListCreate(ResourceFileToListItemMixin, generics.ListCreateAPI
                 download/bd88d2a152894134928c587d38cf0272/data/contents/
                 mytest_resource/text_file.txt",
                 "size": 21,
-                "content_type": "text/plain"
+                "content_type": "text/plain",
+                "modified_time": "2020-02-25T08:28:14"
             },
             {
                 "url": "http://mill24.cep.unc.edu/django_irods/download/
                 bd88d2a152894134928c587d38cf0272/data/contents/mytest_resource/a_directory/cea.tif",
                 "size": 270993,
-                "content_type": "image/tiff"
+                "content_type": "image/tiff",
+                "modified_time": "2020-02-25T08:28:14"
             }
         ]
     }

--- a/hs_core/views/serializers.py
+++ b/hs_core/views/serializers.py
@@ -165,6 +165,7 @@ class ResourceFileSerializer(serializers.Serializer):
     size = serializers.IntegerField(help_text='The size of the file')
     content_type = serializers.CharField(max_length=255, help_text='The content type of the file')
     logical_file_type = serializers.CharField(max_length=255)
+    modified_time = serializers.DateTimeField(format="%Y-%m-%dT%H:%M:%S")
 
 
 class GroupPrivilegeSerializer(serializers.Serializer):
@@ -233,7 +234,8 @@ ResourceFileItem = namedtuple('ResourceFileItem',
                                'file_name',
                                'size',
                                'content_type',
-                               'logical_file_type'])
+                               'logical_file_type',
+                               'modified_time'])
 
 
 class UserAuthenticateRequestValidator(serializers.Serializer):


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Query /hsapi/resource/{id}/file_list/ and verify modified_time is included in the results
