### PR TITLE
Update Nginx to avoid needless reverse proxy

### DIFF
--- a/nginx/config-files/hydroshare-local-nginx.conf.template
+++ b/nginx/config-files/hydroshare-local-nginx.conf.template
@@ -12,8 +12,6 @@ geo $external {
   10.0.0.0/8 0;
 }
 
-limit_req_zone $binary_remote_addr zone=applaunch:10m rate=2r/s;
-
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -92,14 +90,6 @@ server {
         }
         proxy_pass http://FQDN_OR_IP:8000;
         proxy_set_header X-Django-Reverse-Proxy true;
-    }
-
-    location /tracking/applaunch/ {
-        if (-f $document_root/maintenance_on.html) {
-            return 503;
-        }
-        limit_req zone=applaunch burst=50;
-        proxy_pass http://FQDN_OR_IP:8000;
     }
 
     location / { 

--- a/nginx/config-files/hydroshare-local-nginx.conf.template
+++ b/nginx/config-files/hydroshare-local-nginx.conf.template
@@ -96,7 +96,10 @@ server {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
+        try_files $uri @proxy; 
+    } 
 
+    location @proxy { 
         proxy_pass  http://FQDN_OR_IP:8000;
     } 
 

--- a/nginx/config-files/hydroshare-local-nginx.conf.template
+++ b/nginx/config-files/hydroshare-local-nginx.conf.template
@@ -67,17 +67,13 @@ server {
         alias IRODS_CACHE_ROOT/;
     }
 
-    location / {
+    location /django_irods/download/ {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-        try_files $uri @proxy;
-#        AUTH_BASIC;
-#        AUTH_BASIC_USER_FILE;
-    }
 
-    location @proxy {
         proxy_pass  http://FQDN_OR_IP:8000;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -95,6 +91,14 @@ server {
         proxy_connect_timeout 300s;
         proxy_read_timeout 300;
     }
+
+    location / { 
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+
+        proxy_pass  http://FQDN_OR_IP:8000;
+    } 
 
     error_page 503 @maintenance;
     location @maintenance {

--- a/nginx/config-files/hydroshare-local-nginx.conf.template
+++ b/nginx/config-files/hydroshare-local-nginx.conf.template
@@ -12,6 +12,25 @@ geo $external {
   10.0.0.0/8 0;
 }
 
+limit_req_zone $binary_remote_addr zone=applaunch:10m rate=2r/s;
+
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+
+client_max_body_size 4096m;
+client_body_buffer_size 1m;
+proxy_intercept_errors on;
+proxy_buffering on;
+proxy_buffer_size 128k;
+proxy_buffers 256 16k;
+proxy_busy_buffers_size 256k;
+proxy_temp_file_write_size 256k;
+proxy_max_temp_file_size 0;
+proxy_connect_timeout 300s;
+proxy_read_timeout 300;
+
 server {
     listen          80;
     server_name     FQDN_OR_IP;
@@ -71,25 +90,16 @@ server {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-
-        proxy_pass  http://FQDN_OR_IP:8000;
-
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://FQDN_OR_IP:8000;
         proxy_set_header X-Django-Reverse-Proxy true;
+    }
 
-        client_max_body_size 4096m;
-        client_body_buffer_size 1m;
-        proxy_intercept_errors on;
-        proxy_buffering on;
-        proxy_buffer_size 128k;
-        proxy_buffers 256 16k;
-        proxy_busy_buffers_size 256k;
-        proxy_temp_file_write_size 256k;
-        proxy_max_temp_file_size 0;
-        proxy_connect_timeout 300s;
-        proxy_read_timeout 300;
+    location /tracking/applaunch/ {
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+        limit_req zone=applaunch burst=50;
+        proxy_pass http://FQDN_OR_IP:8000;
     }
 
     location / { 
@@ -100,7 +110,7 @@ server {
     } 
 
     location @proxy { 
-        proxy_pass  http://FQDN_OR_IP:8000;
+        proxy_pass http://FQDN_OR_IP:8000;
     } 
 
     error_page 503 @maintenance;

--- a/nginx/config-files/hydroshare-nginx.conf.template
+++ b/nginx/config-files/hydroshare-nginx.conf.template
@@ -12,6 +12,25 @@ geo $external {
   10.0.0.0/8 0;
 }
 
+limit_req_zone $binary_remote_addr zone=applaunch:10m rate=2r/s;
+
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+
+client_max_body_size 4096m;
+client_body_buffer_size 1m;
+proxy_intercept_errors on;
+proxy_buffering on;
+proxy_buffer_size 128k;
+proxy_buffers 256 16k;
+proxy_busy_buffers_size 256k;
+proxy_temp_file_write_size 256k;
+proxy_max_temp_file_size 0;
+proxy_connect_timeout 300s;
+proxy_read_timeout 300;
+
 server {
     listen          80;
     server_name     FQDN_OR_IP;
@@ -71,25 +90,16 @@ server {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-
         proxy_pass http://unix:/hs_tmp/gunicorn.sock;
-
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Django-Reverse-Proxy true;
+    }
 
-        client_max_body_size 4096m;
-        client_body_buffer_size 1m;
-        proxy_intercept_errors on;
-        proxy_buffering on;
-        proxy_buffer_size 128k;
-        proxy_buffers 256 16k;
-        proxy_busy_buffers_size 256k;
-        proxy_temp_file_write_size 256k;
-        proxy_max_temp_file_size 0;
-        proxy_connect_timeout 300s;
-        proxy_read_timeout 300;
+    location /tracking/applaunch/ {
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+        limit_req zone=applaunch burst=50;
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
     }
 
     location / { 

--- a/nginx/config-files/hydroshare-nginx.conf.template
+++ b/nginx/config-files/hydroshare-nginx.conf.template
@@ -96,7 +96,10 @@ server {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
+        try_files $uri @proxy;
+    } 
 
+    location @proxy { 
         proxy_pass http://unix:/hs_tmp/gunicorn.sock;
     } 
 

--- a/nginx/config-files/hydroshare-nginx.conf.template
+++ b/nginx/config-files/hydroshare-nginx.conf.template
@@ -12,8 +12,6 @@ geo $external {
   10.0.0.0/8 0;
 }
 
-limit_req_zone $binary_remote_addr zone=applaunch:10m rate=2r/s;
-
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -92,14 +90,6 @@ server {
         }
         proxy_pass http://unix:/hs_tmp/gunicorn.sock;
         proxy_set_header X-Django-Reverse-Proxy true;
-    }
-
-    location /tracking/applaunch/ {
-        if (-f $document_root/maintenance_on.html) {
-            return 503;
-        }
-        limit_req zone=applaunch burst=50;
-        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
     }
 
     location / { 

--- a/nginx/config-files/hydroshare-nginx.conf.template
+++ b/nginx/config-files/hydroshare-nginx.conf.template
@@ -67,17 +67,13 @@ server {
         alias IRODS_CACHE_ROOT/;
     }
 
-    location / {
+    location /django_irods/download/ {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-        try_files $uri @proxy;
-#        AUTH_BASIC;
-#        AUTH_BASIC_USER_FILE;
-    }
 
-    location @proxy {
-        proxy_pass  http://unix:/hs_tmp/gunicorn.sock;
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -95,6 +91,14 @@ server {
         proxy_connect_timeout 300s;
         proxy_read_timeout 300;
     }
+
+    location / { 
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock;
+    } 
 
     error_page 503 @maintenance;
     location @maintenance {

--- a/nginx/config-files/hydroshare-ssl-nginx-ingress.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx-ingress.conf.template
@@ -1,0 +1,47 @@
+# template for deploying front-end switch as nginx instance. 
+# This does almost no work locally, and instead reroutes all requests 
+# to the value of the template variable CURRENT_VM. 
+
+upstream backend {
+   server CURRENT_VM;
+}
+
+server {
+    listen          80;
+    server_name     FQDN_OR_IP;
+    rewrite ^/(.*)  https://FQDN_OR_IP/$1 permanent;
+}
+
+server {
+    listen          443 ssl;
+    server_name     FQDN_OR_IP;
+    root            /system/static/; 
+
+    access_log      /var/log/nginx/access.log combined;
+    error_log       /var/log/nginx/error.log debug;
+
+    sendfile off;
+    proxy_request_buffering off; 
+    proxy_buffering off; 
+
+    charset         utf-8;
+    client_max_body_size 4096m;  # limit uploads to 4 GiB. 
+
+    ssl_certificate         /hs-certs/SSL_CERT_FILE;
+    ssl_certificate_key     /hs-certs/SSL_KEY_FILE;
+
+    location / {
+        if (-f $document_root/maintenance_on.html) {
+            return 503;  # invoke error handling as defined below
+        }
+	proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+	proxy_pass https://backend;  # allows extra backend servers
+    }
+
+    # return error 503 and custom error message for maintenance
+    error_page 503 @maintenance;
+    location @maintenance {
+        rewrite ^(.*)$ /maintenance_on.html break;
+    }
+}

--- a/nginx/config-files/hydroshare-ssl-nginx-ingress.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx-ingress.conf.template
@@ -1,6 +1,15 @@
-# template for deploying front-end switch as nginx instance. 
-# This does almost no work locally, and instead reroutes all requests 
-# to the value of the template variable CURRENT_VM. 
+# This is the configuration of the outer switch that selects which
+# instance of hydroshare to run. 
+#
+# This file should be named hydroshare-ssl-nginx.conf on that switch, 
+# in the directory /home/hydro/hydroshare/nginx/config-files 
+#
+# Request chokes are implemented here rather than on the hydroshare instance, 
+# so that this host is protected. Recent high-volume attacks against the
+# switch have brought the switch down.  April 16, 2020 -- Alva Couch
+
+# put a limit on the rate of requests made from one ip address. 
+limit_req_zone $binary_remote_addr zone=applaunch:10m rate=5r/s;
 
 upstream backend {
    server CURRENT_VM;
@@ -30,13 +39,27 @@ server {
     ssl_certificate         /hs-certs/SSL_CERT_FILE;
     ssl_certificate_key     /hs-certs/SSL_KEY_FILE;
 
+    # This limits the number of app launches that can be made from a single IP address. 
+    # At most 5 per second can be made, with a burst limit of 50 queued requests 
+    # to be addressed at 5 per second. This allows classes that are using apps 
+    # to simultaneously launch 50 instances, even if the class is using the same 
+    # request IP address due to network address translation (common). 
+    location /tracking/applaunch/ {
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+        limit_req zone=applaunch burst=50;
+        proxy_pass https://CURRENT_VM; 
+    }
+
+    # all other url
     location / {
         if (-f $document_root/maintenance_on.html) {
             return 503;  # invoke error handling as defined below
         }
 	proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-	proxy_pass https://backend;  # allows extra backend servers
+	proxy_pass https://CURRENT_VM;  # needed for server switching code. 
     }
 
     # return error 503 and custom error message for maintenance

--- a/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -110,7 +110,10 @@ server {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
+        try_files $uri @proxy;
+    } 
 
+    location @proxy { 
         proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
     } 
 

--- a/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -12,6 +12,25 @@ geo $external {
   10.0.0.0/8 0;
 }
 
+limit_req_zone $binary_remote_addr zone=applaunch:10m rate=2r/s;
+
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+
+client_max_body_size 4096m;
+client_body_buffer_size 1m;
+proxy_intercept_errors on;
+proxy_buffering on;
+proxy_buffer_size 128k;
+proxy_buffers 256 16k;
+proxy_busy_buffers_size 256k;
+proxy_temp_file_write_size 256k;
+proxy_max_temp_file_size 0;
+proxy_connect_timeout 300s;
+proxy_read_timeout 300;
+
 server {
     listen          80;
     server_name     FQDN_OR_IP;
@@ -84,26 +103,24 @@ server {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-
         proxy_pass http://unix:/hs_tmp/gunicorn.sock;
-
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Django-Reverse-Proxy true;
+    }
 
-        client_max_body_size 4096m;
-        client_body_buffer_size 1m;
-        proxy_intercept_errors on;
-        proxy_buffering on;
-        proxy_buffer_size 128k;
-        proxy_buffers 256 16k;
-        proxy_busy_buffers_size 256k;
-        proxy_temp_file_write_size 256k;
-        proxy_max_temp_file_size 0;
-        proxy_connect_timeout 300s;
-        proxy_read_timeout 300;
+    location /tracking/applaunch/ {
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+        limit_req zone=applaunch burst=50;
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
+    }
+
+    location /tracking/applaunch/ {
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+        limit_req zone=applaunch burst=50;
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
     }
 
     location / { 

--- a/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -80,17 +80,13 @@ server {
         alias IRODS_CACHE_ROOT/;
     }
 
-    location / {
+    location /django_irods/download/ {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-        try_files $uri @proxy;
-        AUTH_BASIC;
-        AUTH_BASIC_USER_FILE;
-    }
 
-    location @proxy {
-        proxy_pass  http://unix:/hs_tmp/gunicorn.sock;
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -109,6 +105,14 @@ server {
         proxy_connect_timeout 300s;
         proxy_read_timeout 300;
     }
+
+    location / { 
+        if (-f $document_root/maintenance_on.html) {
+            return 503;
+        }
+
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
+    } 
 
     error_page 503 @maintenance;
     location @maintenance {

--- a/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -1,7 +1,12 @@
 # hydroshare-ssl-nginx.conf
- 
+#
+# This is the configuration for the active Nginx server that interacts with Django and iRODs.
+# It should be named /home/hydro/hydroshare/nginx/config-files/hydroshare-ssl-nginx.conf
+# This contains the django interface but request chokes are now implemented on the
+# outer (downstream) switch server that chooses hydroshare instances.
+
 # $external is 1 if the URI is external and 0 if it cannot possibly be
-# external due to use of RFC-1918 addressing. This avoids redirects 
+# external due to use of RFC-1918 addressing. This avoids redirects
 # to canonical naming when a request comes from inside hydroshare
 
 geo $external {
@@ -10,9 +15,10 @@ geo $external {
   172.16.0.0/12 0;
   127.0.0.0/8 0;
   10.0.0.0/8 0;
+  152.54.0.0/22 0;
 }
 
-limit_req_zone $binary_remote_addr zone=applaunch:10m rate=2r/s;
+limit_req_zone $binary_remote_addr zone=applaunch:10m rate=5r/s;
 
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
@@ -34,11 +40,11 @@ proxy_read_timeout 300;
 server {
     listen          80;
     server_name     FQDN_OR_IP;
-    # This should not rewrite hostname! 
+    # This should not rewrite hostname!
     # rewrite ^/(.*)  https://FQDN_OR_IP/$1 permanent;
-    # This syntax is considered more efficient in nginx documentation 
-    # and does the same thing as the above: 
-    return 301 https://$http_host/$request_uri; 
+    # This syntax is considered more efficient in nginx documentation
+    # and does the same thing as the above:
+    return 301 https://$http_host/$request_uri;
 }
 
 server {
@@ -49,7 +55,7 @@ server {
     # Compute whether we need to rewrite an address. Rewrite all erronious
     # external addresses but avoid rewriting internal references (from django
     # management commands).
-     
+
     set $need_rewrite 0;
 
     if ($http_host != "FQDN_OR_IP") {
@@ -67,7 +73,7 @@ server {
     access_log      /var/log/nginx/access.log combined;
     error_log       /var/log/nginx/error.log error;
     error_log       /var/log/nginx/system.log notice;
-    # Uncomment the following line to generate debugging log entries 
+    # Uncomment the following line to generate debugging log entries
     # error_log       /var/log/nginx/system.log debug;
 
     charset         utf-8;
@@ -85,17 +91,17 @@ server {
     }
 
     location /IRODS_DATA_URI/ {
-        internal; 
+        internal;
         alias IRODS_DATA_ROOT/;
     }
 
     location /IRODS_USER_URI/ {
-        internal; 
+        internal;
         alias IRODS_USER_ROOT/;
     }
 
     location /IRODS_CACHE_URI/ {
-        internal; 
+        internal;
         alias IRODS_CACHE_ROOT/;
     }
 
@@ -112,27 +118,22 @@ server {
             return 503;
         }
         limit_req zone=applaunch burst=50;
-        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock;
     }
 
-    location /tracking/applaunch/ {
+    location / {
         if (-f $document_root/maintenance_on.html) {
             return 503;
         }
-        limit_req zone=applaunch burst=50;
-        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
-    }
-
-    location / { 
-        if (-f $document_root/maintenance_on.html) {
-            return 503;
-        }
+        # This curious directive allows admin static files to be referenced
+        # as /admin/* rather than /static/admin/*, and mezzanine static files to
+        # be referenced as /mezzanine/* rather than /static/mezzanine/*.
         try_files $uri @proxy;
-    } 
+    }
 
-    location @proxy { 
-        proxy_pass http://unix:/hs_tmp/gunicorn.sock; 
-    } 
+    location @proxy {
+        proxy_pass http://unix:/hs_tmp/gunicorn.sock;
+    }
 
     error_page 503 @maintenance;
     location @maintenance {

--- a/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -18,8 +18,6 @@ geo $external {
   152.54.0.0/22 0;
 }
 
-limit_req_zone $binary_remote_addr zone=applaunch:10m rate=5r/s;
-
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -111,14 +109,6 @@ server {
         }
         proxy_pass http://unix:/hs_tmp/gunicorn.sock;
         proxy_set_header X-Django-Reverse-Proxy true;
-    }
-
-    location /tracking/applaunch/ {
-        if (-f $document_root/maintenance_on.html) {
-            return 503;
-        }
-        limit_req zone=applaunch burst=50;
-        proxy_pass http://unix:/hs_tmp/gunicorn.sock;
     }
 
     location / {


### PR DESCRIPTION
Set Nginx to avoid reverse proxy overhead for everything except download. 
This lessens the effect of (incompetent) denial-of-service attempts. 
This PR also implements request frequency limits on /tracking/applaunch on the switch instance of Nginx that chooses the active hydroshare instance to use. The configuration of that server is now archived as `hydroshare/nginx/config-files/hydroshare-ssl-nginx-ingress.conf.template` for documentation purposes. 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case

1. Do a download. Check logs for "proxying" entry. Check that download worked. 
2. Check all other functions. Function should be unchanged. 
3. Check /admin and /mezzanine functions, which should still work. 
