### PR TITLE
include resource additional metadata as web app keys

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3498,6 +3498,7 @@ class BaseResource(Page, AbstractResource):
 
         hs_term_dict["HS_RES_ID"] = self.short_id
         hs_term_dict["HS_RES_TYPE"] = self.resource_type
+        hs_term_dict.update(self.extra_metadata.items())
 
         return hs_term_dict
 

--- a/hs_file_types/models/reftimeseries.py
+++ b/hs_file_types/models/reftimeseries.py
@@ -1043,7 +1043,7 @@ def _validate_json_data(json_data):
             try:
                 urlopen(url)
             except URLError:
-                raise Exception(err_msg.format("Invalid web service URL found {}".format(request_info['url'])))
+                raise Exception(err_msg.format("Invalid web service URL found"))
 
         #  validate methodDescription for empty string
         _check_for_empty_string(series['method']['methodDescription'], 'methodDescription')

--- a/hs_tools_resource/app_launch_helper.py
+++ b/hs_tools_resource/app_launch_helper.py
@@ -75,7 +75,7 @@ def _get_app_tool_info(request_obj, resource_obj, tool_res_obj, open_with=False)
     tool_icon_url = tool_res_obj.metadata.app_icon.data_url \
         if tool_res_obj.metadata.app_icon else "raise-img-error"
 
-    url_key_values = get_app_dict(request_obj.user, resource_obj)
+    url_key_values = get_app_dict(request_obj.user, resource_obj, tool_res_obj.extra_metadata)
 
     tool_url_resource_new = parse_app_url_template(tool_url_resource, url_key_values)
     tool_url_agg_new = parse_app_url_template(tool_url_aggregation, url_key_values)
@@ -110,7 +110,7 @@ def _get_app_tool_info(request_obj, resource_obj, tool_res_obj, open_with=False)
         return {}
 
 
-def get_app_dict(user, resource):
+def get_app_dict(user, resource, default_resource_term_dict):
     hs_term_dict_user = {}
     hs_term_dict_user["HS_USR_NAME"] = user.username if user.is_authenticated() else "anonymous"
     hs_term_dict_file = {}
@@ -119,7 +119,8 @@ def get_app_dict(user, resource):
     hs_term_dict_file["HS_AGG_PATH"] = "HS_JS_AGG_KEY"
     hs_term_dict_file["HS_FILE_PATH"] = "HS_JS_FILE_KEY"
     hs_term_dict_file["HS_MAIN_FILE"] = "HS_JS_MAIN_FILE_KEY"
-    return [resource.get_hs_term_dict(), hs_term_dict_user, hs_term_dict_file]
+    default_resource_term_dict.update(resource.get_hs_term_dict())
+    return [default_resource_term_dict, hs_term_dict_user, hs_term_dict_file]
 
 
 def _check_user_can_view_app(request_obj, tool_res_obj):

--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -120,71 +120,13 @@ class UrlValidationForm(forms.Form):
 class AppResourceLevelUrlValidationForm(forms.Form):
     value = forms.URLField(max_length=1024, required=False)
 
-    def clean(self):
-        cleaned_data = super(AppResourceLevelUrlValidationForm, self).clean()
-        cleaned_url = cleaned_data.get("value")
-        if not cleaned_url:
-            return
-
-        from .utils import parse_app_url_template
-
-        term_dict = {}
-        term_dict["HS_RES_ID"] = "a"
-        term_dict["HS_RES_TYPE"] = "b"
-        term_dict["HS_USR_NAME"] = "c"
-        term_dict["HS_FILE_NAME"] = "d"
-        parsed = parse_app_url_template(cleaned_url, [term_dict])
-
-        if not parsed:
-            raise ValidationError("[WebApp] '{0}' cannot be parsed by term_dict {1}.".
-                                  format(cleaned_url, str(list(term_dict.keys()))))
-
 
 class AppAggregationLevelUrlValidationForm(forms.Form):
     value = forms.URLField(max_length=1024, required=False)
 
-    def clean(self):
-        cleaned_data = super(AppAggregationLevelUrlValidationForm, self).clean()
-        cleaned_url = cleaned_data.get("value")
-        if not cleaned_url:
-            return
-
-        from .utils import parse_app_url_template
-
-        term_dict = {}
-        term_dict["HS_RES_ID"] = "a"
-        term_dict["HS_RES_TYPE"] = "b"
-        term_dict["HS_USR_NAME"] = "c"
-        term_dict["HS_AGG_PATH"] = "d"
-        term_dict["HS_MAIN_FILE"] = "e"
-        parsed = parse_app_url_template(cleaned_url, [term_dict])
-
-        if not parsed:
-            raise ValidationError("[WebApp] '{0}' cannot be parsed by term_dict {1}.".
-                                  format(cleaned_url, str(list(term_dict.keys()))))
-
 
 class AppFileLevelUrlValidationForm(forms.Form):
     value = forms.URLField(max_length=1024, required=False)
-
-    def clean(self):
-        cleaned_data = super(AppFileLevelUrlValidationForm, self).clean()
-        cleaned_url = cleaned_data.get("value")
-        if not cleaned_url:
-            return
-
-        from .utils import parse_app_url_template
-
-        term_dict = {}
-        term_dict["HS_RES_ID"] = "a"
-        term_dict["HS_RES_TYPE"] = "b"
-        term_dict["HS_USR_NAME"] = "c"
-        term_dict["HS_FILE_PATH"] = "d"
-        parsed = parse_app_url_template(cleaned_url, [term_dict])
-
-        if not parsed:
-            raise ValidationError("[WebApp] '{0}' cannot be parsed by term_dict {1}.".
-                                  format(cleaned_url, str(list(term_dict.keys()))))
 
 
 class SupportedFileExtensionsValidationForm(forms.Form):

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -392,8 +392,7 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         request.user = self.user
 
         relevant_tools = resource_level_tool_urls(self.resComposite, request)
-        self.assertIsNotNone(relevant_tools, msg='relevant_tools should not be None with appkey '
-                                                 'matching')
+        self.assertIsNotNone(relevant_tools, msg='relevant_tools should not be None')
         tc = relevant_tools['resource_level_app_counter']
         self.assertEqual(tc, 1, msg='open with app counter ' + str(tc) + ' is not 1')
         tl = relevant_tools['tool_list'][0]
@@ -409,6 +408,12 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         relevant_tools = resource_level_tool_urls(self.resComposite, request)
         self.assertIsNone(relevant_tools, msg='relevant_tools should be None with no web app '
                                               'matching')
+        # test for default custom key value specified in the web app
+        self.resWebApp.extra_metadata = {'search_string': 'it works'}
+        self.resWebApp.save()
+        relevant_tools = resource_level_tool_urls(self.resComposite, request)
+        self.assertIsNotNone(relevant_tools, msg='relevant_tools should not be None with a default '
+                                                 'web app key')
 
     def test_web_app_do_needed_work_when_being_launched(self):
         # testing a web app does needed work when being launched. Currently, the needed work when

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -372,8 +372,7 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
                                               'matching')
 
     def test_web_app_extended_metadata_custom_key(self):
-        # testing a resource can be associated with a web app tool resource via
-        # appkey name-value extended metadata matching
+        # testing a web resource may contain custom keys
         self.user.ulabels.add_open_with_app(self.resWebApp)
         self.assertEqual(ToolResource.objects.count(), 1)
         metadata = []

--- a/hs_tools_resource/tests/test_web_app.py
+++ b/hs_tools_resource/tests/test_web_app.py
@@ -414,6 +414,17 @@ class TestWebAppFeature(TestCaseCommonUtilities, TransactionTestCase):
         relevant_tools = resource_level_tool_urls(self.resComposite, request)
         self.assertIsNotNone(relevant_tools, msg='relevant_tools should not be None with a default '
                                                  'web app key')
+        tl = relevant_tools['tool_list'][0]
+        self.assertEqual(tl['url'], "{'value': 'https://www.google.com?s=it works'}")
+
+        # test for resource override of default custom key value specified in the web app
+        self.resComposite.extra_metadata = {'search_string': 'overridden'}
+        self.resComposite.save()
+        relevant_tools = resource_level_tool_urls(self.resComposite, request)
+        self.assertIsNotNone(relevant_tools, msg='relevant_tools should not be None with a default '
+                                                 'web app key')
+        tl = relevant_tools['tool_list'][0]
+        self.assertEqual(tl['url'], "{'value': 'https://www.google.com?s=overridden'}")
 
     def test_web_app_do_needed_work_when_being_launched(self):
         # testing a web app does needed work when being launched. Currently, the needed work when

--- a/hs_tools_resource/tests/test_web_app_validation.py
+++ b/hs_tools_resource/tests/test_web_app_validation.py
@@ -53,12 +53,13 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
         self.assertEqual(1, RequestUrlBaseFile.objects.all().count())
+        self.assertEqual(good_url, RequestUrlBaseFile.objects.first().value)
 
-    def test_file_level_keys_add_bad(self):
-        bad_url = 'https://www.google.com?' \
-                  'file_id=${BAD_KEY}'
+    def test_file_level_keys_add_custom(self):
+        custom_url = 'https://www.google.com?' \
+                  'file_id=${custom_KEY}'
 
-        post_data = {'value': bad_url}
+        post_data = {'value': custom_url}
         url_params = {'element_name': "requesturlbasefile", 'shortkey': self.resWebApp.short_id}
 
         url = reverse('add_metadata_element', kwargs=url_params)
@@ -69,7 +70,8 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
                                         element_name="requesturlbasefile")
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
-        self.assertEqual(0, RequestUrlBaseFile.objects.all().count())
+        self.assertEqual(1, RequestUrlBaseFile.objects.all().count())
+        self.assertEqual(custom_url, RequestUrlBaseFile.objects.first().value)
 
     def test_file_level_keys_update(self):
         good_url = 'https://www.google.com?' \
@@ -110,9 +112,10 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(1, RequestUrlBaseFile.objects.all().count())
         self.assertEqual(updated_url, RequestUrlBaseFile.objects.first().value)
 
-        # update bad url
+        # update custom url
         url = reverse('update_metadata_element', kwargs=url_params)
-        post_data = {'value': 'https://www.google.com?file_id=${BAD_KEY}'}
+        custom_url = 'https://www.google.com?file_id=${BAD_KEY}'
+        post_data = {'value': custom_url}
         request = self.factory.post(url, data=post_data)
         request.user = self.user
         request.META['HTTP_REFERER'] = 'http_referer'
@@ -121,8 +124,7 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
         self.assertEqual(1, RequestUrlBaseFile.objects.all().count())
-        # ensure it did not change
-        self.assertEqual(updated_url, RequestUrlBaseFile.objects.first().value)
+        self.assertEqual(custom_url, RequestUrlBaseFile.objects.first().value)
 
     def test_aggregation_level_keys_add_good(self):
         good_url = 'https://www.google.com?' \
@@ -145,12 +147,13 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
         self.assertEqual(1, RequestUrlBaseAggregation.objects.all().count())
+        self.assertEqual(good_url, RequestUrlBaseFile.objects.first().value)
 
-    def test_aggregation_level_keys_add_bad(self):
-        bad_url = 'https://www.google.com?' \
-                  'file_id=${BAD_KEY}'
+    def test_aggregation_level_keys_add_custom(self):
+        custom_url = 'https://www.google.com?' \
+                  'file_id=${Custom_KEY}'
 
-        post_data = {'value': bad_url}
+        post_data = {'value': custom_url}
         url_params = {'element_name': "requesturlbaseaggregation",
                       'shortkey': self.resWebApp.short_id}
 
@@ -162,7 +165,8 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
                                         element_name="requesturlbaseaggregation")
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
-        self.assertEqual(0, RequestUrlBaseAggregation.objects.all().count())
+        self.assertEqual(1, RequestUrlBaseAggregation.objects.all().count())
+        self.assertEqual(custom_url, RequestUrlBaseAggregation.objects.first().value)
 
     def test_aggregation_level_keys_update(self):
         good_url = 'https://www.google.com?' \
@@ -205,9 +209,10 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(1, RequestUrlBaseAggregation.objects.all().count())
         self.assertEqual(updated_url, RequestUrlBaseAggregation.objects.first().value)
 
-        # update bad url
+        # update custom key url
         url = reverse('update_metadata_element', kwargs=url_params)
-        post_data = {'value': 'https://www.google.com?file_id=${BAD_KEY}'}
+        custom_url = 'https://www.google.com?file_id=${BAD_KEY}'
+        post_data = {'value': custom_url}
         request = self.factory.post(url, data=post_data)
         request.user = self.user
         request.META['HTTP_REFERER'] = 'http_referer'
@@ -216,8 +221,7 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
         self.assertEqual(1, RequestUrlBaseAggregation.objects.all().count())
-        # ensure it did not change
-        self.assertEqual(updated_url, RequestUrlBaseAggregation.objects.first().value)
+        self.assertEqual(custom_url, RequestUrlBaseAggregation.objects.first().value)
 
     def test_resource_level_keys_add_good(self):
         good_url = 'https://www.google.com?' \
@@ -239,11 +243,11 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
 
         self.assertEqual(1, RequestUrlBase.objects.all().count())
 
-    def test_resource_level_keys_add_bad(self):
-        bad_url = 'https://www.google.com?' \
-                  'file_id=${BAD_KEY}'
+    def test_resource_level_keys_add_custom(self):
+        custom_url = 'https://www.google.com?' \
+                  'file_id=${CUSTOM_KEY}'
 
-        post_data = {'value': bad_url}
+        post_data = {'value': custom_url}
         url_params = {'element_name': "requesturlbase", 'shortkey': self.resWebApp.short_id}
 
         url = reverse('add_metadata_element', kwargs=url_params)
@@ -254,7 +258,8 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
                                         element_name="requesturlbase")
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
-        self.assertEqual(0, RequestUrlBase.objects.all().count())
+        self.assertEqual(1, RequestUrlBase.objects.all().count())
+        self.assertEqual(custom_url, RequestUrlBase.objects.first().value)
 
     def test_resource_level_keys_update(self):
         good_url = 'https://www.google.com?' \
@@ -295,9 +300,10 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(1, RequestUrlBase.objects.all().count())
         self.assertEqual(updated_url, RequestUrlBase.objects.first().value)
 
-        # update bad url
+        # update custom url
         url = reverse('update_metadata_element', kwargs=url_params)
-        post_data = {'value': 'https://www.google.com?file_id=${BAD_KEY}'}
+        custom_key_url = 'https://www.google.com?file_id=${CUSTOM_KEY}'
+        post_data = {'value': custom_key_url}
         request = self.factory.post(url, data=post_data)
         request.user = self.user
         request.META['HTTP_REFERER'] = 'http_referer'
@@ -306,8 +312,7 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
         self.assertEqual(1, RequestUrlBase.objects.all().count())
-        # ensure it did not change
-        self.assertEqual(updated_url, RequestUrlBase.objects.first().value)
+        self.assertEqual(custom_key_url, RequestUrlBase.objects.first().value)
 
     def test_file_extensions_update(self):
         good_extensions = '.tif, .txt,.html'

--- a/hs_tools_resource/tests/test_web_app_validation.py
+++ b/hs_tools_resource/tests/test_web_app_validation.py
@@ -147,11 +147,11 @@ class TestWebAppValidationFeature(TestCaseCommonUtilities, TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
         self.assertEqual(1, RequestUrlBaseAggregation.objects.all().count())
-        self.assertEqual(good_url, RequestUrlBaseFile.objects.first().value)
+        self.assertEqual(good_url, RequestUrlBaseAggregation.objects.first().value)
 
     def test_aggregation_level_keys_add_custom(self):
         custom_url = 'https://www.google.com?' \
-                  'file_id=${Custom_KEY}'
+                  'file_id=${HS_CUSTOM}'
 
         post_data = {'value': custom_url}
         url_params = {'element_name': "requesturlbaseaggregation",

--- a/hs_tools_resource/utils.py
+++ b/hs_tools_resource/utils.py
@@ -35,7 +35,7 @@ def parse_app_url_template(url_template_string, term_dict_list=()):
 
         new_url_string = Template(new_url_string).substitute(merged_term_dic)
     except Exception:
-        logger.exception("[WebApp] '{0}' cannot be parsed by term_dict {1}.".
+        logger.debug("[WebApp] '{0}' cannot be parsed by term_dict {1}, skipping.".
                          format(new_url_string, str(merged_term_dic)))
         new_url_string = None
     finally:


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Add a custom key to a web app url.  Mark all sharing permissions and Composite Resource type.  Add the web app to your open with list.  Go to a composite resource, validate the web app does not show.  Add additional metadata with the same key as the custom key provided in the web app and anything you'd like as the value.  Refresh the resource page and validate the web app appears.  Click the web app from the list and validate the url replaces the custom key with the value provided in your reosurce.
