### PR TITLE
turn off bot indexing and heap analytics when DEBUG is set to TRUE

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -3,7 +3,7 @@
 {% load pages_tags mezzanine_tags i18n staticfiles theme_tags hydroshare_tags %}
 {% get_site_conf as siteconf %}
 <head>
-{% if settings.DEBUG == True %}<meta name="robots" content="noindex">{% endif %}
+{% if page|is_debug %}<meta name="robots" content="noindex">{% endif %}
 <meta http-equiv="Content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width">
 <meta name="keywords" content="{% block meta_keywords %}{% endblock %}">
@@ -69,12 +69,12 @@
 <![endif]-->
 
 {% block extra_head %}{% endblock %}
-
+{% if not page|is_debug %}
 <script type="text/javascript">
     window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
       heap.load("1320547260");
 </script>
-
+{% endif %}
 </head>
 
 <body id="{% block body_id %}body{% endblock %}">


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. When settings.DEBUG is True, `<meta name="robots" content="noindex">` should show on each page,  When DEBUG is false, it should not show.
2. When Settings.DEBUG is True, heap analytics should not be included on each page.  When DEBUG is false heap analytics should be referenced in a script tag on each page.
