### PR TITLE
Collection optimize bugfix

### DIFF
--- a/hs_collection_resource/tests/test_utils.py
+++ b/hs_collection_resource/tests/test_utils.py
@@ -85,13 +85,17 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
     def test_collectable_shareable_resources(self):
         # owned resources are collectable
         self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)
+        # ensure resource not owned by user1 is public and shareable
         self.res_1_user_2.raccess.public = True
         self.res_1_user_2.raccess.shareable = True
         self.res_1_user_2.raccess.save()
         self.assertTrue(self.res_1_user_2.raccess.public)
         self.assertTrue(self.res_1_user_2.raccess.shareable)
+        # claim user_2's resource for user_1
         self.user1.ulabels.claim_resource(self.res_1_user_2)
+        # validate the claimed resource is included with the collectable result
         self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 3)
+        # turn off sharing to validate the claimed resource no longer is included with the collectable result
         self.res_1_user_2.raccess.shareable = False
         self.res_1_user_2.raccess.save()
         self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)

--- a/hs_collection_resource/tests/test_utils.py
+++ b/hs_collection_resource/tests/test_utils.py
@@ -78,13 +78,12 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
             title='Gen 3'
         )
 
-
     def tearDown(self):
         os.remove('test1.txt')
 
     def test_collectable_shareable_resources(self):
         # owned resources are collectable
-        self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)
+        self.assertEqual(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)
         # ensure resource not owned by user1 is public and shareable
         self.res_1_user_2.raccess.public = True
         self.res_1_user_2.raccess.shareable = True
@@ -94,8 +93,8 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
         # claim user_2's resource for user_1
         self.user1.ulabels.claim_resource(self.res_1_user_2)
         # validate the claimed resource is included with the collectable result
-        self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 3)
+        self.assertEqual(get_collectable_resources(self.user1, self.resCollection).all().count(), 3)
         # turn off sharing to validate the claimed resource no longer is included with the collectable result
         self.res_1_user_2.raccess.shareable = False
         self.res_1_user_2.raccess.save()
-        self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)
+        self.assertEqual(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)

--- a/hs_collection_resource/tests/test_utils.py
+++ b/hs_collection_resource/tests/test_utils.py
@@ -1,0 +1,97 @@
+import os
+from django.test import TransactionTestCase, Client
+from django.contrib.auth.models import Group
+
+from hs_core.hydroshare import create_resource, create_account, UploadedFile
+from hs_core.testing import MockIRODSTestCaseMixin
+
+from hs_collection_resource.utils import get_collectable_resources
+
+
+class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
+
+    def setUp(self):
+        super(TestCollection, self).setUp()
+        self.api_client = Client()
+        self.group, _ = Group.objects.get_or_create(name='Hydroshare Author')
+
+        self.user1 = create_account(
+            'byu1@byu.edu',
+            username='user1',
+            password='mypassword1',
+            first_name='myfirstname1',
+            last_name='mylastname1',
+            superuser=False,
+            groups=[self.group]
+        )
+
+        self.resCollection = create_resource(
+            resource_type='CollectionResource',
+            owner=self.user1,
+            title='My Collection',
+            keywords=['kw1', 'kw2'],
+            metadata=[{"rights": {"statement": "mystatement", "url": "http://www.google.com"}},
+                      {"description": {"abstract": "myabstract"}}
+                      ]
+        )
+
+        self.res_1_user_1 = create_resource(
+            resource_type='CompositeResource',
+            owner=self.user1,
+            title='Gen 1'
+        )
+
+        self.res_2_user_1 = create_resource(
+            resource_type='CompositeResource',
+            owner=self.user1,
+            title='Gen 2'
+        )
+
+        self.user2 = create_account(
+            'byu2@byu.edu',
+            username='user2',
+            password='mypassword2',
+            first_name='myfirstname2',
+            last_name='mylastname2',
+            superuser=False,
+            groups=[self.group]
+        )
+
+        test_file1 = open('test1.txt', 'w')
+        test_file1.write("Test text file in test1.txt")
+        test_file1.close()
+        test_file1 = open('test1.txt', 'rb')
+        files = [UploadedFile(file=test_file1, name='test1.txt')]
+        metadata_dict = [{'description': {'abstract': 'My test abstract'}}]
+        self.res_1_user_2 = create_resource(
+            resource_type='CompositeResource',
+            owner=self.user2,
+            title='Gen 4',
+            keywords=['kw1', 'kw2'],
+            files=files,
+            metadata=metadata_dict
+        )
+
+        self.res_2_user_2 = create_resource(
+            resource_type='CompositeResource',
+            owner=self.user2,
+            title='Gen 3'
+        )
+
+
+    def tearDown(self):
+        os.remove('test1.txt')
+
+    def test_collectable_shareable_resources(self):
+        # owned resources are collectable
+        self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)
+        self.res_1_user_2.raccess.public = True
+        self.res_1_user_2.raccess.shareable = True
+        self.res_1_user_2.raccess.save()
+        self.assertTrue(self.res_1_user_2.raccess.public)
+        self.assertTrue(self.res_1_user_2.raccess.shareable)
+        self.user1.ulabels.claim_resource(self.res_1_user_2)
+        self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 3)
+        self.res_1_user_2.raccess.shareable = False
+        self.res_1_user_2.raccess.save()
+        self.assertEquals(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)

--- a/hs_collection_resource/utils.py
+++ b/hs_collection_resource/utils.py
@@ -5,9 +5,12 @@ import shutil
 import logging
 
 from django.core.files.uploadedfile import UploadedFile
+from django.db.models import Q
 
 from hs_core.hydroshare.utils import resource_modified, current_site_url
 from hs_core.hydroshare.resource import delete_resource_file_only, add_resource_files
+from hs_core.views.utils import get_my_resources_list
+from hs_access_control.models import PrivilegeCodes
 
 logger = logging.getLogger(__name__)
 RES_LANDING_PAGE_URL_TEMPLATE = current_site_url() + "/resource/{0}/"
@@ -119,6 +122,19 @@ def update_collection_list_csv(collection_obj):
         if tmp_dir is not None:
             shutil.rmtree(tmp_dir)
         return csv_content_list
+
+
+def get_collectable_resources(user, coll_resource):
+    get_my_resources_list(user)
+
+    # resource is collectable if
+    # 1) Shareable=True
+    # 2) OR, current user is a owner of it
+    # 3) exclude this resource as well as resources already in the collection
+    return get_my_resources_list(user) \
+        .exclude(short_id=coll_resource.short_id) \
+        .exclude(id__in=coll_resource.resources.values_list("id", flat=True)) \
+        .filter(Q(raccess__shareable=True) | (Q(r2urp__user=user) & Q(r2urp__privilege=PrivilegeCodes.OWNER)))
 
 
 def _get_owners_string(owners_list):

--- a/theme/templates/resource-landing-page/manage-access.html
+++ b/theme/templates/resource-landing-page/manage-access.html
@@ -198,7 +198,7 @@
                                     <div class="checkbox">
                                         <label>
                                             <input type="checkbox" v-model="resAccess.isShareable" :disabled="isProcessingShareable"
-                                                   @change="setShareable(resAccess.isShareable ? 'make_not_shareable' : 'make_shareable')">
+                                                   @change="setShareable(resAccess.isShareable ? 'make_shareable' : 'make_not_shareable')">
                                             Shareable
                                         </label>
                                     </div>


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Share/unshare a resource, refresh the page between and check to make sure the shareable checkbox is correct.
2. Create a composite resource with user1, make it public and shareable.  Create a collection resource with user1, validate the composite resource is available to add to the collection.  Create a collection resource with user2, add user1's composite resource to user2's my-resource, validate user1's composite resource is availabe to add to user2's collection resource.  Uncheck shareable on user1's composite resource.  Validate user1 can add the composite resource to it's collection.  Validate user2 can not add the composite resource to it's collection.
