### PR TITLE
[#3863] - check empty string file_folder for root directory

### DIFF
--- a/hs_composite_resource/tests/test_readme_file.py
+++ b/hs_composite_resource/tests/test_readme_file.py
@@ -215,6 +215,28 @@ class TestReadmeResourceFile(MockIRODSTestCaseMixin, TransactionTestCase):
         self.assertNotEqual(self.composite_resource.readme_file, None)
         self.assertNotEqual(self.composite_resource.get_readme_file_content(), None)
 
+    def test_readme_file_8(self):
+        """Test that when a README.md file with file_folder as '' instead of None,
+        this file is considered as the readme file of the resource"""
+
+        self._create_composite_resource()
+        # resource should not have any file at this point
+        self.assertEqual(self.composite_resource.files.count(), 0)
+        # resource has no readme file
+        self.assertEqual(self.composite_resource.readme_file, None)
+        # add the README.MD file to the resource at the root level
+        files_to_add = [self.README_MD]
+        self._add_files_to_resource(files_to_add)
+        # resource should have one file at this point
+        self.assertEqual(self.composite_resource.files.count(), 1)
+        # Update the readme file_folder to an empty string
+        file = self.composite_resource.files.first()
+        file.file_folder=''
+        file.save()
+        # resource has a readme file
+        self.assertNotEqual(self.composite_resource.readme_file, None)
+        self.assertNotEqual(self.composite_resource.get_readme_file_content(), None)
+
     def _create_composite_resource(self):
         self.composite_resource = hydroshare.create_resource(
              resource_type='CompositeResource',

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2330,7 +2330,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
         'readme.txt' or 'readme.md' (filename is case insensitive). If no such file then None
         is returned. If both files exist then resource file for readme.md is returned"""
 
-        res_files_at_root = self.files.filter(file_folder=None)
+        res_files_at_root = self.files.filter(Q(file_folder=None)|Q(file_folder=''))
         readme_txt_file = None
         readme_md_file = None
         for res_file in res_files_at_root:


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Somehow make the file_folder of a README ResourceFile model an empty string rather than None. (I did this by opening the python shell and updating it directly, however there are ways to do this in the system, I'm just not sure what they are).  Open the resource landing page and validate the README page renders.
