### PR TITLE
Turn on pseudo threads in gevent

### DIFF
--- a/gunicorn_start
+++ b/gunicorn_start
@@ -15,6 +15,7 @@ DJANGO_WSGI_MODULE=hydroshare.wsgi                  # WSGI module name
 GUNICORN_LOG=/hydroshare/log/gunicorn.log           # path to logfile
 TIMEOUT_PERIOD=300                                  # timeout period in seconds
 MAX_REQUESTS=1000                                   # maximum number of requests a worker will process before restarting
+THREADS=1000
 
 ### Do not edit below this line ###
 echo "Starting $NAME as `whoami`"
@@ -30,6 +31,7 @@ exec gunicorn ${DJANGO_WSGI_MODULE}:application \
   --name $NAME \
   --workers $NUM_WORKERS \
   --worker-class gevent \
+  --worker-connections $THREADS \
   --user $USER \
   --group $GROUP \
   --bind unix:$SOCKFILE \

--- a/nginx/config-files/hydroshare-local-nginx.conf.template
+++ b/nginx/config-files/hydroshare-local-nginx.conf.template
@@ -20,7 +20,7 @@ proxy_set_header X-Forwarded-Proto $scheme;
 client_max_body_size 4096m;
 client_body_buffer_size 1m;
 proxy_intercept_errors on;
-proxy_buffering on;
+proxy_buffering off;
 proxy_buffer_size 128k;
 proxy_buffers 256 16k;
 proxy_busy_buffers_size 256k;

--- a/nginx/config-files/hydroshare-nginx.conf.template
+++ b/nginx/config-files/hydroshare-nginx.conf.template
@@ -20,7 +20,7 @@ proxy_set_header X-Forwarded-Proto $scheme;
 client_max_body_size 4096m;
 client_body_buffer_size 1m;
 proxy_intercept_errors on;
-proxy_buffering on;
+proxy_buffering off;
 proxy_buffer_size 128k;
 proxy_buffers 256 16k;
 proxy_busy_buffers_size 256k;

--- a/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -26,7 +26,7 @@ proxy_set_header X-Forwarded-Proto $scheme;
 client_max_body_size 4096m;
 client_body_buffer_size 1m;
 proxy_intercept_errors on;
-proxy_buffering on;
+proxy_buffering off;
 proxy_buffer_size 128k;
 proxy_buffers 256 16k;
 proxy_busy_buffers_size 256k;


### PR DESCRIPTION
This simple change modifies the Guincorn and NGINX configurations to turn off NGINX-based Django response buffering and replace this with gunicorn Django response buffering.  It utilizes 1000 pseudo-threads per worker to manage TCP connections from Django to the outside world. 

This enables a number of things, including streaming download from Django, and is recommended for I/o intensive applications like ours. 

See issue #3953 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
