### PR TITLE
#3959 Change JH app target URL to jupyterhub.cuahsi.org

### DIFF
--- a/theme/templates/pages/dashboard.html
+++ b/theme/templates/pages/dashboard.html
@@ -105,7 +105,7 @@ timestamp should go with a template tags to convert to a human readble day.
             {% include "includes/apps_block_title.html" %}
             <div class="row big-app-row">
                 {% trans "CUAHSI JupyterHub" as title_name %}
-                {% trans "https://jupyter.cuahsi.org" as title_url %}
+                {% trans "https://jupyterhub.cuahsi.org" as title_url %}
                 {% trans "jupiterhub.png" as app_image %}
                 {% trans "Jupyter Hub App" as app_image_alt %}
                 {% trans "Use this app to launch HydroShare data in an online Python environment that uses JupyterHub software stack." as app_content %}


### PR DESCRIPTION
This pull request fixes an issue caused by launching the CUAHSI JupyterHub using the legacy url (i.e. jupyter.cuahsi.org). I believe the error occurs because the OAuth handshake begins before redirecting to the new url (jupyterhub.cuahsi.org) resulting in missing state cookies. This PR contains one simple change to the dashboard page to change the CUAHSI JupyterHub target url from jupyter.cuahsi.org to jupyterhub.cuahsi.org.

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

- [ ] Automated Testing

- [ ] Sufficient User and Developer Documentation

- [ ] Passing Jenkins Build

- [ ] Peer Code review and approval

### Positive Test Case

1. Go to HydroShare.org/home
2. Click CUAHSI JupyterHub
3. Verify that you are redirected to jupyterhub.cuahsi.org
4. Agree to the terms of use and login
5. Verify that a 400 error does not occur.