### PR TITLE
Allow public/discoverable resource to be part of collection resource

### DIFF
--- a/hs_collection_resource/tests/test_collection.py
+++ b/hs_collection_resource/tests/test_collection.py
@@ -465,6 +465,36 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
         resp_json = json.loads(response.content.decode())
         self.assertEqual(resp_json["status"], "error")
         self.assertEqual(self.resCollection.resources.count(), 0)
+
+        # make resGen5 not discoverable
+        self.resGen5.raccess.discoverable = False
+        self.resGen5.raccess.save()
+        # remove all existing contained resources
+        response = self.api_client.post(url_to_update_collection,
+                                        {'resource_id_list': []},
+                                        )
+        resp_json = json.loads(response.content.decode())
+        self.assertEqual(resp_json["status"], "success")
+        self.assertEqual(self.resCollection.resources.count(), 0)
+        # trying to add resGen5 (for which user1 has vew permission) to the collection should fail as resGen5 is not
+        # discoverable
+        response = self.api_client.post(url_to_update_collection,
+                                        {'resource_id_list': [self.resGen5.short_id]}, )
+        resp_json = json.loads(response.content.decode())
+        self.assertEqual(resp_json["status"], "error")
+        self.assertEqual(self.resCollection.resources.count(), 0)
+
+        # make resGen5 discoverable
+        self.resGen5.raccess.discoverable = True
+        self.resGen5.raccess.public = False
+        self.resGen5.raccess.save()
+        # trying to add resGen5 (resource discoverable but private) to the collection should be successful
+        response = self.api_client.post(url_to_update_collection,
+                                        {'resource_id_list': [self.resGen5.short_id]}, )
+        resp_json = json.loads(response.content.decode())
+        self.assertEqual(resp_json["status"], "success")
+        self.assertEqual(self.resCollection.resources.count(), 1)
+
         # make resGen5 public
         self.resGen5.raccess.public = True
         self.resGen5.raccess.save()

--- a/hs_collection_resource/tests/test_collection.py
+++ b/hs_collection_resource/tests/test_collection.py
@@ -448,6 +448,33 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
         self.assertIn(self.resGen2, self.resCollection.resources.all())
         self.assertIn(self.resGen5, self.resCollection.resources.all())
 
+        # make resGen5 not shareable
+        self.resGen5.raccess.shareable = False
+        self.resGen5.raccess.save()
+        # remove all existing contained resources
+        response = self.api_client.post(url_to_update_collection,
+                                        {'resource_id_list': []},
+                                        )
+        resp_json = json.loads(response.content.decode())
+        self.assertEqual(resp_json["status"], "success")
+        self.assertEqual(self.resCollection.resources.count(), 0)
+        # trying to add resGen5 (for which user1 has vew permission) to the collection should fail as resGen5 is not
+        # shareable
+        response = self.api_client.post(url_to_update_collection,
+                                        {'resource_id_list': [self.resGen5.short_id]}, )
+        resp_json = json.loads(response.content.decode())
+        self.assertEqual(resp_json["status"], "error")
+        self.assertEqual(self.resCollection.resources.count(), 0)
+        # make resGen5 public
+        self.resGen5.raccess.public = True
+        self.resGen5.raccess.save()
+        # trying to add resGen5 (public resource not shareable) to the collection should be successful
+        response = self.api_client.post(url_to_update_collection,
+                                        {'resource_id_list': [self.resGen5.short_id]}, )
+        resp_json = json.loads(response.content.decode())
+        self.assertEqual(resp_json["status"], "success")
+        self.assertEqual(self.resCollection.resources.count(), 1)
+
         # test adding resources to a collection that does not have all the required metadata
         self.assertEqual(self.resCollection_with_missing_metadata.resources.count(), 0)
         url_to_update_collection = self.url_to_update_collection.format(

--- a/hs_collection_resource/tests/test_utils.py
+++ b/hs_collection_resource/tests/test_utils.py
@@ -98,3 +98,8 @@ class TestCollection(MockIRODSTestCaseMixin, TransactionTestCase):
         self.res_1_user_2.raccess.shareable = False
         self.res_1_user_2.raccess.save()
         self.assertEqual(get_collectable_resources(self.user1, self.resCollection).all().count(), 2)
+
+        # turn on discoverable to validate the claimed resource is included with the collectable result
+        self.res_1_user_2.raccess.discoverable = True
+        self.res_1_user_2.raccess.save()
+        self.assertEqual(get_collectable_resources(self.user1, self.resCollection).all().count(), 3)

--- a/hs_collection_resource/utils.py
+++ b/hs_collection_resource/utils.py
@@ -125,16 +125,18 @@ def update_collection_list_csv(collection_obj):
 
 
 def get_collectable_resources(user, coll_resource):
-    get_my_resources_list(user)
+    my_resources = get_my_resources_list(user)
 
     # resource is collectable if
     # 1) Shareable=True
-    # 2) OR, current user is a owner of it
-    # 3) exclude this resource as well as resources already in the collection
-    return get_my_resources_list(user) \
+    # 2) Discoverable=True
+    # 3) OR, current user is a owner of it
+    # 4) exclude this resource as well as resources already in the collection
+    return my_resources \
         .exclude(short_id=coll_resource.short_id) \
         .exclude(id__in=coll_resource.resources.values_list("id", flat=True)) \
-        .filter(Q(raccess__shareable=True) | (Q(r2urp__user=user) & Q(r2urp__privilege=PrivilegeCodes.OWNER)))
+        .filter(Q(raccess__shareable=True) | Q(raccess__discoverable=True) |
+                (Q(r2urp__user=user) & Q(r2urp__privilege=PrivilegeCodes.OWNER)))
 
 
 def _get_owners_string(owners_list):

--- a/hs_collection_resource/views.py
+++ b/hs_collection_resource/views.py
@@ -117,13 +117,14 @@ def update_collection(request, shortkey, *args, **kwargs):
                     = authorize(request, res_id_add,
                                 needed_permission=ACTION_TO_AUTHORIZE.VIEW_METADATA)
 
-                # the resources being added should be 'Shareable' or 'Public'
+                # the resources being added should be 'Shareable', 'Discoverable' or 'Public'
                 # or is owned by current user
+                is_discoverable = res_to_add.raccess.discoverable
                 is_shareable = res_to_add.raccess.shareable
                 is_public = res_to_add.raccess.public
                 is_owner = res_to_add.raccess.owners.filter(pk=user.pk).exists()
-                if not is_shareable and not is_public and not is_owner:
-                    raise Exception('Only resource owner can add a non-shareable or private '
+                if not any([is_discoverable, is_shareable, is_public, is_owner]):
+                    raise Exception('Only resource owner can add a non-shareable, non-discoverable, or private '
                                     'resource to a collection ')
 
                 # add this new res to collection

--- a/hs_collection_resource/views.py
+++ b/hs_collection_resource/views.py
@@ -117,13 +117,14 @@ def update_collection(request, shortkey, *args, **kwargs):
                     = authorize(request, res_id_add,
                                 needed_permission=ACTION_TO_AUTHORIZE.VIEW_METADATA)
 
-                # the resources being added should be 'Shareable'
+                # the resources being added should be 'Shareable' or 'Public'
                 # or is owned by current user
                 is_shareable = res_to_add.raccess.shareable
+                is_public = res_to_add.raccess.public
                 is_owner = res_to_add.raccess.owners.filter(pk=user.pk).exists()
-                if not is_shareable and not is_owner:
-                        raise Exception('Only resource owner can add a non-shareable '
-                                        'resource to a collection ')
+                if not is_shareable and not is_public and not is_owner:
+                    raise Exception('Only resource owner can add a non-shareable or private '
+                                    'resource to a collection ')
 
                 # add this new res to collection
                 res_obj_add = get_resource_by_shortkey(res_id_add)


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a collection resource.
2. Create a composite resource for which the owner is different from the collection resource. Set the composite resource to 'public'.
3. Edit the collection resource to add the composite resource to that collection. Verify that you are able to add the public composite resource to the collection.
4. Create another composite resource for which the owner is different from the collection resource. Set the composite resource to 'discoverable'.
5. Edit the collection resource to add the composite resource that you created in step#4 to that collection. Verify that you are able to add the discoverable composite resource to the collection.
