### PR TITLE
Bag ingestion timeseries citations

### DIFF
--- a/hs_app_timeseries/models.py
+++ b/hs_app_timeseries/models.py
@@ -16,7 +16,7 @@ from django.db import models
 from django.utils.timezone import now
 
 from dominate.tags import table, tbody, tr, td, th, a
-from hs_core.hs_rdf import HSTERMS
+from hs_core.hs_rdf import HSTERMS, rdf_terms
 
 from mezzanine.pages.page_processors import processor_for
 
@@ -123,7 +123,7 @@ class TimeSeriesAbstractMetaDataElement(AbstractMetaDataElement):
                     continue
                 field_term = cls.get_field_term(field.name)
                 val = graph.value(metadata_node, field_term)
-                if field_term == HSTERMS.series_ids:
+                if field_term == HSTERMS.timeSeriesResultUUID:
                     if val is not None:
                         value_dict[field.name] = [v.replace("'", "") for v in val.strip('][').split(', ')]
                 elif val is not None:
@@ -135,6 +135,9 @@ class TimeSeriesAbstractMetaDataElement(AbstractMetaDataElement):
         abstract = True
 
 
+@rdf_terms(HSTERMS.site, series_ids=HSTERMS.timeSeriesResultUUID, site_code=HSTERMS.SiteCode,
+           site_name=HSTERMS.SiteName, elevation_m=HSTERMS.Elevation_m, elevation_datum=HSTERMS.ElevationDatum,
+           site_type=HSTERMS.SiteType, latitude=HSTERMS.Latitude, longitude=HSTERMS.Longitude)
 class Site(TimeSeriesAbstractMetaDataElement):
     term = 'Site'
     site_code = models.CharField(max_length=200)
@@ -252,6 +255,9 @@ class Site(TimeSeriesAbstractMetaDataElement):
         return _get_series_ids(element_class=cls, metadata_obj=metadata_obj)
 
 
+@rdf_terms(HSTERMS.variable, series_ids=HSTERMS.timeSeriesResultUUID, variable_code=HSTERMS.VariableCode,
+           variable_name=HSTERMS.VariableName, variable_type=HSTERMS.VariableType, no_data_value=HSTERMS.NoDataValue,
+           variable_definition=HSTERMS.VariableDefinition, speciation=HSTERMS.Speciation)
 class Variable(TimeSeriesAbstractMetaDataElement):
     term = 'Variable'
     variable_code = models.CharField(max_length=50)
@@ -356,6 +362,9 @@ class Variable(TimeSeriesAbstractMetaDataElement):
         return html_table.render(pretty=pretty)
 
 
+@rdf_terms(HSTERMS.method, series_ids=HSTERMS.timeSeriesResultUUID, method_code=HSTERMS.MethodCode,
+           method_name=HSTERMS.MethodName, method_type=HSTERMS.MethodType, method_description=HSTERMS.MethodDescription,
+           method_link=HSTERMS.MethodLink)
 class Method(TimeSeriesAbstractMetaDataElement):
     term = 'Method'
     method_code = models.CharField(max_length=50)
@@ -473,6 +482,9 @@ class Method(TimeSeriesAbstractMetaDataElement):
         return html_table.render(pretty=pretty)
 
 
+@rdf_terms(HSTERMS.processingLevel, series_ids=HSTERMS.timeSeriesResultUUID,
+           processing_level_code=HSTERMS.ProcessingLevelCode, definition=HSTERMS.Definition,
+           explanation=HSTERMS.Explanation)
 class ProcessingLevel(TimeSeriesAbstractMetaDataElement):
     term = 'ProcessingLevel'
     processing_level_code = models.CharField(max_length=50)
@@ -565,6 +577,10 @@ class ProcessingLevel(TimeSeriesAbstractMetaDataElement):
         return html_table.render(pretty=pretty)
 
 
+@rdf_terms(HSTERMS.timeSeriesResult, series_ids=HSTERMS.timeSeriesResultUUID, units_type=HSTERMS.UnitsType,
+           units_name=HSTERMS.UnitsName, units_abbreviation=HSTERMS.UnitsAbbreviation,
+           status=HSTERMS.Status, sample_medium=HSTERMS.SampleMedium, value_count=HSTERMS.ValueCount,
+           aggregation_statistics=HSTERMS.AggregationStatistic, series_label=HSTERMS.SeriesLabel)
 class TimeSeriesResult(TimeSeriesAbstractMetaDataElement):
     term = 'TimeSeriesResult'
     units_type = models.CharField(max_length=255)
@@ -663,6 +679,7 @@ class TimeSeriesResult(TimeSeriesAbstractMetaDataElement):
         return html_table.render(pretty=pretty)
 
 
+@rdf_terms(HSTERMS.UTCOffSet, series_ids=HSTERMS.timeSeriesResultUUID)
 class UTCOffSet(TimeSeriesAbstractMetaDataElement):
     # this element is not part of the science metadata
     term = 'UTCOffSet'

--- a/hs_core/tests/api/native/test_bag_ingestion.py
+++ b/hs_core/tests/api/native/test_bag_ingestion.py
@@ -15,7 +15,7 @@ from hs_core.hydroshare import resource, add_resource_files, current_site_url
 from hs_core.testing import MockIRODSTestCaseMixin
 from hs_core import hydroshare
 from hs_file_types.models import GenericLogicalFile, FileSetLogicalFile, GeoFeatureLogicalFile, GeoRasterLogicalFile, \
-    NetCDFLogicalFile, RefTimeseriesLogicalFile
+    NetCDFLogicalFile, RefTimeseriesLogicalFile, TimeSeriesLogicalFile
 
 
 class TestCreateResource(MockIRODSTestCaseMixin, TestCase):
@@ -102,3 +102,5 @@ class TestCreateResource(MockIRODSTestCaseMixin, TestCase):
                           "SWE_time_meta.xml")
         compare_metadatas(res.get_logical_files(RefTimeseriesLogicalFile.type_name())[0].metadata.get_xml(),
                           "msf_version.refts_meta.xml")
+        compare_metadatas(res.get_logical_files(TimeSeriesLogicalFile.type_name())[0].metadata.get_xml(),
+                          "ODM2_Multi_Site_One_Variable_meta.xml")

--- a/hs_file_types/models/timeseries.py
+++ b/hs_file_types/models/timeseries.py
@@ -449,8 +449,6 @@ class TimeSeriesFileMetaData(TimeSeriesMetaDataMixin, AbstractFileMetaData):
             graph.remove((result_node, HSTERMS.timeSeriesResultUUID, series_id))
             graph.add((result_node, HSTERMS.timeSeriesResultUUID, Literal([str(series_id)])))
 
-        rdf_string = graph.serialize(format='hydro-xml').decode()
-
         super(TimeSeriesFileMetaData, self).ingest_metadata(graph)
 
     def get_rdf_graph(self):


### PR DESCRIPTION
An amendement to the bag ingestion branch which includes rdf/xml for timeseries.  It also adds a citations entry for the resource rdf/xml.

Timeseries breaks all the normal conventions for storing the metadata, so I had to overwrite the hs_rdf methods.  Each timeseries metadata element has a series id.  That series id is used to tie the element to a timeseriesresult.  In the rdf/xml, instead of using a series id, it just includes each of the corresponding elements within the timeseriesresult.  For ingestion, this process has to be reversed.  A test was added to test_bag_ingestion.py for timeseries.

Citations are mostly straightforward, but needed some custom code to account for custom vs default citations.  I talked to @horsburgh about how to identify a custom citation vs a default citation and we decided on a regex that gives the basic structure of the default citation.  It is possible for a custom citation to be mistaken as a default one, but it's unlikely.  I couldn't do a simple string match because the default citation can change based on the authors and modified date.  A test was added to the resourcemetadata.xml within the zip for the test files of test_bag_ingestion.py

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Download the resourcemetadata.xml file of any resource and verify the citation exists.  Note, that this won't work on an existing resource unless you update it.  This won't be an issue when we deploy as we're regenerating all metadata rdf/xml.
2. Create a resource with a timeseries aggregation and download the _meta.xml file.  Verify the terms match and metadata elements such as Site, Variable, etc are within timeSeriesResult elements.  Update one or more values in the rdf/xml and send it through ingest_metadata endpoint.  Verify the changes are on the resource landing page.
