### PR TITLE
Add watchdog URLs in http mode to outer and inner nginx proxies

### DIFF
--- a/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -38,11 +38,22 @@ proxy_read_timeout 300;
 server {
     listen          80;
     server_name     FQDN_OR_IP;
-    # This should not rewrite hostname!
-    # rewrite ^/(.*)  https://FQDN_OR_IP/$1 permanent;
-    # This syntax is considered more efficient in nginx documentation
-    # and does the same thing as the above:
-    return 301 https://$http_host/$request_uri;
+
+    # bypass https for internal monitoring 
+    location /whatzupdoc-inner { 
+        if ($external) { 
+            return 404; 
+        } 
+        stub_status; 
+    } 
+
+    location / { 
+        # This should not rewrite hostname!
+        # rewrite ^/(.*)  https://FQDN_OR_IP/$1 permanent;
+        # This syntax is considered more efficient in nginx documentation
+        # and does the same thing as the above:
+        return 301 https://$http_host/$request_uri;
+    } 
 }
 
 server {

--- a/nginx/hs_proxy/nginx/config-files/hydroshare-ssl-nginx.conf.template
+++ b/nginx/hs_proxy/nginx/config-files/hydroshare-ssl-nginx.conf.template
@@ -10,10 +10,38 @@ upstream backend {
    server CURRENT_VM;
 }
 
+geo $external {
+  default 1;
+  192.168.0.0/16 0;
+  172.16.0.0/12 0;
+  127.0.0.0/8 0;
+  10.0.0.0/8 0;
+  152.54.0.0/22 0;
+}
+
 server {
     listen          80;
     server_name     FQDN_OR_IP;
-    rewrite ^/(.*)  https://FQDN_OR_IP/$1 permanent;
+
+    # enable two watchdog URLS: outer and inner NGINX status
+     
+    location /whatzupdoc-outer { 
+        if ($external) { 
+            return 404; 
+        } 
+        stub_status; 
+    } 
+
+    location /whatzupdoc-inner { 
+        if ($external) { 
+            return 404; 
+        } 
+	proxy_pass https://CURRENT_VM; 
+    } 
+
+    location / { 
+        rewrite ^/(.*)  https://FQDN_OR_IP/$1 permanent;
+    } 
 }
 
 server {


### PR DESCRIPTION
This adds the following URLS to the NGINX proxies:
  
* `http://nginx-outer/whatszupdoc-outer`: status report on outer server. 
* `http://nginx-outer/whatszupdoc-inner`: status report on inner server. 
* `http://nginx-inner/whatzupdoc-inner`: status report on inner server. 

Each of these URLs servers as an NGINX heartbeat for the outer and/or inner servers. http is used rather than https to allow the inner server to be queried directly. These heartbeats are only available in the RENCI domain. 

The purpose of this change is to incorporate queries of this kind in the Jenkins watchdog scripts. These URLS report number of NGINX connections and activities, so we should be able to determine why the site is crashing from this input. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
URLS respond with appropriate statistics inside RENCI, and outside, respond with error 404. 