### PR TITLE
turn off TaskNotification creation for api downloads

### DIFF
--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -176,7 +176,7 @@ def download(request, path, use_async=True, use_reverse_proxy=True,
             delete_zip.apply_async((irods_output_path,),
                                    countdown=(60 * 60 * 24))  # delete after 24 hours
             if api_request:
-                return HttpResponse({
+                return JsonResponse({
                     'zip_status': 'Not ready',
                     'task_id': task.task_id,
                     'download_path': '/django_irods/rest_download/' + output_path})

--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -234,7 +234,10 @@ def download(request, path, use_async=True, use_reverse_proxy=True,
                         return JsonResponse({
                             'bag_status': 'Not ready',
                             'task_id': task_id,
-                            'download_path': res.bag_url})
+                            'download_path': res.bag_url,
+                            # status and id are checked by by hs_core.tests.api.rest.test_create_resource.py
+                            'status': 'Not ready',
+                            'id': task_id})
                     else:
                         task_dict = get_or_create_task_notification(task_id, name='bag download', payload=res.bag_url,
                                                                     username=user_id)

--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -176,12 +176,10 @@ def download(request, path, use_async=True, use_reverse_proxy=True,
             delete_zip.apply_async((irods_output_path,),
                                    countdown=(60 * 60 * 24))  # delete after 24 hours
             if api_request:
-                return HttpResponse(
-                    json.dumps({
-                        'zip_status': 'Not ready',
-                        'task_id': task.task_id,
-                        'download_path': '/django_irods/rest_download/' + output_path}),
-                    content_type="application/json")
+                return HttpResponse({
+                    'zip_status': 'Not ready',
+                    'task_id': task.task_id,
+                    'download_path': '/django_irods/rest_download/' + output_path})
             else:
                 # return status to the task notification App AJAX call
                 task_dict = get_or_create_task_notification(task_id, name='zip download', payload=download_path,

--- a/hs_core/task_utils.py
+++ b/hs_core/task_utils.py
@@ -81,31 +81,6 @@ def get_or_create_task_notification(task_id, status='progress', name='', payload
                 obj.status = status
             obj.save()
 
-        if name in ['zip download', 'bag download']:
-            response_map = {
-                'id': task_id,
-                'name': name,
-                'status': obj.status,
-                'payload': obj.payload,
-                # rest download backwards compatible keys
-                'task_id': task_id,
-                'download_path': obj.payload
-            }
-            if name == "zip download":
-                response_map['zip_status'] = 'Not ready'
-                if status == "failed":
-                    response_map['zip_status'] = 'Failed'
-                if status == "completed":
-                    response_map['zip_status'] = 'Ready'
-                return response_map
-            if name == "bag download":
-                response_map['bag_status'] = 'Not ready'
-                if status == "failed":
-                    response_map['bag_status'] = 'Failed'
-                if status == "completed":
-                    response_map['bag_status'] = 'Ready'
-                return response_map
-
         return {
             'id': task_id,
             'name': name,


### PR DESCRIPTION
Found a side effect with async tasks and enabling api downloads through the same entry point as web downloads.  An api download with credentials will create a tasknotification for the credentials used, which can then trigger a download if the user is logged in on the website.  This fix distinguishes api vs browser requests by looking for the csrf token in the header.  The csrf token will only exist on browser requests.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Trigger a bag and zip download via the api.  Login to hydroshare with the same credentials and ensure a download doesn't trigger when the zip is ready.
