### PR TITLE
url encode resourcemap urls

### DIFF
--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -10,6 +10,7 @@ from foresite import utils, Aggregation, AggregatedResource, RdfLibSerializer
 from rdflib import Namespace, URIRef
 
 import bagit
+
 from hs_core.models import ResourceFile
 
 
@@ -56,6 +57,7 @@ def create_bag_files(resource):
     create a bag on demand as needed.
     """
     from hs_core.hydroshare.utils import current_site_url, get_file_mime_type
+    from hs_core.hydroshare import encode_resource_url
 
     istorage = resource.get_irods_storage()
 
@@ -141,6 +143,7 @@ def create_bag_files(resource):
                 hs_url=current_site_url,
                 res_id=resource.short_id,
                 file_name=f.short_path)
+            res_uri = encode_resource_url(res_uri)
             ar = AggregatedResource(res_uri)
             ar._ore.isAggregatedBy = ag_url
             ar._dc.format = get_file_mime_type(os.path.basename(f.short_path))
@@ -170,6 +173,7 @@ def create_bag_files(resource):
                 hs_url=current_site_url,
                 res_id=resource.short_id,
                 map_file_path=logical_file.map_short_file_path)
+            agg_uri = encode_resource_url(agg_uri)
             agg = Aggregation(aggr_uri)
             agg._ore.isAggregatedBy = ag_url
             agg_type_url = "{site}/terms/{aggr_type}"

--- a/hs_core/hydroshare/hs_bagit.py
+++ b/hs_core/hydroshare/hs_bagit.py
@@ -173,7 +173,7 @@ def create_bag_files(resource):
                 hs_url=current_site_url,
                 res_id=resource.short_id,
                 map_file_path=logical_file.map_short_file_path)
-            agg_uri = encode_resource_url(agg_uri)
+            aggr_uri = encode_resource_url(aggr_uri)
             agg = Aggregation(aggr_uri)
             agg._ore.isAggregatedBy = ag_url
             agg_type_url = "{site}/terms/{aggr_type}"

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -6,6 +6,9 @@ import shutil
 import copy
 from uuid import uuid4
 import errno
+import urllib
+
+from urllib.request import pathname2url, url2pathname
 
 from django.apps import apps
 from django.http import Http404
@@ -1087,3 +1090,27 @@ def check_aggregations(resource, res_files):
                 if logical_file:
                     new_logical_files.append(logical_file)
     return new_logical_files
+
+
+def encode_resource_url(url):
+    """
+    URL encodes a full resource file/folder url.
+    :param url: a string url
+    :return: url encoded string
+    """
+    parsed_url = urllib.parse.urlparse(url)
+    url_encoded_path = pathname2url(parsed_url.path)
+    encoded_url = parsed_url._replace(path=url_encoded_path).geturl()
+    return encoded_url
+
+
+def decode_resource_url(url):
+    """
+    URL decodes a full resource file/folder url.
+    :param url: an encoded string url
+    :return: url decoded string
+    """
+    parsed_url = urllib.parse.urlparse(url)
+    url_encoded_path = url2pathname(parsed_url.path)
+    encoded_url = parsed_url._replace(path=url_encoded_path).geturl()
+    return encoded_url

--- a/hs_core/tests/utils/test_utils.py
+++ b/hs_core/tests/utils/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from hs_core.hydroshare.utils import encode_resource_url, decode_resource_url
 
+
 @pytest.mark.parametrize("decoded_url,encoded_url", [
     ("https://www.hydroshare.org/oh look/ a/ space /weird names.txt",
      "https://www.hydroshare.org/oh%20look/%20a/%20space%20/weird%20names.txt"),

--- a/hs_core/tests/utils/test_utils.py
+++ b/hs_core/tests/utils/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+from hs_core.hydroshare.utils import encode_resource_url, decode_resource_url
+
+@pytest.mark.parametrize("decoded_url,encoded_url", [
+    ("https://www.hydroshare.org/oh look/ a/ space /weird names.txt",
+     "https://www.hydroshare.org/oh%20look/%20a/%20space%20/weird%20names.txt"),
+    ("https://www.hydroshare.org/data/contents/just file.txt",
+     "https://www.hydroshare.org/data/contents/just%20file.txt"),
+    ("https://www.hydroshare.org/data/contents/just folder/",
+     "https://www.hydroshare.org/data/contents/just%20folder/"),
+    ("https://www.hydroshare.org/data/contents/just folder/file.txt",
+     "https://www.hydroshare.org/data/contents/just%20folder/file.txt")
+])
+def test_encode_decode_resource_url(decoded_url, encoded_url):
+    """
+    Tests the encode/decode url functions work correctly
+    """
+    assert encode_resource_url(decoded_url) == encoded_url
+    assert decode_resource_url(encoded_url) == decoded_url


### PR DESCRIPTION
When regenerating the bag resourcemap.xml files, we noticed a lot of warnings from rdflib for unencoded urls.  This PR addresses the issue and also includes url encoding for resource and aggregation metadata files.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource with a space in a file and folder name.  Download the bag and check the resourcemap.url to ensure the file url is properly encoded with the `space` replaced with `%20`.
