### PR TITLE
add missing abstract to timeseries rdf/xml

### DIFF
--- a/hs_core/tests/data/test_resource_metadata_files/ODM2_Multi_Site_One_Variable_meta.xml
+++ b/hs_core/tests/data/test_resource_metadata_files/ODM2_Multi_Site_One_Variable_meta.xml
@@ -9,6 +9,11 @@
   <hsterms:TimeSeriesAggregation rdf:about="http://www.hydroshare.org/resource/e013dae505e647378dfc7d1662170e20/data/contents/ODM2_Multi_Site_One_Variable_resmap.xml#aggregation">
     <dc:title>changed from the Little Bear River, UT</dc:title>
     <dc:type rdf:resource="https://www.hydroshare.org/terms/TimeSeriesAggregation"/>
+    <dc:description>
+      <rdf:Description>
+        <dcterms:abstract>a timseries abstract</dcterms:abstract>
+      </rdf:Description>
+    </dc:description>
     <hsterms:timeSeriesResult>
       <rdf:Description>
         <hsterms:site>

--- a/hs_file_types/models/timeseries.py
+++ b/hs_file_types/models/timeseries.py
@@ -14,6 +14,7 @@ from django.template import Template, Context
 from dominate.tags import div, legend, strong, form, select, option, button, _input, p, \
     textarea, span
 from rdflib import BNode, Literal
+from rdflib.namespace import DCTERMS, DC
 
 from hs_core.hs_rdf import HSTERMS
 
@@ -449,6 +450,12 @@ class TimeSeriesFileMetaData(TimeSeriesMetaDataMixin, AbstractFileMetaData):
             graph.remove((result_node, HSTERMS.timeSeriesResultUUID, series_id))
             graph.add((result_node, HSTERMS.timeSeriesResultUUID, Literal([str(series_id)])))
 
+        # abstract is all by itself on this model, won't get picked up by ingestion automatically
+        description_node = graph.value(subject=subject, predicate=DC.description, default=None)
+        if description_node:
+            self.abstract = graph.value(subject=description_node, predicate=DCTERMS.abstract, default="").toPython()
+        self.save()
+
         super(TimeSeriesFileMetaData, self).ingest_metadata(graph)
 
     def get_rdf_graph(self):
@@ -517,6 +524,12 @@ class TimeSeriesFileMetaData(TimeSeriesMetaDataMixin, AbstractFileMetaData):
                 if units_abbreviation:
                     graph.add((unit_node, HSTERMS.UnitsAbbreviation, units_abbreviation))
                     graph.remove((result_node, HSTERMS.UnitsAbbreviation, units_abbreviation))
+
+        if self.abstract:
+            # abstract is all by itself on this model, won't get picked up by rdf/xml creation automatically
+            description_node = BNode()
+            graph.add((subject, DC.description, description_node))
+            graph.add((description_node, DCTERMS.abstract, Literal(self.abstract)))
 
         return graph
 

--- a/hs_file_types/models/timeseries.py
+++ b/hs_file_types/models/timeseries.py
@@ -454,7 +454,7 @@ class TimeSeriesFileMetaData(TimeSeriesMetaDataMixin, AbstractFileMetaData):
         description_node = graph.value(subject=subject, predicate=DC.description, default=None)
         if description_node:
             self.abstract = graph.value(subject=description_node, predicate=DCTERMS.abstract, default="").toPython()
-        self.save()
+            self.save()
 
         super(TimeSeriesFileMetaData, self).ingest_metadata(graph)
 


### PR DESCRIPTION
I noticed abstract went missing from the rdf/xml for timeseries aggregation.  After looking into why it was getting picked up with the other fields, I noticed it's by itself and not part of the rest of the timeseries metadata.  This PR accounts for that difference with a test for rdf/xml creation and ingestion.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Download the timeseries aggregation rdf/xml with an abstract and verify it's present with predicate DC.abstract.
