### PR TITLE
encode urls in aggregation map rdf/xml file

### DIFF
--- a/hs_file_types/models/base.py
+++ b/hs_file_types/models/base.py
@@ -1261,7 +1261,7 @@ class AbstractLogicalFile(models.Model):
 
     def _generate_map_xml(self):
         """Generates the xml needed to write to the aggregation map xml document"""
-
+        from hs_core.hydroshare import encode_resource_url
         from hs_core.hydroshare.utils import current_site_url, get_file_mime_type
 
         current_site_url = current_site_url()
@@ -1270,15 +1270,18 @@ class AbstractLogicalFile(models.Model):
         # this is the path to the resourcemedata file for download
         aggr_metadata_file_path = self.metadata_short_file_path
         metadata_url = os.path.join(hs_res_url, aggr_metadata_file_path)
+        metadata_url = encode_resource_url(metadata_url)
         # this is the path to the aggregation resourcemap file for download
         aggr_map_file_path = self.map_short_file_path
         res_map_url = os.path.join(hs_res_url, aggr_map_file_path)
+        res_map_url = encode_resource_url(res_map_url)
 
         # make the resource map:
         utils.namespaces['citoterms'] = Namespace('http://purl.org/spar/cito/')
         utils.namespaceSearchOrder.append('citoterms')
 
         ag_url = res_map_url + '#aggregation'
+        ag_url = ag_url
         a = Aggregation(ag_url)
 
         # Set properties of the aggregation
@@ -1310,6 +1313,7 @@ class AbstractLogicalFile(models.Model):
                 hs_url=current_site_url,
                 res_id=self.resource.short_id,
                 file_name=f.short_path)
+            res_uri = encode_resource_url(res_uri)
             resFiles.append(AggregatedResource(res_uri))
             resFiles[n]._ore.isAggregatedBy = ag_url
             resFiles[n]._dc.format = get_file_mime_type(os.path.basename(f.short_path))
@@ -1326,6 +1330,7 @@ class AbstractLogicalFile(models.Model):
                 hs_url=current_site_url,
                 res_id=self.resource.short_id,
                 aggr_name=child_aggr.map_short_file_path + '#aggregation')
+            res_uri = encode_resource_url(encode_resource_url)
             child_ore_aggr = Aggregation(res_uri)
             child_ore_aggregations.append(child_ore_aggr)
             child_ore_aggregations[n]._ore.isAggregatedBy = ag_url

--- a/hs_file_types/models/base.py
+++ b/hs_file_types/models/base.py
@@ -1281,7 +1281,6 @@ class AbstractLogicalFile(models.Model):
         utils.namespaceSearchOrder.append('citoterms')
 
         ag_url = res_map_url + '#aggregation'
-        ag_url = ag_url
         a = Aggregation(ag_url)
 
         # Set properties of the aggregation

--- a/hs_file_types/models/base.py
+++ b/hs_file_types/models/base.py
@@ -1330,7 +1330,7 @@ class AbstractLogicalFile(models.Model):
                 hs_url=current_site_url,
                 res_id=self.resource.short_id,
                 aggr_name=child_aggr.map_short_file_path + '#aggregation')
-            res_uri = encode_resource_url(encode_resource_url)
+            res_uri = encode_resource_url(res_uri)
             child_ore_aggr = Aggregation(res_uri)
             child_ore_aggregations.append(child_ore_aggr)
             child_ore_aggregations[n]._ore.isAggregatedBy = ag_url


### PR DESCRIPTION
Aggregation map rdf/xml urls are not currently url encoded.  This PR encodes all urls in these files for all aggregation types.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a singlefile aggregtion on a file with spaces in the name.  Download the aggregations _map.xml file and ensure the urls to your file have the spaces url encoded.
