### PR TITLE
check for bagit file exists before download

### DIFF
--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -274,10 +274,11 @@ def download(request, path, use_async=True, use_reverse_proxy=True,
         if path in [f"{res_id}/data/resourcemap.xml", f"{res_id}/data/resourcemetadata.xml",
                     f"{res_id}/manifest-md5.txt", f"{res_id}/tagmanifest-md5.txt", f"{res_id}/readme.txt",
                     f"{res_id}/bagit.txt"]:
-            metadata_dirty = res.getAVU("metadata_dirty")
-            if metadata_dirty is None or metadata_dirty or not istorage.exists(irods_output_path):
-                create_bag_metadata_files(res)  # sets metadata_dirty to False
-                create_bagit_files_by_irods(res, istorage)
+
+            bag_modified = res.getAVU("bag_modified")
+            if bag_modified is None or bag_modified or not istorage.exists(irods_output_path):
+                res.setAVU("bag_modified", True)  # ensure bag_modified is set when irods_output_path does not exist
+                create_bag_by_irods(res_id, False)
 
         # send signal for pre download file
         # TODO: does not contain subdirectory information: duplicate refreshes possible

--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -11,7 +11,6 @@ from rest_framework import status
 
 from django_irods import icommands
 from hs_core.hydroshare.resource import check_resource_type
-from hs_core.hydroshare.hs_bagit import create_bag_metadata_files, create_bagit_files_by_irods
 from hs_core.task_utils import get_resource_bag_task, get_or_create_task_notification, get_task_user_id
 
 from hs_core.signals import pre_download_file, pre_check_bag_flag

--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -270,13 +270,14 @@ def download(request, path, use_async=True, use_reverse_proxy=True,
             return JsonResponse(task_dict)
     else:  # regular file download
         # if fetching main metadata files, then these need to be refreshed.
+
         if path in [f"{res_id}/data/resourcemap.xml", f"{res_id}/data/resourcemetadata.xml",
                     f"{res_id}/manifest-md5.txt", f"{res_id}/tagmanifest-md5.txt", f"{res_id}/readme.txt",
                     f"{res_id}/bagit.txt"]:
             metadata_dirty = res.getAVU("metadata_dirty")
-            if metadata_dirty is None or metadata_dirty:
+            if metadata_dirty is None or metadata_dirty or not istorage.exists(irods_output_path):
                 create_bag_metadata_files(res)  # sets metadata_dirty to False
-                create_bagit_files_by_irods(res, res.get_irods_storage())
+                create_bagit_files_by_irods(res, istorage)
 
         # send signal for pre download file
         # TODO: does not contain subdirectory information: duplicate refreshes possible

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -365,10 +365,6 @@ def create_bag_by_irods(resource_id, create_zip=True):
         is_exist = istorage.exists(irods_bagit_input_path)
         if is_exist:
             try:
-                # call iRODS run and ibun command to zip the bag, ignore SessionException
-                # for now as a workaround which could be raised from potential race conditions when
-                # multiple ibun commands try to create the same zip file or the very same resource
-                # gets deleted by another request when being downloaded
                 istorage.zipup(irods_bagit_input_path, bag_path)
                 if res.raccess.published:
                     # compute checksum to meet DataONE distribution requirement

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -329,12 +329,13 @@ def create_temp_zip(resource_id, input_path, output_path, aggregation_name=None,
 
 
 @shared_task
-def create_bag_by_irods(resource_id):
+def create_bag_by_irods(resource_id, create_zip=True):
     """Create a resource bag on iRODS side by running the bagit rule and ibun zip.
     This function runs as a celery task, invoked asynchronously so that it does not
     block the main web thread when it creates bags for very large files which will take some time.
     :param
     resource_id: the resource uuid that is used to look for the resource to create the bag for.
+    :param create_zip: defaults to True, set to false to create bagit files without zipping
     :return: bag_url if bag creation operation succeeds or
              raise an exception if resource does not exist or any other issues that prevent bags from being created.
     """
@@ -344,34 +345,40 @@ def create_bag_by_irods(resource_id):
 
     bag_path = res.bag_path
 
-    metadata_dirty = istorage.getAVU(res.root_path, 'metadata_dirty')
+    metadata_dirty = res.getAVU('metadata_dirty')
+    metadata_dirty = metadata_dirty is None or metadata_dirty
     # if metadata has been changed, then regenerate metadata xml files
-    if metadata_dirty is None or metadata_dirty.lower() == "true":
+    if metadata_dirty:
         create_bag_metadata_files(res)
 
-    irods_bagit_input_path = res.get_irods_path(resource_id, prepend_short_id=False)
-
-    # only proceed when the resource is not deleted potentially by another request
-    # when being downloaded
-    is_exist = istorage.exists(irods_bagit_input_path)
-    if is_exist:
+    bag_modified = res.getAVU("bag_modified")
+    bag_modified = bag_modified is None or bag_modified
+    if metadata_dirty or bag_modified:
         create_bagit_files_by_irods(res, istorage)
-        try:
-            # call iRODS run and ibun command to zip the bag, ignore SessionException
-            # for now as a workaround which could be raised from potential race conditions when
-            # multiple ibun commands try to create the same zip file or the very same resource
-            # gets deleted by another request when being downloaded
-            istorage.zipup(irods_bagit_input_path, bag_path)
-            if res.raccess.published:
-                # compute checksum to meet DataONE distribution requirement
-                chksum = istorage.checksum(bag_path)
-                res.bag_checksum = chksum
-            istorage.setAVU(irods_bagit_input_path, 'bag_modified', "false")
-            return res.bag_url
-        except SessionException as ex:
-            raise SessionException(-1, '', ex.stderr)
-    else:
-        raise ObjectDoesNotExist('Resource {} does not exist.'.format(resource_id))
+        res.setAVU("bag_modified", False)
+
+    if create_zip:
+        irods_bagit_input_path = res.get_irods_path(resource_id, prepend_short_id=False)
+
+        # only proceed when the resource is not deleted potentially by another request
+        # when being downloaded
+        is_exist = istorage.exists(irods_bagit_input_path)
+        if is_exist:
+            try:
+                # call iRODS run and ibun command to zip the bag, ignore SessionException
+                # for now as a workaround which could be raised from potential race conditions when
+                # multiple ibun commands try to create the same zip file or the very same resource
+                # gets deleted by another request when being downloaded
+                istorage.zipup(irods_bagit_input_path, bag_path)
+                if res.raccess.published:
+                    # compute checksum to meet DataONE distribution requirement
+                    chksum = istorage.checksum(bag_path)
+                    res.bag_checksum = chksum
+                return res.bag_url
+            except SessionException as ex:
+                raise SessionException(-1, '', ex.stderr)
+        else:
+            raise ObjectDoesNotExist('Resource {} does not exist.'.format(resource_id))
 
 
 @shared_task

--- a/hs_file_types/utils.py
+++ b/hs_file_types/utils.py
@@ -278,7 +278,8 @@ def ingest_metadata_files(resource, meta_files, map_files):
         except:
             # logger.exception("Error processing resource metadata file")
             raise
-    resource.setAVU('metadata_dirty', 'true')
+    resource.setAVU('metadata_dirty', True)
+    resource.setAVU("bag_modified", True)
 
 
 def identify_metadata_files(files):

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -708,6 +708,9 @@ TASK_NAME_MAPPING = {
     'hs_core.tasks.unzip_task': 'file unzip',
     'hs_core.tasks.copy_resource_task': 'resource copy',
 }
+
+HSWS_ACTIVATED = False
+
 ####################################
 # DO NOT PLACE SETTINGS BELOW HERE #
 ####################################


### PR DESCRIPTION
This is a minor update for the bagit file downloads.  I found out that the metadata-dirty flag isn't always reliable and a check for the file on irods is needed.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Download one of the bagit files in a newly created resource, ensure the bagit file downloads.
