### PR TITLE
Allow dev deployments to survive network interruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ## Custom
+nohup.out
 local_settings.py
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Fix .gitignore