### PR TITLE
Fix for SOLR corruption problem.

### DIFF
--- a/hs_core/hydro_realtime_signal_processor.py
+++ b/hs_core/hydro_realtime_signal_processor.py
@@ -67,23 +67,7 @@ class HydroRealtimeSignalProcessor(RealtimeSignalProcessor):
         """
         Given an individual model instance, determine which backends the
         delete should be sent to & delete the object on those backends.
+        This never worked well. Just set the resource to not discoverable 
+        before deleting it. This will delete it from SOLR properly. 
         """
-        from hs_core.models import BaseResource
-        from hs_access_control.models import ResourceAccess
-
-        # only delete the SOLR instance when the raccess field is recursively deleted.
-        # At this point, the resource still exists.
-        # Thus, the BaseResource is literally available and can be unindexed.
-        # Trying to delete as a result of deleting the Resource fails, because
-        # it is not possible to recover the BaseResource object.
-        if isinstance(instance, ResourceAccess):
-            newinstance = instance.resource # automatically a BaseResource
-            newsender = BaseResource
-            # self.handle_delete(newsender, newinstance)
-            using_backends = self.connection_router.for_write(instance=newinstance)
-            for using in using_backends:
-                try:
-                    index = self.connections[using].get_unified_index().get_index(newsender)
-                    index.remove_object(newinstance, using=using)
-                except NotHandled:
-                    logger.exception("Failure: delete of %s with short_id %s failed.", str(type(instance)), newinstance.short_id)
+        pass

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -814,6 +814,11 @@ def delete_resource(pk):
                 obsolete_res.raccess.immutable = False
                 obsolete_res.raccess.save()
 
+    # deletion of a discoverable resource corrupts SOLR.
+    # Fix by making the resource undiscoverable.
+    # This has the side-effect of deleting the resource from SOLR.
+    res.set_discoverable(False)
+
     res.delete()
     return pk
 

--- a/hs_core/management/commands/solr_update.py
+++ b/hs_core/management/commands/solr_update.py
@@ -134,8 +134,12 @@ class Command(BaseCommand):
                 except BaseResource.DoesNotExist:
                     print("SOLR resource {} NOT FOUND in Django; removing from SOLR"
                           .format(r.short_id))
-                    ind.remove_object(r)
-                    solr_deleted += 1
+                    try:
+                        ind.remove_object(r)
+                        solr_deleted += 1
+                    except Exception as e:
+                        print("resource {} generated exception {}".format(r.short_id, str(e)))
+
                     continue
 
             print("Django contains {} discoverable resources and {} replaced resources"


### PR DESCRIPTION
This is a simple fix to the "discovered" problem that deleting a discoverable resource corrupts SOLR. There are three parts: 

1. Make a resource undiscoverable before any deletion. 
2. Correct solr_update so that it doesn't crash under these conditions. 
3. Remove the useless handle_delete function by making it non-operative. 

This will fix the problem, but there are other changes to be made later: 

To the best of my knowledge, this still allows the REST API to delete a published resource. This is bad. 

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource. Make it discoverable. Delete it. It should disappear from the Discovery page. 

