### PR TITLE
No exception when checking for undo involving inactive user or group 

### DIFF
--- a/hs_access_control/models/user.py
+++ b/hs_access_control/models/user.py
@@ -2077,9 +2077,13 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
         if not this_group.gaccess.active:
-            raise PermissionDenied("Group is not active")
+            # This causes problems with display of resources
+            # raise PermissionDenied("Group is not active")
+            return False
         if not this_user.is_active:
-            raise PermissionDenied("User is not active")
+            # This causes problems with display of resources
+            # raise PermissionDenied("User is not active")
+            return False
 
         return self.__get_group_undo_users(this_group).filter(id=this_user.id).exists()
 
@@ -2182,7 +2186,9 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
         if not this_user.is_active:
-            raise PermissionDenied("User is not active")
+            # This causes problems with display of resources
+            # raise PermissionDenied("User is not active")
+            return False
 
         return self.__get_resource_undo_users(this_resource).filter(id=this_user.id).exists()
 
@@ -2274,7 +2280,9 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
         if not this_group.gaccess.active:
-            raise PermissionDenied("Group is not active")
+            # This causes problems with display of resources
+            # raise PermissionDenied("Group is not active")
+            return False
 
         return self.__get_resource_undo_groups(this_resource).filter(id=this_group.id).exists()
 
@@ -3262,7 +3270,9 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
         if not this_user.is_active:
-            raise PermissionDenied("Grantee user is not active")
+            # This causes problems with display of resources
+            # raise PermissionDenied("Grantee user is not active")
+            return False
 
         return self.__get_community_undo_users(this_community).filter(id=this_user.id).exists()
 
@@ -3355,7 +3365,9 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
         if not this_group.gaccess.active:
-            raise PermissionDenied("Group is not active")
+            # This causes problems with display of resources
+            # raise PermissionDenied("Group is not active")
+            return False
 
         return self.__get_community_undo_groups(this_community).filter(id=this_group.id).exists()
 
@@ -3390,7 +3402,9 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
         if not this_group.gaccess.active:
-            raise PermissionDenied("Group is not active")
+            # This causes problems with display of resources
+            # raise PermissionDenied("Group is not active")
+            return False
 
         qual_undo = self.__get_community_undo_groups(this_community)
         if qual_undo.filter(id=this_group.id).exists():


### PR DESCRIPTION
Address issue #4134 by not returning Permission Denied for calls to can_undo_* concerning inactive users or groups. Just return False. 

This fixes an issue reported by @horsburgh that resources become inaccessible with shared with inactive users. 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. If a user is set to inactive, this no longer hides access to resources the user can view. 
