### PR TITLE
Remove stale code make navbar more independent

### DIFF
--- a/theme/templates/includes/navbar.html
+++ b/theme/templates/includes/navbar.html
@@ -435,6 +435,7 @@
     </div>
 </div>
 {# ======= Modal window ends =======#}
+{% include 'autocomplete_light/static.html' %}
 <script type="text/javascript" src="/static/js/vue-2.6.10-min.js"></script>
 
 <script>
@@ -455,6 +456,21 @@
         createResource(resourceType, title);
     });
 
+    function getCookie(name) {
+      let cookieValue = null;
+      if (document.cookie && document.cookie !== '') {
+        const cookies = document.cookie.split(';');
+        for (let i=0; i < cookies.length; i++) {
+          const cookie = cookies[i].trim();
+          if (cookie.substring(0, name.length + 1) === (name + '=')) {
+            cookieValue = decodeURIComponent(cookie.substring(name.length +1));
+            break;
+          }
+        }
+      }
+      return cookieValue;
+    }
+
     function createResource(type, title) {
         // Disable dropdown items while we process the request
         $(".navbar-inverse .res-dropdown .dropdown-menu").toggleClass("disabled", true);
@@ -463,7 +479,8 @@
         if (!title) {
             title = "Untitled Resource";
         }
-        formData.append("csrfmiddlewaretoken", csrf_token);
+        const csrftoken = getCookie('csrftoken');
+        formData.append("csrfmiddlewaretoken", csrftoken);
         formData.append("title", title);
         formData.append("resource-type", type);
 

--- a/theme/templates/includes/navbar.html
+++ b/theme/templates/includes/navbar.html
@@ -435,7 +435,6 @@
     </div>
 </div>
 {# ======= Modal window ends =======#}
-{% include 'autocomplete_light/static.html' %}
 <script type="text/javascript" src="/static/js/vue-2.6.10-min.js"></script>
 
 <script>

--- a/theme/templates/newbase.html
+++ b/theme/templates/newbase.html
@@ -79,20 +79,12 @@
             display: block;
         }
     </style>
-    {% block extra_css %}{% endblock %}
     <script src="/static/mezzanine/js/jquery-1.8.3.min.js"></script>
     <script src="/static/js/custom.js"></script>
     <script src="/static/js/scrolltopcontrol.js"></script>
-    <script src="/static/js/jqcsrf.js"></script>
-    <script src="/static/js/jquery-ui.js"></script>
     <script src="/static/js/bootstrap.3.0.2.min.js"></script>
     <script src="/static/js/bootstrap-extras.js"></script>
-    {% block extra_js %}{% endblock %}
-    {% include 'autocomplete_light/static.html' %}
 
-    {% load inplace_edit %}{% inplace_static %}
-
-    {% block extra_head %}{% endblock %}
     {% if not page|is_debug %}
         <script type="text/javascript">
             window.heap = window.heap || [], heap.load = function (e, t) {
@@ -112,7 +104,7 @@
     {% endif %}
 </head>
 
-<body id="{% block body_id %}body{% endblock %}">
+<body id="body">
 {% include 'includes/navbar.html' %}
 {% nevercache %}
     {% if messages %}
@@ -122,7 +114,6 @@
                     <div class="row">
                         <div class="col-md-12">
                             <button type="button" class="close btn-close-message">&times;</button>
-                            {# TODO: TESTING #}
                             {% if 'verification email' in message.message %}
                                 <!-- Google Code for HydroShare Conversions Conversion Page -->
                                 <script type="text/javascript">
@@ -156,12 +147,9 @@
     {% endif %}
 {% endnevercache %}
 
-{% block all_content %}
-    <div class="main-container">
-        {% block main %}{% endblock %}
-        {% block after_main %}{% endblock %}
-    </div>
-{% endblock %}
+<div class="main-container">
+    {% block main %}{% endblock %}
+</div>
 {% include 'includes/footer.html' %}
 </body>
 </html>

--- a/theme/templates/newbase.html
+++ b/theme/templates/newbase.html
@@ -84,6 +84,7 @@
     <script src="/static/js/scrolltopcontrol.js"></script>
     <script src="/static/js/bootstrap.3.0.2.min.js"></script>
     <script src="/static/js/bootstrap-extras.js"></script>
+    {% include 'autocomplete_light/static.html' %}
 
     {% if not page|is_debug %}
         <script type="text/javascript">


### PR DESCRIPTION
Navbar has too many dependencies squirreled away in various depths of code includes, assumptions about global scope and Django extends. Bring csrf functions into navbar code (for resource creation), collecting first then will dedupe over time and sub out css, script files.

- Ensure create resource works
- Review basic functionality/layout of Discover as presumably stale scripts have been removed
