### PR TITLE
django will cascade delete for us

### DIFF
--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2309,18 +2309,6 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
     def delete(self, using=None):
         """Delete resource along with all of its metadata and data bag."""
         from .hydroshare import hs_bagit
-        for fl in self.files.all():
-            if fl.logical_file is not None:
-                # delete of metadata file deletes the logical file (one-to-one relation)
-                # so no need for fl.logical_file.delete() and deleting of metadata file
-                # object deletes (cascade delete) all the contained GenericRelated metadata
-                # elements
-                fl.logical_file.metadata.delete()
-            # COUCH: delete of file objects now cascades.
-            fl.delete()
-        # TODO: Pabitra - delete_all_elements() may not be needed in Django 1.8 and later
-        self.metadata.delete_all_elements()
-        self.metadata.delete()
         hs_bagit.delete_files_and_bag(self)
         super(AbstractResource, self).delete()
 


### PR DESCRIPTION
The custom delete logic is no longer necessary as Django does the cascade delete for us now.  It's both more efficient and should prevent a problematic edge case we have seen.  We have seen cases where a resource is being deleted, but the same resource is then viewed.  Part of the view logic updates the view count on the resource object, so the resource object can be deleted by the normal delete logic but then restored by the view.  Django makes this process atomic, avoiding the issue altogether.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Delete a resource with aggregations.  Ensure the aggregation and metadata objects are deleted when the resource is deleted.
