### PR TITLE
4191 meta xml file check fix for check_irods_files

### DIFF
--- a/hs_core/debug_urls.py
+++ b/hs_core/debug_urls.py
@@ -5,10 +5,10 @@ from hs_core import views
 
 urlpatterns = [
     # Resource Debugging: print consistency problems in a resource
-    url(r'^resource/(?P<shortkey>[0-9a-f-]+)/debug/$',
+    url(r'^debug/resource/(?P<shortkey>[0-9a-f-]+)/$',
         views.debug_resource_view.debug_resource,
         name='debug_resource'),
-    url(r'^resource/(?P<shortkey>[0-9a-f-]+)/debug/irods-issues/$',
+    url(r'^debug/resource/(?P<shortkey>[0-9a-f-]+)/irods-issues/$',
         views.debug_resource_view.irods_issues,
         name='debug_resource'),
     url(r'^taskstatus/(?P<task_id>[A-z0-9\-]+)/$',

--- a/hs_core/management/commands/check_irods_files.py
+++ b/hs_core/management/commands/check_irods_files.py
@@ -14,6 +14,8 @@ This checks that:
 """
 
 from django.core.management.base import BaseCommand
+
+from hs_composite_resource.models import CompositeResource
 from hs_core.models import BaseResource
 from hs_core.management.utils import check_irods_files, check_for_dangling_irods
 
@@ -100,6 +102,8 @@ class Command(BaseCommand):
             if options['sync_ispublic']:
                 print(' (correcting isPublic in iRODs)')
             for r in BaseResource.objects.all():
+                if r.resource_type == "CompositeResource":
+                    r = CompositeResource.objects.get(short_id=r.short_id)
                 check_irods_files(r, stop_on_error=False,
                                   echo_errors=not options['log'],  # Don't both log and echo
                                   log_errors=options['log'],


### PR DESCRIPTION
The check for the metadata XML files works fine in the debug URL but it was not working in the management command. Turns out the management command is running off a BaseResource object instead of a CompositeResource object. The BaseResource implementation of is_aggregation_xml_file always returns false. The implementation of is_aggregation_xml_file in CompositeResource has an implementation to check if it's a logical file metadata XML file. The solution is to use a CompositeResource object instead of a BaseResource object in the management command when the resource is a Composite type.

I also included an update to the resource debug URL because of a change to downloads that caused the previous debug URL to route to a download which will always fail.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Run the check_irods_files management command and confirm no `_meta.xml` and `_resmap.xml` files are reported that are associated with a logical file.
2. Navigate to a resources debug URL `/debug/resource/<resource_id>/`
