### PR TITLE
fix author sorting in discover

### DIFF
--- a/hs_discover/views.py
+++ b/hs_discover/views.py
@@ -170,9 +170,9 @@ class SearchAPI(APIView):
             filterdata = [authors, owners, subjects, contributors, types, availability]
 
         if sort == 'author':
-            sqs = sqs.order_by('author_exact')
+            sqs = sqs.order_by('author')
         elif sort == '-author':
-            sqs = sqs.order_by('-author_exact')
+            sqs = sqs.order_by('-author')
         else:
             sqs = sqs.order_by(sort)
 


### PR DESCRIPTION
Looks like we missed one more updated index name.  This change fixes author sorting.  I also search hs_discover/views.py to ensure there were no more remaining _exact indexes within the view.