### PR TITLE
Debugging tool for counting SOLR records.

### DIFF
--- a/hs_core/management/commands/solr_count.py
+++ b/hs_core/management/commands/solr_count.py
@@ -1,0 +1,67 @@
+""" This creates counts of what is in SOLR versus what is in Django for comparison.
+    Note that in Django, publisher --> public --> discoverable, while in SOLR these
+    are distinct facets.  """
+from django.core.management.base import BaseCommand
+from hs_core.models import BaseResource
+from haystack.query import SearchQuerySet
+
+
+class Command(BaseCommand):
+    help = "Compare SOLR records."
+
+    def add_arguments(self, parser):
+
+        # a list of resource id's: none acts on everything.
+        parser.add_argument('resource_ids', nargs='*', type=str)
+
+    def handle(self, *args, **options):
+
+        count_disc_include = 0
+        count_disc_exclude = 0
+        count_disc_solr = 0
+        discoverable = BaseResource.objects.filter(raccess__discoverable=True,
+                                                   raccess__public=False)
+        for d in discoverable:
+            if d.show_in_discover:
+                count_disc_include += 1
+            else:
+                count_disc_exclude += 1
+
+        disc_solr = SearchQuerySet().filter(availability='discoverable').exclude(availability='public')
+        count_disc_solr = disc_solr.count()
+
+        print("discoverable shown={}, hidden={} solr={}"
+              .format(count_disc_include, count_disc_exclude, count_disc_solr))
+
+        count_public_include = 0
+        count_public_exclude = 0
+        count_public_solr = 0
+        public = BaseResource.objects.filter(raccess__public=True,
+                                             raccess__published=False)
+        for d in public:
+            if d.show_in_discover:
+                count_public_include += 1
+            else:
+                count_public_exclude += 1
+
+        disc_solr = SearchQuerySet().filter(availability='public').exclude(availability='published')
+        count_public_solr = disc_solr.count()
+
+        print("public shown={}, hidden={} solr={}"
+              .format(count_public_include, count_public_exclude, count_public_solr))
+
+        count_published_include = 0
+        count_published_exclude = 0
+        count_published_solr = 0
+        published = BaseResource.objects.filter(raccess__published=True)
+        for d in published:
+            if d.show_in_discover:
+                count_published_include += 1
+            else:
+                count_published_exclude += 1
+
+        disc_solr = SearchQuerySet().filter(availability='published')
+        count_published_solr = disc_solr.count()
+
+        print("published shown={}, hidden={} solr={}"
+              .format(count_published_include, count_published_exclude, count_published_solr))


### PR DESCRIPTION
This provides data to debug issue 4264 -- discrepancies in counts between django and solr. 
A single management command `solr_count.py` computes counts of what is in Django, what is in Solr, and the versions that are omitted from SOLR but present in Django.  
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
