### PR TITLE
[#4309] - use view authorization for extra_metadata GET

### DIFF
--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -28,9 +28,13 @@ class TestResourceScienceMetadata(HSRESTTestCase):
         self.resources_to_delete.append(self.pid2)
 
     def test_get_scimeta(self):
+        # set resource public
+        self.resource.raccess.public = True
+        self.resource.raccess.save()
+        # remove authentication to test public view
+        self.client.logout()
         # Get the resource system metadata
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(res_id=self.pid)
-        self.client.logout()
         response = self.client.get(sysmeta_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # content = json.loads(response.content.decode())

--- a/hs_core/tests/api/rest/test_resource_science_meta.py
+++ b/hs_core/tests/api/rest/test_resource_science_meta.py
@@ -30,6 +30,7 @@ class TestResourceScienceMetadata(HSRESTTestCase):
     def test_get_scimeta(self):
         # Get the resource system metadata
         sysmeta_url = "/hsapi/resource/{res_id}/scimeta/elements/".format(res_id=self.pid)
+        self.client.logout()
         response = self.client.get(sysmeta_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # content = json.loads(response.content.decode())

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -385,12 +385,14 @@ def update_key_value_metadata(request, shortkey, *args, **kwargs):
 
     return HttpResponseRedirect(request.META['HTTP_REFERER'])
 
+
 @api_view(['POST', 'GET'])
 def update_key_value_metadata_public(request, pk):
-    res, _, _ = authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
-
     if request.method == 'GET':
+        res, _, _ = authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
         return HttpResponse(status=200, content=json.dumps(res.extra_metadata))
+
+    res, _, _ = authorize(request, pk, needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
 
     post_data = request.data.copy()
     res.extra_metadata = post_data


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

fixes #4309 

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1.  GET `/hsapi/resource/{id}/scimeta/custom/` without authentication on a public resource
