### PR TITLE
[#4272] - handle non-json responses

### DIFF
--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -308,8 +308,12 @@ function metadata_update_ajax_submit(form_id){
             $form.find(".btn-form-submit").removeClass("disabled");
         },
         error: function(XMLHttpRequest, textStatus, errorThrown) {
-            var responseText = JSON.parse(XMLHttpRequest.responseText);
-            var errMessage = "Metadata failed to update " + JSON.stringify(responseText.message);
+            var responseMessage = "Could not parse the error message";
+            try{
+                responseMessage = JSON.parse(XMLHttpRequest.responseText).message;
+            } catch (Error){
+            }
+            var errMessage = "Metadata failed to update " + JSON.stringify(responseMessage);
             $alert_error = $alert_error.replace("Metadata failed to update.", errMessage);
             $('#' + form_id).before($alert_error);
             $(".alert-error").fadeTo(2000, 500).slideUp(1000, function(){


### PR DESCRIPTION
There is a deeper issue with form validation feedback on the backend.  I spent some time looking into the backend issue.  Basically, there is some[ validation in the coverage clean() method ](https://github.com/hydroshare/hydroshare/blame/develop/hs_core/forms.py#L1021-L1022) that removes the invalid data before returning the cleaned_data.  That modified form data is then passed to the Coverage metadata element which fails to create because the fields are missing.  There is some error messaging done in the clean_data method that I don't recognize, I'm not sure if I remove it if I'll break coverage in another area, so I left it alone. 

If someone has insight on the backend issue, I'm open to talking about it and implementing a solution.  The PR as it is, however, fixes the user experience issue.  It could be improved with validation feedback if the backend issue were fixed.

fixes #4272 

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Edit a spatial coverage north field with a non-numeric character and save.  Verify an error message shows.  Correct the value and click save.  Verify it saves.
