### PR TITLE
[#4322] - add popout with cookie support and delay after first search

### DIFF
--- a/hs_discover/public/index.html
+++ b/hs_discover/public/index.html
@@ -58,6 +58,19 @@
 </style>
 <input type="hidden" id="qstring" value="{{ request.GET.q }}">
 <input type="hidden" id="prefillsubject" value="{{ request.GET.subject }}">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
+<script>
+    function completedSurvey(event) {
+        $.cookie('discover-survey', 'complete');
+    }
+
+    var cookie = $.cookie('discover-survey');
+    if (!cookie) {
+        $('.main-container').before("<div data-tf-sidetab=\"gfePN4ur\" data-tf-width=\"320\" data-tf-height=\"400\" data-tf-on-submit=\"completedSurvey\" data-tf-button-color=\"#F4B080\" data-tf-button-text=\"Help us improve\" data-tf-auto-close  data-tf-hidden=\"email={{ user.email }},cookie={{ request.session.session_key }}\" style=\"all:unset;\"></div>");
+    }
+
+</script>
+<script src="//embed.typeform.com/next/embed.js"></script>
 <div class="container" id="discover-main">
     <h2 class="page-title">Discover
         <small class="text-muted"><i>Public resources shared with the community</i></small>

--- a/hs_discover/src/components/Search.vue
+++ b/hs_discover/src/components/Search.vue
@@ -258,6 +258,8 @@ import axios from 'axios'; // css font-size overridden in hs_discover/index.html
 export default {
   data() {
     return {
+      initialSearch: true,
+      showPopup: true,
       loading: true,
       prefiltered: false,
       columns: ['name', 'author', 'created', 'modified'],
@@ -377,6 +379,13 @@ export default {
   },
   methods: {
     searchClick(paging, dofilters, reset) { // paging flag to skip the page reset after data retrieval
+      if (!this.initialSearch && this.showPopup) {
+        this.$delayPopOutSurvey();
+        this.showPopup = false;
+      }
+      if (this.initialSearch) {
+        this.initialSearch = false;
+      }
       if (!this.pagenum) return; // user has cleared input box with intent do manually input an integer and subsequently caused a search event
       document.body.style.cursor = 'wait';
       if (reset) {

--- a/hs_discover/src/main.js
+++ b/hs_discover/src/main.js
@@ -6,6 +6,23 @@ import Search from './components/Search.vue';
 
 Vue.use(BootstrapVue);
 
+function delayPopOutSurvey() {
+  const cookie = $.cookie('discover-survey');
+  if (!cookie) {
+    const delaySeconds = 60;
+    const buttonExists = $('.typeform-sidetab-button').length;
+    if (buttonExists) {
+      setTimeout(
+        () => {
+          $('.typeform-sidetab-button').click();
+        }, delaySeconds * 1000,
+      );
+    }
+  }
+}
+
+Vue.prototype.$delayPopOutSurvey = delayPopOutSurvey;
+
 new Vue({
   render: h => h(Search),
 }).$mount('#app');


### PR DESCRIPTION
This is a survey that will run temporarily.  The survey tab is shown to all users on the discover page.  The survey pops-out 60 seconds after initial search.  After a user has completed the survey, a cookie is created and the next time the user loads the discover page, the survey tab will not show up.

**This merge will be reverted once the survey is complete.**
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Navigate to Discover, verify the survey tab shows on the right side.  
2. Look at the source of the Discover page, verify the div with attribute `data-tf-hidden` has a value containing the email if you're logged in and the session cookie.
3. Do a search via the textbox or facet, wait 60 seconds and verify the survey tab pops-out.  
4. Complete the survey and reload the discover page, verify the survey tab does not show.
