### PR TITLE
[#3683] - escape resource title in recently visited

### DIFF
--- a/theme/templatetags/dashboard_tags.py
+++ b/theme/templatetags/dashboard_tags.py
@@ -3,6 +3,8 @@
 from django import template
 import timeago
 from django.utils import timezone as django_timezone
+from django.utils.html import escape
+
 register = template.Library()
 
 
@@ -15,7 +17,7 @@ def date_time_pac(in_datetime):
 @register.simple_tag(name='resource_link_builder')
 def build_resource_link(title, short_id):
     link = "/resource/" + short_id + "/"
-    return "<strong> <a href=\"" + link + "\">" + title + "</a> </strong>"
+    return "<strong> <a href=\"" + link + "\">" + escape(title) + "</a> </strong>"
 
 
 @register.simple_tag(name='build_privacy_status')


### PR DESCRIPTION
I missed the title in the recently visited section
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Put an HTML snippet in a resource title and navigate to home.  Verify the title doesn't render in the recently visited section.
