### PR TITLE
[#4359] - set resource to private before deleting in the API

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -800,6 +800,8 @@ def delete_resource(pk, request_username=None):
     Note:  Only HydroShare administrators will be able to delete formally published resource
     """
     from hs_core.tasks import delete_resource_task
+    resource = utils.get_resource_by_shortkey(pk)
+    resource.set_discoverable(False)
     delete_resource_task(pk, request_username)
 
     return pk

--- a/hs_core/tests/api/native/test_delete_resource.py
+++ b/hs_core/tests/api/native/test_delete_resource.py
@@ -1,6 +1,11 @@
+import os
+import tempfile
+
 from django.contrib.auth.models import Group
 from django.test import TestCase
+from haystack.query import SearchQuerySet
 
+from hs_composite_resource.models import CompositeResource
 from hs_core.hydroshare import resource
 from hs_core.hydroshare import users
 from hs_core.models import GenericResource
@@ -12,6 +17,7 @@ class TestDeleteResource(MockIRODSTestCaseMixin, TestCase):
     def setUp(self):
         super(TestDeleteResource, self).setUp()
         self.group, _ = Group.objects.get_or_create(name='Hydroshare Author')
+        self.tmp_dir = tempfile.mkdtemp()
         # create a user
         self.user = users.create_account(
             'test_user@email.com',
@@ -36,6 +42,33 @@ class TestDeleteResource(MockIRODSTestCaseMixin, TestCase):
 
         # there should be no resource at this point
         self.assertEqual(GenericResource.objects.all().count(), 0, msg="Number of resources not equal to 0")
+
+    def test_delete_resource_public(self):
+        # create files
+        file_one = os.path.join(self.tmp_dir, "test1.txt")
+
+        file_one_write = open(file_one, "w")
+        file_one_write.write("Putting something inside")
+        file_one_write.close()
+
+        # open files for read and upload
+        self.file_one = open(file_one, "rb")
+
+        new_res = resource.create_resource(
+            'GenericResource',
+            self.user,
+            'My Test Resource',
+            files=(self.file_one,),
+            keywords=("one", "two",),
+            metadata=[{"description": {"abstract": "myabstract"}}]
+        )
+        self.assertEqual(len(SearchQuerySet().all()), 0)
+
+        new_res.set_public(True)
+        self.assertEqual(len(SearchQuerySet().all()), 1)
+
+        resource.delete_resource(new_res.short_id)
+        self.assertEqual(len(SearchQuerySet().all()), 0)
 
 
 


### PR DESCRIPTION
fixes #4359 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Delete a public resource through `/hsapi/resource/{id}`
2. Verify the deleted resource does not show in discover
