### PR TITLE
4434 message text change for accessing content files

### DIFF
--- a/hs_core/templates/pages/genericresource.html
+++ b/hs_core/templates/pages/genericresource.html
@@ -914,7 +914,7 @@
                     {% endif %}
                 {% else %}
                     <i class="glyphicon glyphicon-eye-close text-danger no-access-icon"></i>&nbsp;
-                    <span>You do not have permission to see these content files. Please contact the Authors if you wish to obtain access.</span>
+                    <span>You do not have permission to see these content files. Please contact an Owner if you wish to obtain access.</span>
                 {% endif %}
             </div>
         {% endif %}


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource. Upload a file to the resource.
2. Add needed metadata to make the resource discoverable
3. Make the resource discoverable
4. Logout. Then try to access the resource. On the resource landing page check that you see the following message under the "**Content**' section:

 You do not have permission to see these content files. Please contact an Owner if you wish to obtain access.
