### PR TITLE
tool icon preview responsive margins Resolves #4493 

### DIFF
--- a/hs_tools_resource/forms.py
+++ b/hs_tools_resource/forms.py
@@ -481,22 +481,23 @@ class ToolIconFormHelper(BaseFormHelper):
                         </a>
                         """),
                     HTML("""
-                    <a type="button" id="icon-delete-btn" class="" title="Clear icon">
-                        <span class="glyphicon glyphicon-trash icon-button btn-remove"></span>
-                    </a>
-                    """),
-                    css_class='form-group col-md-6 mb-0'
+                        <a type="button" id="icon-delete-btn" class="" title="Clear icon">
+                            <span class="glyphicon glyphicon-trash icon-button btn-remove"></span>
+                        </a>
+                        """),
+                    css_class='form-group col-sm-6'
                 ),
-                css_class='form-row'
             ),
             Row(
-                HTML("""
-                    <span id="icon-preview-label" class="control-label">Preview</span>
-                    <br>
-                    <img id="tool-icon-preview" src="{data_url_db}">
-                    """.format(data_url_db=data_url_db)),
-                css_class='form-row'
+                Column(
+                    HTML("""
+                        <span id="icon-preview-label" class="control-label">Preview</span>
+                        <br>
+                        <img id="tool-icon-preview" src="{data_url_db}">
+                        """.format(data_url_db=data_url_db)),
+                    css_class='form-group col-sm-12'
                 ),
+            )
         )
         kwargs['element_name_label'] = 'Icon URL or File'
         super(ToolIconFormHelper, self).__init__(allow_edit,

--- a/hs_tools_resource/models.py
+++ b/hs_tools_resource/models.py
@@ -487,7 +487,7 @@ class ToolIcon(AbstractMetaDataElement):
     def create(cls, **kwargs):
         if "value" in kwargs:
             url = kwargs["value"]
-
+            data_url = cls._validate_tool_icon(url) if url else ""
             metadata_obj = kwargs['content_object']
             new_meta_instance = ToolIcon.objects.create(content_object=metadata_obj)
             new_meta_instance.value = url


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a new web app connector
2. Reduce your screen size until the bootstrap "sm" styles kick in
3. Scroll down to the Icon URL/FILE section
4. The preview no longer hangs off the side of the page

This PR resolves #4493 
This PR fixes merged issues from PR #4479 

## Before
![image](https://user-images.githubusercontent.com/17934193/154314027-ddd85b6c-862d-4f0a-9b65-f1a93e05ab8f.png)

##After
![image](https://user-images.githubusercontent.com/17934193/154314429-f9c9c555-5539-4e92-8245-d2f3f82f335c.png)
