### PR TITLE
Prevent temporal coverage submit unless dates are completed

### DIFF
--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -1361,23 +1361,39 @@ function initializeDatePickers(){
     });
 
     // Temporal coverage: only allow submit if both dates are completed
+    let temporal_button = $("#coverage-temporal button");
+    let temporal_warn = $('#temporal-warn');
+    if (temporal_warn.length === 0) {
+        temporal_warn = $("<em>", {
+            id: "temporal-warn",
+            text: "Both a Start Date and End Date are required when providing temporal information",
+            css: {
+                "font-style": "italic",
+                "color": "red"
+            }
+        });
+        temporal_button.closest('div').before(temporal_warn);
+    }
+    temporal_warn.hide();
+
     $("#coverage-temporal .dateinput").each(function () {
         $(this).on('change', function (e) {
-            let button = $(this).closest("form").find("button")
-            let this_date = $(this).val()
-            let other_date = $(this).closest("form").find(".form-control").not(this).first().val();
-            if (this_date && other_date) {
-                button.removeClass("disabled")
-                    .text("Save changes")
-                    .addClass('btn-primary')
-                    .removeClass('btn-warning')
-            }else if ( this_date || other_date){
-                button.addClass("disabled")
-                        .text("Fill both dates to save")
-                        .removeClass('btn-primary')
-                        .addClass('btn-warning')
+            let this_date = $(this)
+            let other_date = $(this).closest("form").find(".form-control").not(this).first();
+            if (this_date.val() && other_date.val()) {
+                temporal_button.removeClass("disabled");
+                temporal_warn.hide();
+            }else if ( this_date.val()){
+                temporal_button.addClass("disabled");
+                other_date.after(temporal_warn);
+                temporal_warn.show();
+            }else if(other_date.val()){
+                temporal_button.addClass("disabled");
+                this_date.after(temporal_warn);
+                temporal_warn.show();
             }else{
-                button.hide()
+                temporal_button.hide()
+                temporal_warn.hide()
             }
         });
     });

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -1359,6 +1359,28 @@ function initializeDatePickers(){
             $(this).datepicker("setDate", pickerDate);
         }
     });
+
+    // Temporal coverage: only allow submit if both dates are completed
+    $("#coverage-temporal .dateinput").each(function () {
+        $(this).on('change', function (e) {
+            let button = $(this).closest("form").find("button")
+            let this_date = $(this).val()
+            let other_date = $(this).closest("form").find(".form-control").not(this).first().val();
+            if (this_date && other_date) {
+                button.removeClass("disabled")
+                    .text("Save changes")
+                    .addClass('btn-primary')
+                    .removeClass('btn-warning')
+            }else if ( this_date || other_date){
+                button.addClass("disabled")
+                        .text("Fill both dates to save")
+                        .removeClass('btn-primary')
+                        .addClass('btn-warning')
+            }else{
+                button.hide()
+            }
+        });
+    });
 }
 
 function updateEditCoverageStateFileType() {

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -1383,11 +1383,11 @@ function initializeDatePickers(){
             if (this_date.val() && other_date.val()) {
                 temporal_button.removeClass("disabled");
                 temporal_warn.hide();
-            }else if ( this_date.val()){
+            }else if (this_date.val()) {
                 temporal_button.addClass("disabled");
                 other_date.after(temporal_warn);
                 temporal_warn.show();
-            }else if(other_date.val()){
+            }else if (other_date.val()) {
                 temporal_button.addClass("disabled");
                 this_date.after(temporal_warn);
                 temporal_warn.show();


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [X] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a new resource
2. Edit temporal coverage dates
3. You will not be able to "Save Changes" until you have completed both dates

Resolves #3451 

### Screenshots

#### BEFORE:
![image](https://user-images.githubusercontent.com/17934193/155030120-bb9a14bf-7d77-4750-9f2e-f2586ef6fc5a.png)

#### AFTER:
![image](https://user-images.githubusercontent.com/17934193/155030072-a2591e40-dfd3-4804-af9f-de5fd600ac45.png)

