### PR TITLE
Only prompt to publish if user has auth to publish resource

### DIFF
--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1069,6 +1069,12 @@ a[data-toggle='tab']{
     border-color: #20833F;
 }
 
+#btn-public:disabled, 
+#btn-private:disabled, 
+#btn-discoverable:disabled {
+	pointer-events: auto;
+}
+
 #btn-private.active {
     color: #FFF;
     background: #d9534f;

--- a/theme/static/js/hs-vue/manage-access-app.js
+++ b/theme/static/js/hs-vue/manage-access-app.js
@@ -29,6 +29,7 @@ let manageAccessApp = new Vue({
             edit: 'Can edit',
             owner: 'Is owner'
         },
+        accessDeniedTitle: "You do not have permission to change the sharing status",
         error: "",
         quotaError: "",
         sharingError: "",

--- a/theme/static/js/hs-vue/manage-access-app.js
+++ b/theme/static/js/hs-vue/manage-access-app.js
@@ -29,7 +29,7 @@ let manageAccessApp = new Vue({
             edit: 'Can edit',
             owner: 'Is owner'
         },
-        accessDeniedTitle: "You do not have permission to change the sharing status",
+        accessDeniedTitle: "You do not have permission to change the sharing status.",
         error: "",
         quotaError: "",
         sharingError: "",

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -338,32 +338,32 @@ function showCompletedMessage(json_response) {
                 showMetaStatus = json_response.show_meta_status;
             }
             if (showMetaStatus) {
-                if (json_response.metadata_status.toLowerCase().indexOf("insufficient") == -1 &&
-                    manageAccessApp.canChangeResourceFlags) {
-                        manageAccessApp.$data.canBePublicDiscoverable = true;
-                        let resourceType = RES_TYPE;
-                        let promptMessage = "";
-                        if (resourceType != 'Web App Resource' && resourceType != 'Collection Resource')
-                            promptMessage = "All required fields are completed. The resource can now be made discoverable " +
-                                "or public. To permanently publish the resource and obtain a DOI, the resource " +
-                                "must first be made public.";
-                        else
-                            promptMessage = "All required fields are completed. The resource can now be made discoverable " +
-                                "or public.";
+                let sufficient = json_response.metadata_status.toLowerCase().indexOf("insufficient") == -1;
+                if (sufficient && manageAccessApp.canChangeResourceFlags) {
+                    manageAccessApp.$data.canBePublicDiscoverable = true;
+                    let resourceType = RES_TYPE;
+                    let promptMessage = "";
+                    if (resourceType != 'Web App Resource' && resourceType != 'Collection Resource')
+                        promptMessage = "All required fields are completed. The resource can now be made discoverable " +
+                            "or public. To permanently publish the resource and obtain a DOI, the resource " +
+                            "must first be made public.";
+                    else
+                        promptMessage = "All required fields are completed. The resource can now be made discoverable " +
+                            "or public.";
 
-                        if (!metadata_update_ajax_submit.resourceSatusDisplayed) {
-                            metadata_update_ajax_submit.resourceSatusDisplayed = true;
-                            if (json_response.hasOwnProperty('res_public_status')) {
-                                if (json_response.res_public_status.toLowerCase() === "not public") {
-                                    // if the resource is already public no need to show the following alert message
-                                    customAlert("Resource Status:", promptMessage, "success", 8000);
-                                }
-                            } else {
+                    if (!metadata_update_ajax_submit.resourceSatusDisplayed) {
+                        metadata_update_ajax_submit.resourceSatusDisplayed = true;
+                        if (json_response.hasOwnProperty('res_public_status')) {
+                            if (json_response.res_public_status.toLowerCase() === "not public") {
+                                // if the resource is already public no need to show the following alert message
                                 customAlert("Resource Status:", promptMessage, "success", 8000);
                             }
+                        } else {
+                            customAlert("Resource Status:", promptMessage, "success", 8000);
                         }
-                        $("#missing-metadata-or-file:not(.persistent)").fadeOut();
-                        $("#missing-metadata-file-type:not(.persistent)").fadeOut();
+                    }
+                    $("#missing-metadata-or-file:not(.persistent)").fadeOut();
+                    $("#missing-metadata-file-type:not(.persistent)").fadeOut();
                 } else {
                     manageAccessApp.onMetadataInsufficient();
                 }

--- a/theme/static/js/resourceLandingAjax.js
+++ b/theme/static/js/resourceLandingAjax.js
@@ -338,31 +338,32 @@ function showCompletedMessage(json_response) {
                 showMetaStatus = json_response.show_meta_status;
             }
             if (showMetaStatus) {
-                if (json_response.metadata_status.toLowerCase().indexOf("insufficient") == -1) {
-                    manageAccessApp.$data.canBePublicDiscoverable = true;
-                    let resourceType = RES_TYPE;
-                    let promptMessage = "";
-                    if (resourceType != 'Web App Resource' && resourceType != 'Collection Resource')
-                        promptMessage = "All required fields are completed. The resource can now be made discoverable " +
-                            "or public. To permanently publish the resource and obtain a DOI, the resource " +
-                            "must first be made public.";
-                    else
-                        promptMessage = "All required fields are completed. The resource can now be made discoverable " +
-                            "or public.";
+                if (json_response.metadata_status.toLowerCase().indexOf("insufficient") == -1 &&
+                    manageAccessApp.canChangeResourceFlags) {
+                        manageAccessApp.$data.canBePublicDiscoverable = true;
+                        let resourceType = RES_TYPE;
+                        let promptMessage = "";
+                        if (resourceType != 'Web App Resource' && resourceType != 'Collection Resource')
+                            promptMessage = "All required fields are completed. The resource can now be made discoverable " +
+                                "or public. To permanently publish the resource and obtain a DOI, the resource " +
+                                "must first be made public.";
+                        else
+                            promptMessage = "All required fields are completed. The resource can now be made discoverable " +
+                                "or public.";
 
-                    if (!metadata_update_ajax_submit.resourceSatusDisplayed) {
-                        metadata_update_ajax_submit.resourceSatusDisplayed = true;
-                        if (json_response.hasOwnProperty('res_public_status')) {
-                            if (json_response.res_public_status.toLowerCase() === "not public") {
-                                // if the resource is already public no need to show the following alert message
+                        if (!metadata_update_ajax_submit.resourceSatusDisplayed) {
+                            metadata_update_ajax_submit.resourceSatusDisplayed = true;
+                            if (json_response.hasOwnProperty('res_public_status')) {
+                                if (json_response.res_public_status.toLowerCase() === "not public") {
+                                    // if the resource is already public no need to show the following alert message
+                                    customAlert("Resource Status:", promptMessage, "success", 8000);
+                                }
+                            } else {
                                 customAlert("Resource Status:", promptMessage, "success", 8000);
                             }
-                        } else {
-                            customAlert("Resource Status:", promptMessage, "success", 8000);
                         }
-                    }
-                    $("#missing-metadata-or-file:not(.persistent)").fadeOut();
-                    $("#missing-metadata-file-type:not(.persistent)").fadeOut();
+                        $("#missing-metadata-or-file:not(.persistent)").fadeOut();
+                        $("#missing-metadata-file-type:not(.persistent)").fadeOut();
                 } else {
                     manageAccessApp.onMetadataInsufficient();
                 }

--- a/theme/templates/resource-landing-page/manage-access.html
+++ b/theme/templates/resource-landing-page/manage-access.html
@@ -160,7 +160,7 @@
                                             :class="{active: resAccess.isPublic}"
                                             class="btn btn-default"
                                             id="btn-public" data-toggle="tooltip" data-placement="auto" 
-                                            :title="!canChangeResourceFlags ? this.accessDeniedTitle : 'Can be viewed and downloaded by anyone'" 
+                                            :title="!canChangeResourceFlags ? this.accessDeniedTitle : 'Can be viewed and downloaded by anyone.'" 
                                             type="button">
                                             Public
                                         </button>

--- a/theme/templates/resource-landing-page/manage-access.html
+++ b/theme/templates/resource-landing-page/manage-access.html
@@ -155,7 +155,7 @@
                                     <div class="btn-group" role="group">
                                         {# -------- PUBLIC -------- #}
                                         <button
-                                            :disabled="!canBePublicDiscoverable || resAccess.isPublic || isProcessingAccess"
+                                            :disabled="!canBePublicDiscoverable || !canChangeResourceFlags || isProcessingAccess"
                                             @click="setResourceAccess('make_public')"
                                             :class="{active: resAccess.isPublic}"
                                             class="btn btn-default"
@@ -165,7 +165,7 @@
                                         </button>
 
                                         {# -------- DISCOVERABLE -------- #}
-                                        <button :disabled="!canBePublicDiscoverable || isProcessingAccess"
+                                        <button :disabled="!canBePublicDiscoverable || !canChangeResourceFlags || isProcessingAccess"
                                                 @click="setResourceAccess('make_discoverable')"
                                                 :class="{active: resAccess.isDiscoverable && !resAccess.isPublic}"
                                                 class="btn btn-default"
@@ -176,7 +176,7 @@
 
                                         {# -------- PRIVATE -------- #}
                                         <button
-                                            :disabled="!resAccess.isPublic && !resAccess.isDiscoverable || isProcessingAccess"
+                                            :disabled="!resAccess.isPublic && !resAccess.isDiscoverable || !canChangeResourceFlags || isProcessingAccess"
                                             @click="setResourceAccess('make_private')"
                                             :class="{active: !resAccess.isPublic && !resAccess.isDiscoverable}"
                                             class="btn btn-default"

--- a/theme/templates/resource-landing-page/manage-access.html
+++ b/theme/templates/resource-landing-page/manage-access.html
@@ -159,8 +159,9 @@
                                             @click="setResourceAccess('make_public')"
                                             :class="{active: resAccess.isPublic}"
                                             class="btn btn-default"
-                                            id="btn-public" data-toggle="tooltip" data-placement="auto"
-                                            title='Can be viewed and downloaded by anyone.' type="button">
+                                            id="btn-public" data-toggle="tooltip" data-placement="auto" 
+                                            :title="!canChangeResourceFlags ? this.accessDeniedTitle : 'Can be viewed and downloaded by anyone'" 
+                                            type="button">
                                             Public
                                         </button>
 
@@ -169,8 +170,9 @@
                                                 @click="setResourceAccess('make_discoverable')"
                                                 :class="{active: resAccess.isDiscoverable && !resAccess.isPublic}"
                                                 class="btn btn-default"
-                                                id="btn-discoverable" data-toggle="tooltip" data-placement="auto"
-                                                type="button" title='Metadata is public but data are protected.'>
+                                                id="btn-discoverable" data-toggle="tooltip" data-placement="auto" 
+                                                :title="!canChangeResourceFlags ? this.accessDeniedTitle : 'Metadata is public but data are protected.'"
+                                                type="button">
                                             Discoverable
                                         </button>
 
@@ -181,7 +183,7 @@
                                             :class="{active: !resAccess.isPublic && !resAccess.isDiscoverable}"
                                             class="btn btn-default"
                                             id="btn-private" data-toggle="tooltip" data-placement="auto"
-                                            title='Can be viewed and downloaded only by designated users or research groups.'
+                                            :title="!canChangeResourceFlags ? this.accessDeniedTitle : 'Can be viewed and downloaded only by designated users or research groups.'"
                                             type="button">
                                             Private
                                         </button>


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [X] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Go to a resource that you do not own, that is private and that you have edit permission on.
2. Add information to the resource such as a keyword or file that makes its metadata sufficient for it to be made public.
3. Message prompting you to publish will not appear
4. Now "Manage who has access"
5. The sharing status "public/discoverable" buttons are inactivated


#### Before screenshots:
![136199040-4a3787f2-74df-476a-b645-30af610ff37a](https://user-images.githubusercontent.com/17934193/155164492-4c0db4d7-93d9-4f3c-ba97-0dab6cff897d.png)
![before4375](https://user-images.githubusercontent.com/17934193/155186457-09f63b48-7b38-48ae-9977-455840d587fb.png)


#### After screenshots:
<img width="604" alt="Screen Shot 2022-02-28 at 1 08 22 PM" src="https://user-images.githubusercontent.com/17934193/156035316-b12ce97b-6bf1-42a8-b2a8-38d59a7914b4.png">


Resolves #4374 
Resolves #4375 