### PR TITLE
4495 Fix 'is part of' relations

### DIFF
--- a/hs_core/management/commands/migrate_ispartof_not_collection_related.py
+++ b/hs_core/management/commands/migrate_ispartof_not_collection_related.py
@@ -1,0 +1,50 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from hs_core.enums import RelationTypes
+from hs_core.hydroshare.utils import set_dirty_bag_flag
+from hs_core.models import BaseResource
+
+
+class Command(BaseCommand):
+    help = "Migrate 'isPartOf' relation type (which are not related to collection) to 'isReferencedBy' relation type."
+
+    def handle(self, *args, **options):
+        log = logging.getLogger()
+        res_count = BaseResource.objects.count()
+        log_msg = "Total resources to process:{}".format(res_count)
+        print(log_msg)
+        updated_res_count = 0
+        for res in BaseResource.objects.all().iterator():
+            res = res.get_content_model()
+            if res.metadata is None:
+                log_msg = "Resource with ID:{} missing metadata object. Skipping this resource".format(res.short_id)
+                print(log_msg)
+                log.warning(log_msg)
+                continue
+
+            if res.collections:
+                res.update_relation_meta()
+            rel_type_updated = False
+            for rel in res.metadata.relations.filter(type=RelationTypes.isPartOf).all():
+                for col_res in res.collections.all():
+                    if rel.value == col_res.get_citation():
+                        break
+                else:
+                    # isPartOf relation is not related to collection - so update the relation type
+                    rel.type = RelationTypes.isReferencedBy
+                    rel.save()
+                    rel_type_updated = True
+            if rel_type_updated:
+                updated_res_count += 1
+                set_dirty_bag_flag(res)
+                log_msg = "Relation type:{} migrated to type:{} for resource with ID:{} and type:{}."
+                log_msg = log_msg.format(RelationTypes.isPartOf.value, RelationTypes.isReferencedBy.value,
+                                         res.short_id, res.resource_type)
+                print(log_msg)
+                log.info(log_msg)
+
+        log_msg = "{} resource(s) updated for migrating relation type (isPartOf).".format(updated_res_count)
+        print(log_msg)
+        log.info(log_msg)

--- a/hs_core/tests/api/native/test_ispartof_to_isreferencedby_update_command.py
+++ b/hs_core/tests/api/native/test_ispartof_to_isreferencedby_update_command.py
@@ -1,0 +1,116 @@
+from unittest import TestCase
+
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+
+from hs_collection_resource.models import CollectionResource
+from hs_composite_resource.models import CompositeResource
+from hs_core import hydroshare
+from hs_core.enums import RelationTypes
+from hs_core.testing import MockIRODSTestCaseMixin
+
+
+class TestRelationTypeUpdateCommand(MockIRODSTestCaseMixin, TestCase):
+
+    def setUp(self):
+        super(TestRelationTypeUpdateCommand, self).setUp()
+
+        self.hs_group, _ = Group.objects.get_or_create(name='Hydroshare Author')
+        # create a user
+        self.user = hydroshare.create_account(
+            'mp_resource_migration@email.com',
+            username='mp_resource_migration',
+            first_name='some_first_name',
+            last_name='some_last_name',
+            superuser=False,
+            groups=[self.hs_group],
+        )
+        self.update_command = "migrate_ispartof_not_collection_related"
+
+        # delete all resources in case a test isn't cleaning up after itself
+        CompositeResource.objects.all().delete()
+        CollectionResource.objects.all().delete()
+
+    def tearDown(self):
+        super(TestRelationTypeUpdateCommand, self).tearDown()
+        self.user.delete()
+        self.hs_group.delete()
+        CompositeResource.objects.all().delete()
+        CollectionResource.objects.all().delete()
+
+    def test_update_is_part_of_relation_1(self):
+        """
+        Testing user edited relation type 'isPartOf' is updated to 'isReferencedBy' when we run the command.
+        """
+
+        # create a composite resource
+        comp_res = self._create_resource()
+        # check no 'isPartOf' relation exists
+        metadata = comp_res.metadata
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isPartOf).exists())
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isReferencedBy).exists())
+        # add 'isPartOf' relation that is not related to collection
+        metadata.create_element('relation', type=RelationTypes.isPartOf, value="testing")
+        self.assertTrue(metadata.relations.filter(type=RelationTypes.isPartOf).exists())
+
+        # run  update command to update the type 'isPartOf' to 'isReferencedBy'
+        call_command(self.update_command)
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isPartOf).exists())
+        self.assertEqual(metadata.relations.filter(type=RelationTypes.isReferencedBy).count(), 1)
+
+    def test_update_is_part_of_relation_2(self):
+        """
+        Testing user edited multiple relation type 'isPartOf' is updated to 'isReferencedBy' when we run the command.
+        """
+
+        # create a composite resource
+        comp_res = self._create_resource()
+        comp_res_2 = self._create_resource()
+        # check no 'isPartOf' relation exists
+        metadata = comp_res.metadata
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isPartOf).exists())
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isReferencedBy).exists())
+        # add 2 'isPartOf' relation that is not related to collection
+        metadata.create_element('relation', type=RelationTypes.isPartOf, value="testing-1")
+        metadata.create_element('relation', type=RelationTypes.isPartOf, value=comp_res_2.get_citation())
+        self.assertEqual(metadata.relations.filter(type=RelationTypes.isPartOf).count(), 2)
+
+        # run  update command to update the type 'isPartOf' to 'isReferencedBy'
+        call_command(self.update_command)
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isPartOf).exists())
+        self.assertEqual(metadata.relations.filter(type=RelationTypes.isReferencedBy).count(), 2)
+
+    def test_update_is_part_of_relation_3(self):
+        """
+        Testing user edited relation type 'isPartOf' is updated to 'isReferencedBy' when we run the command. However,
+        'isPartOf' relation type that is related to collection resource is not updated by the command.
+        """
+
+        # create a composite resource and a collection resource
+        comp_res = self._create_resource()
+        col_res = self._create_resource(res_type='CollectionResource')
+        # make the res part of the collection resource
+        col_res.resources.add(comp_res)
+        # check no 'isPartOf' relation exists
+        metadata = comp_res.metadata
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isPartOf).exists())
+        self.assertFalse(metadata.relations.filter(type=RelationTypes.isReferencedBy).exists())
+        # add collection related 'isPartOf' relation - this won't be updated when we run the command
+        metadata.create_element('relation', type=RelationTypes.isPartOf, value=col_res.get_citation())
+
+        # add 2 'isPartOf' relation that is not related to collection
+        metadata.create_element('relation', type=RelationTypes.isPartOf, value="testing-1")
+        metadata.create_element('relation', type=RelationTypes.isPartOf, value="testing-2")
+        self.assertEqual(metadata.relations.filter(type=RelationTypes.isPartOf).count(), 3)
+
+        # run  update command to update the type 'isPartOf' to 'isReferencedBy'
+        call_command(self.update_command)
+        self.assertEqual(metadata.relations.filter(type=RelationTypes.isPartOf).count(), 1)
+        self.assertEqual(metadata.relations.filter(type=RelationTypes.isReferencedBy).count(), 2)
+        
+    def _create_resource(self, res_type='CompositeResource', add_keywords=False):
+        res = hydroshare.create_resource(res_type, self.user, "Testing updating relation type isPartOf")
+        if add_keywords:
+            res.metadata.create_element('subject', value='kw-1')
+            res.metadata.create_element('subject', value='kw-2')
+        return res

--- a/hs_core/tests/api/native/test_ispartof_to_isreferencedby_update_command.py
+++ b/hs_core/tests/api/native/test_ispartof_to_isreferencedby_update_command.py
@@ -107,7 +107,7 @@ class TestRelationTypeUpdateCommand(MockIRODSTestCaseMixin, TestCase):
         call_command(self.update_command)
         self.assertEqual(metadata.relations.filter(type=RelationTypes.isPartOf).count(), 1)
         self.assertEqual(metadata.relations.filter(type=RelationTypes.isReferencedBy).count(), 2)
-        
+
     def _create_resource(self, res_type='CompositeResource', add_keywords=False):
         res = hydroshare.create_resource(res_type, self.user, "Testing updating relation type isPartOf")
         if add_keywords:

--- a/theme/templates/resource-landing-page/references.html
+++ b/theme/templates/resource-landing-page/references.html
@@ -10,7 +10,7 @@
         <div class="col-xs-12 content-block">
             <table class="table hs-table info-table">
                 {% for relation in relations %}
-                    {% if relation.type|lower != "haspart" %}
+                    {% if relation.type|lower != "haspart" and relation.type|lower != "ispartof" %}
                         <tr style="padding-bottom: 20px">
                             <td class="dataset-label" style="min-width: 100px;">
                                 {{ relation.type_description }}
@@ -56,7 +56,7 @@ Click this button to add a relationship to another resource, external website, o
         <table class="table hs-table info-table">
             <tbody>
             {% for relation in relations %}
-                {% if  relation.type|lower != "haspart" %}
+                {% if  relation.type|lower != "haspart" and relation.type|lower != "ispartof" %}
                     <tr>
                         <td scope="row" class="dataset-label" style="min-width: 100px;">
                             {{ relation.type_description }}


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1.  The migration command to update the relation type 'isPartOf' (which were originally created by users) to relation type 'isReferencedBy'  needs to be tested as part of beta deployment. 
2. Create a resource (composite).
3. Create a collection resource and make the composite resource as part of the collection.
4. View the composite resource both in view and edit mode. Verify that the 'isPartOf' relation is not displayed in the 'Related Resources' section.
