### PR TITLE
dismiss context menu when click outside of it

### DIFF
--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -938,7 +938,6 @@ function bindFileBrowserItemEvents() {
         // register a listener for clicks outside of the context menu
         $(document).on('click.menu', function(event) {
             var $target = $(event.target);
-            console.log(this);
             if(!$target.closest('#right-click-menu').length && 
                 $('#right-click-menu').css("display") !== "none") {
                 $('#right-click-menu').hide();

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -935,12 +935,16 @@ function bindFileBrowserItemEvents() {
 
         $(".selection-menu").hide();    // Hide other menus
 
-        // register a listener for clicks outside of the context menu
+        // register a listener for clicks outside of the context menus
         $(document).on('click.menu', function(event) {
             var $target = $(event.target);
             if(!$target.closest('#right-click-menu').length && 
                 $('#right-click-menu').css("display") !== "none") {
                 $('#right-click-menu').hide();
+            }
+            if(!$target.closest('#right-click-container-menu').length && 
+                $('#right-click-container-menu').css("display") !== "none") {
+                $('#right-click-container-menu').hide();
             }
             // de-register listener to allow bubbling
             $(document).off('click.menu');

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -755,11 +755,6 @@ function bindFileBrowserItemEvents() {
         }
     });
 
-    // Dismiss right click menu when mouse down outside of it
-    $("#fb-files-container, #fb-files-container li, #hsDropzone").mousedown(function () {
-        $(".selection-menu").hide();
-    });
-
     var timer = 0;
     var delay = 200;
     var prevent = false;
@@ -939,6 +934,18 @@ function bindFileBrowserItemEvents() {
         }
 
         $(".selection-menu").hide();    // Hide other menus
+
+        // register a listener for clicks outside of the context menu
+        $(document).on('click.menu', function(event) {
+            var $target = $(event.target);
+            console.log(this);
+            if(!$target.closest('#right-click-menu').length && 
+                $('#right-click-menu').css("display") !== "none") {
+                $('#right-click-menu').hide();
+            }
+            // de-register listener to allow bubbling
+            $(document).off('click.menu');
+        });
 
         var top = event.pageY;
         var left = event.pageX;


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [X] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Right click a file or files in the content browser
2. Left click outside the content browser
3. Observe the right click context menu goes away


Resolves #4140

___
<img width="1237" alt="context" src="https://user-images.githubusercontent.com/17934193/155602036-13eae813-208b-49a4-bbd9-d13ff03192ac.png">

