### PR TITLE
fix actions in "who has access" table

### DIFF
--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -2069,6 +2069,11 @@ table.user-scope tr {
     display: table-row !important;
 }
 
+.access-table tbody > tr.is-group {
+    background-color: #093e541f;
+}
+
+
 #templateRow {
 	display:none !important;
 }

--- a/theme/templates/includes/access-row.html
+++ b/theme/templates/includes/access-row.html
@@ -1,7 +1,7 @@
 {% load hydroshare_tags %}
 
 <tr v-for="(user, index) in this.users" v-bind:key="user.id"
-    :class="{ 'hide-actions': selfAccessLevel !== 'owner' && (user.access === 'owner' && hasOnlyOneOwner || user.user_type === 'user' && user.id === quotaHolder.id), loading: user.loading}">
+    :class="{ 'hide-actions': selfAccessLevel !== 'owner' && (user.access === 'owner' && hasOnlyOneOwner || user.user_type === 'user' && user.id === quotaHolder.id), 'loading': user.loading, 'is-group': user.user_type === 'group'}">
     <td>
         <table class="user-scope">
             <tr v-if="user.user_type === 'user'">
@@ -72,7 +72,7 @@
 
     <td class="user-actions">
         <i @click="undoAccess(user, index)"
-           v-if="user.can_undo && quotaHolder.id !== user.id"
+           v-if="user.can_undo && (user.user_type==='group' || (user.user_type === 'user' && quotaHolder.id !== user.id))"
             {# TODO: manually initialize tooltips of dynamically created items #}
            class="fa fa-undo" aria-hidden="true" data-toggle="tooltip"
            title="Undo Share"></i>
@@ -80,7 +80,7 @@
 
     <td class="user-actions">
         <span @click="user.id === currentUser ? showDeleteSelfDialog(user, index) : removeAccess(user, index)"
-              v-if="!(user.access === 'owner' && hasOnlyOneOwner) && user.id !== quotaHolder.id && (selfAccessLevel === 'owner' || user.id === currentUser)"
+              v-if="!(user.access === 'owner' && hasOnlyOneOwner) && !(user.user_type === 'user' && user.id == quotaHolder.id) && (selfAccessLevel === 'owner' || user.id === currentUser)"
               :id="'form-remove-' + user.user_type + '-' + user.id"
               class="glyphicon glyphicon-remove btn-remove-row"
               data-toggle="tooltip" title="Remove">


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [X] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Manage who has access on a resource that you own
2. "Give Access" to a different user and a different group. Importantly, the user id must match the group id. To ensure this, I checked the "auth_user" and "auth_user_groups" tables in the db. You could of course python model query or use browser console and USERS_JSON to find a set of group+user whose ids match.
3. After adding the user and group, you will notice that the "undo share" and "remove" actions are still available (whereas before this PR, they were missing).

Resolves #3534

***
BEFORE:
![63315526-ccfea900-c2c8-11e9-983a-a4a423038618](https://user-images.githubusercontent.com/17934193/156644740-ba74b1d4-d780-451f-9901-89827d4a5829.png)

![Screen Shot 2022-03-03 at 3 05 53 PM](https://user-images.githubusercontent.com/17934193/156644654-b02f2c44-20fd-4c68-8ec5-82308e52f09c.png)

***

AFTER:
![Screen Shot 2022-03-03 at 3 08 11 PM](https://user-images.githubusercontent.com/17934193/156644672-45993dfa-feb7-41fd-8377-0f71a4bcbf89.png)

