### PR TITLE
4541 Fix for private resource access authorization

### DIFF
--- a/hs_access_control/models/user.py
+++ b/hs_access_control/models/user.py
@@ -1412,7 +1412,7 @@ class UserAccess(models.Model):
 
         Note that:
 
-        * One can view resources that are public, that one does not own.
+        * One can view resources that are public or have private link sharing enabled, that one does not own.
         * Thus, this returns True for many public resources that are not returned from
           view_resources.
         * This is not sensitive to the setting for the "immutable" flag. That only affects editing.
@@ -1422,12 +1422,15 @@ class UserAccess(models.Model):
         if __debug__:  # during testing only, check argument types and preconditions
             assert isinstance(this_resource, BaseResource)
 
+        access_resource = this_resource.raccess
+
+        if access_resource.public or access_resource.allow_private_sharing:
+            return True
+
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
 
-        access_resource = this_resource.raccess
-
-        if access_resource.public or self.user.is_superuser:
+        if self.user.is_superuser:
             return True
 
         if self.view_resources.filter(id=this_resource.id).exists():

--- a/hs_core/page_processors.py
+++ b/hs_core/page_processors.py
@@ -102,13 +102,9 @@ def get_page_context(page, user, resource_edit=False, extended_metadata_layout=N
             del request.session['just_published']
 
     bag_url = content_model.bag_url
-
-    if user.is_authenticated():
+    show_content_files = content_model.raccess.public or content_model.raccess.allow_private_sharing
+    if not show_content_files and user.is_authenticated():
         show_content_files = user.uaccess.can_view_resource(content_model)
-    else:
-        # if anonymous user getting access to a private resource (since resource is discoverable),
-        # then don't show content files unless private link sharing is enabled
-        show_content_files = content_model.raccess.public or content_model.raccess.allow_private_sharing
 
     rights_allow_copy = rights_allows_copy(content_model, user)
 

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -378,7 +378,9 @@ def authorize(request, res_id, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOUR
         raise NotFound(detail="No resource was found for resource id:%s" % res_id)
 
     if needed_permission == ACTION_TO_AUTHORIZE.VIEW_METADATA:
-        if res.raccess.discoverable or res.raccess.public or res.raccess.allow_private_sharing:
+        if res.raccess.discoverable or res.raccess.public:
+            authorized = True
+        elif not user.is_authenticated() and res.raccess.allow_private_sharing:
             authorized = True
         elif user.is_authenticated() and user.is_active:
             authorized = user.uaccess.can_view_resource(res)
@@ -396,7 +398,7 @@ def authorize(request, res_id, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOUR
         elif needed_permission == ACTION_TO_AUTHORIZE.VIEW_RESOURCE_ACCESS:
             authorized = user.uaccess.can_view_resource(res)
         elif needed_permission == ACTION_TO_AUTHORIZE.EDIT_RESOURCE_ACCESS:
-            authorized = user.uaccess.can_share_resource(res, 2)
+            authorized = user.uaccess.can_share_resource(res, PrivilegeCodes.CHANGE)
     elif needed_permission == ACTION_TO_AUTHORIZE.VIEW_RESOURCE:
         authorized = res.raccess.public or res.raccess.allow_private_sharing
 

--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -378,9 +378,7 @@ def authorize(request, res_id, needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOUR
         raise NotFound(detail="No resource was found for resource id:%s" % res_id)
 
     if needed_permission == ACTION_TO_AUTHORIZE.VIEW_METADATA:
-        if res.raccess.discoverable or res.raccess.public:
-            authorized = True
-        elif not user.is_authenticated() and res.raccess.allow_private_sharing:
+        if res.raccess.discoverable or res.raccess.public or res.raccess.allow_private_sharing:
             authorized = True
         elif user.is_authenticated() and user.is_active:
             authorized = user.uaccess.can_view_resource(res)


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource. Upload a file to the resource. Enable private link sharing using the Manage Access panel. Make sure the resource status is private. Copy the url of the resource.
2. Create a new user account
3. Use another browser
    3.1 Login to hydroshare as the user account you created in step 2.
    3.2 Paste the url of the resource in the browser for the hydroshare site.
    3.3 You should see the landing page for the resource in view mode only. The resource file should be listed. 
