### PR TITLE
responsive breakpoints for app tiles

### DIFF
--- a/hs_core/templates/pages/apps.html
+++ b/hs_core/templates/pages/apps.html
@@ -26,7 +26,7 @@
   <div class="container apps-container">
     <div class="row">
       {% for resource in webapp_resources %}
-        <div class="webapp col-lg-3 col-md-4 col-sm-12">
+        <div class="webapp col-lg-3 col-md-4 col-sm-6 col-xs-12">
           <div class="webapp-listing">
             <a class="webapp-link"
                href="{{resource.metadata.app_home_page_url.value}}"

--- a/hs_core/templates/pages/apps.html
+++ b/hs_core/templates/pages/apps.html
@@ -24,33 +24,31 @@
   </div>
 
   <div class="container apps-container">
-    <div class="row">
-      {% for resource in webapp_resources %}
-        <div class="webapp col-lg-3 col-md-4 col-sm-6 col-xs-12">
-          <div class="webapp-listing">
-            <a class="webapp-link"
-               href="{{resource.metadata.app_home_page_url.value}}"
-               target="_blank" title="Open {{ resource.title }} in new tab">
-                {% if resource.metadata.app_icon.data_url %}
-                    <img src="{{ resource.metadata.app_icon.data_url }}" alt="" />
-                {% else %}
-                    <img src="/static/img/web-app-default-icon.png" alt="" />
-                {% endif %}
-              <h3>
-                {{ resource.title }}
-              </h3>
-            </a>
-            <p class="app-description">
-              {{ resource.metadata.description|truncatewords:35 }}
-              <br /><br />
-              <a href="/resource/{{ resource.short_id }}">View Resource Page</a>
-            </p>
+    {% for resource in webapp_resources %}
+      <div class="webapp">
+        <div class="webapp-listing">
+          <a class="webapp-link"
+              href="{{resource.metadata.app_home_page_url.value}}"
+              target="_blank" title="Open {{ resource.title }} in new tab">
+              {% if resource.metadata.app_icon.data_url %}
+                  <img src="{{ resource.metadata.app_icon.data_url }}" alt="" />
+              {% else %}
+                  <img src="/static/img/web-app-default-icon.png" alt="" />
+              {% endif %}
+            <h3>
+              {{ resource.title }}
+            </h3>
+          </a>
+          <p class="app-description">
+            {{ resource.metadata.description|truncatewords:35 }}
+            <br /><br />
+            <a href="/resource/{{ resource.short_id }}">View Resource Page</a>
+          </p>
 
-            <a href="#" class="app-info-toggle">i</a>
-          </div>
+          <a href="#" class="app-info-toggle">i</a>
         </div>
-      {% endfor %}
-    </div>
+      </div>
+    {% endfor %}
   </div>
 {% endblock %}
 

--- a/theme/static/css/apps_page.css
+++ b/theme/static/css/apps_page.css
@@ -3,6 +3,9 @@
   border-bottom: 1px solid #cdcdcd;
   background: #efefef;
   margin-bottom: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); 
+  gap: 1rem;
 }
 
 .webapp-listing {


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
Resolves #4559

### Pull Request Checklist: 
- [X] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Navigate to the Apps Library (if on dev machine, make sure to type `[hostname]/apps/ ` in the URL because clicking on "apps" navigation will take you to production www.hydroshare.org)
2. Reduce your screen width to between 768px-1000px
3. There are now 2 columns of apps instead of 1

***
### SCREENSHOTS
#### Before
![image](https://user-images.githubusercontent.com/17934193/161057292-53edd586-4c05-4afd-8ef6-3354c4a94130.png)

#### After
![Screen Shot 2022-03-31 at 8 29 14 AM](https://user-images.githubusercontent.com/17934193/161057330-caa395eb-44b2-462f-b657-689dc7eb3d63.png)
