### PR TITLE
group-containers bootstrap breakpoint

### DIFF
--- a/hs_communities/templates/hs_communities/find-communities.html
+++ b/hs_communities/templates/hs_communities/find-communities.html
@@ -43,12 +43,12 @@
             </div>
         </div>
 
-        <div class="row group-thumbnails">
+        <div class="group-thumbnails">
             {% if not communities_list %}
                 <div class="col-sm-12"><i>No communities have been created yet.</i></div>
             {% endif %}
                 {% for c in communities_list %}
-                        <div class="col-xs-12 col-sm-6 col-md-4 group-container">
+                        <div class="group-container">
                             <div class="group-thumbnail contribution">
                                 {% if group.gaccess.picture and group.gaccess.picture.url %}
                                     <div class="group-preview-image"

--- a/hs_communities/templates/hs_communities/find-communities.html
+++ b/hs_communities/templates/hs_communities/find-communities.html
@@ -48,7 +48,7 @@
                 <div class="col-sm-12"><i>No communities have been created yet.</i></div>
             {% endif %}
                 {% for c in communities_list %}
-                        <div class="col-sm-6 col-md-4 group-container">
+                        <div class="col-xs-12 col-sm-6 col-md-4 group-container">
                             <div class="group-thumbnail contribution">
                                 {% if group.gaccess.picture and group.gaccess.picture.url %}
                                     <div class="group-preview-image"

--- a/hs_core/templates/pages/groups-authenticated.html
+++ b/hs_core/templates/pages/groups-authenticated.html
@@ -35,7 +35,7 @@
             {% if groups %}
             {% for group in groups %}
                 {% if group.gaccess.public or group.gaccess.discoverable or group.is_user_member %}
-                    <div class="col-sm-6 col-md-4 group-container">
+                    <div class="col-xs-12 col-sm-6 col-md-4 group-container">
                         <div class="group-thumbnail contribution">
                             {% if group.gaccess.picture and group.gaccess.picture.url %}
                                 <div class="group-preview-image" style="background-image: url({{ group.gaccess.picture.url }})"></div>

--- a/hs_core/templates/pages/groups-authenticated.html
+++ b/hs_core/templates/pages/groups-authenticated.html
@@ -31,11 +31,11 @@
             </div>
         </div>
 
-        <div class="row group-thumbnails">
+        <div class="group-thumbnails">
             {% if groups %}
             {% for group in groups %}
                 {% if group.gaccess.public or group.gaccess.discoverable or group.is_user_member %}
-                    <div class="col-xs-12 col-sm-6 col-md-4 group-container">
+                    <div class="group-container">
                         <div class="group-thumbnail contribution">
                             {% if group.gaccess.picture and group.gaccess.picture.url %}
                                 <div class="group-preview-image" style="background-image: url({{ group.gaccess.picture.url }})"></div>

--- a/hs_core/templates/pages/groups-unauthenticated.html
+++ b/hs_core/templates/pages/groups-unauthenticated.html
@@ -30,11 +30,11 @@
                 <p id="id-Group-Search-Result-Msg"></p>
             </div>
         </div>
-        <div class="row group-thumbnails">
+        <div class="group-thumbnails">
             {% if groups %}
                 {% for group in groups %}
                     {% if group.gaccess.public or group.gaccess.discoverable %}
-                        <div class="col-xs-12 col-sm-6 col-md-4 group-container">
+                        <div class="group-container">
                             <div class="group-thumbnail contribution">
                                 {% if group.gaccess.picture and group.gaccess.picture.url %}
                                     <div class="group-preview-image"

--- a/hs_core/templates/pages/groups-unauthenticated.html
+++ b/hs_core/templates/pages/groups-unauthenticated.html
@@ -34,7 +34,7 @@
             {% if groups %}
                 {% for group in groups %}
                     {% if group.gaccess.public or group.gaccess.discoverable %}
-                        <div class="col-sm-6 col-md-4 group-container">
+                        <div class="col-xs-12 col-sm-6 col-md-4 group-container">
                             <div class="group-thumbnail contribution">
                                 {% if group.gaccess.picture and group.gaccess.picture.url %}
                                     <div class="group-preview-image"

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3663,10 +3663,8 @@ input.no-style {
 }
 
 div.group-thumbnails {
-	display: flex;
-	flex-wrap: wrap;
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(min(33.3rem, 100%), 1fr)); 
+	grid-template-columns: repeat(auto-fill, minmax(33.3rem, 1fr));
 	gap: 1rem;
 }
 

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3666,6 +3666,7 @@ div.group-thumbnails {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(33.3rem, 1fr));
 	gap: 1rem;
+	flex-grow: 1
 }
 
 .group-container {

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3665,12 +3665,19 @@ input.no-style {
 div.group-thumbnails {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(33.3rem, 1fr));
+
+	/* I think we might want my originally proposed solution here? */
+	/* grid-template-columns: repeat(auto-fill, minmax(min(33.3rem, 100%), 1fr)); */
+
 	gap: 1rem;
-	flex-grow: 1
 }
 
 .group-container {
     margin-bottom: 20px;
+
+	/* I'm pretty sure this property doesn't have any effect because these child elements aren't in a flexbox*/
+	/* .group-thumbnails doesn't have display: flex, so these .group-container children can't have "flex-" properties */
+	flex-grow: 1
 }
 
 .group-thumbnail img {

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3665,19 +3665,12 @@ input.no-style {
 div.group-thumbnails {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(33.3rem, 1fr));
-
-	/* I think we might want my originally proposed solution here? */
-	/* grid-template-columns: repeat(auto-fill, minmax(min(33.3rem, 100%), 1fr)); */
-
 	gap: 1rem;
+	flex-grow: 1
 }
 
 .group-container {
     margin-bottom: 20px;
-
-	/* I'm pretty sure this property doesn't have any effect because these child elements aren't in a flexbox*/
-	/* .group-thumbnails doesn't have display: flex, so these .group-container children can't have "flex-" properties */
-	flex-grow: 1
 }
 
 .group-thumbnail img {

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3665,6 +3665,9 @@ input.no-style {
 div.group-thumbnails {
 	display: flex;
 	flex-wrap: wrap;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(min(33.3rem, 100%), 1fr)); 
+	gap: 1rem;
 }
 
 .group-container {

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3666,7 +3666,6 @@ div.group-thumbnails {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(33.3rem, 1fr));
 	gap: 1rem;
-	flex-grow: 1
 }
 
 .group-container {

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3664,7 +3664,7 @@ input.no-style {
 
 div.group-thumbnails {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(33.3rem, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(min(33.3rem, 100%), 1fr));
 	gap: 1rem;
 }
 


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
Resolves #4552 

### Pull Request Checklist: 
- [X] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Navigate to Communities (if on dev machine, make sure to type [hostname]/communities/ in the URL because "Collaborate"->"Communities" navigation will take you to production [www.hydroshare.org](http://www.hydroshare.org/))
2. Reduce your screen width to between 768px-1000px
3. Community containers are now a consistent width
4. Same is true for Group containers

***
### Screenshots
#### Before:
![Screen Shot 2022-03-31 at 9 00 29 AM](https://user-images.githubusercontent.com/17934193/161060742-a6734cdf-42de-4ec3-b279-db6edefe2616.png)

#### After:
![Screen Shot 2022-03-31 at 9 01 00 AM](https://user-images.githubusercontent.com/17934193/161060783-a5dabc47-ed14-4423-bf60-f88b97cb25fa.png)

