### PR TITLE
2280 Fix for resource listing by coverage

### DIFF
--- a/hs_core/tests/api/rest/test_resource_list.py
+++ b/hs_core/tests/api/rest/test_resource_list.py
@@ -172,8 +172,10 @@ class TestResourceList(HSRESTTestCase):
         comp_res_one = resource.create_resource('CompositeResource', self.user, 'Resource 1',
                                                 metadata=metadata_dict_one)
 
-        # creating GenericFileMeteData objects now so that when we create a generic aggregation
-        # it's GenericFileMetaData object will have the same id as the id of the resource metadata object
+        # creating and deleting GenericFileMeteData objects now so that when we create a generic aggregation in resource
+        # (comp_res_with_aggregation) its GenericFileMetaData object will have the same id as the id of the
+        # resource (comp_res_one) metadata object so we can test that we are not using aggregation level
+        # coverage for filtering resource
         if comp_res_one.metadata.id > 1:
             for _ in range(comp_res_one.metadata.id - 1):
                 GenericFileMetaData.objects.create()


### PR DESCRIPTION

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create 3 or more composite resources. Add coverage metadata to all resources except one. 
2. Use the following REST endpoint format in the browser (in another tab) to list resources by coverage (change the value for query parameters for coverage bounding box (north, south, east, and west) as necessary:
`http://localhost:8000/hsapi/resource/?resource_type=CompositeResource&coverage_type=box&north=41.8671&south=41.8639&east=-111.5059&west=-111.5114`
4. Verify that the resource with no coverage is not listed when you use the above endpoint. 

