### PR TITLE
less whitespace for groups without members [#4590]

### DIFF
--- a/hs_communities/templates/hs_communities/find-communities.html
+++ b/hs_communities/templates/hs_communities/find-communities.html
@@ -61,7 +61,7 @@
                                     <h3 class="group-name">
                                         <a href="/community/{{ c.id }}">{{ c.name }}</a>
                                     </h3>
-                                    <div class="group-purpose" style="overflow-y: auto">
+                                    <div class="group-purpose">
                                         <p>{{ group.gaccess.purpose|linebreaks }}</p>
                                     </div>
                                     <div class="group-description"><p>{{ group.gaccess.description|linebreaks }}</p>
@@ -69,89 +69,91 @@
 
                                     <div class="text-center group-thumbnail-footer">
                                         {% if group.gaccess.public %}
-                                            <div class="users-joined height-fix">
-                                                <div class="link-members"><a class="text-muted" href="#"
-                                                                             data-toggle="modal"
-                                                                             data-target="#modal-members-list-{{ group.id }}">MEMBERS</a>
+                                            {% if group.gaccess.members|length > 0 %}
+                                                <div class="users-joined height-fix">
+                                                    <div class="link-members"><a class="text-muted" href="#"
+                                                                                data-toggle="modal"
+                                                                                data-target="#modal-members-list-{{ group.id }}">MEMBERS</a>
+                                                    </div>
+                                                    {% for member in group.gaccess.members|slice:":5" %}
+                                                        {% if  member.userprofile.picture and member.userprofile.picture.url %}
+                                                            <div style="background-image: url('{{ member.userprofile.picture.url }}');"
+                                                                class="round-image profile-pic-thumbnail"
+                                                                title="{{ member|best_name }}">
+                                                            </div>
+                                                        {% else %}
+                                                            <div class="profile-pic-thumbnail-small round-image"
+                                                                title="{{ member|best_name }}">
+
+                                                            </div>
+                                                        {% endif %}
+                                                    {% endfor %}
                                                 </div>
-                                                {% for member in group.gaccess.members|slice:":5" %}
-                                                    {% if  member.userprofile.picture and member.userprofile.picture.url %}
-                                                        <div style="background-image: url('{{ member.userprofile.picture.url }}');"
-                                                             class="round-image profile-pic-thumbnail"
-                                                             title="{{ member|best_name }}">
-                                                        </div>
-                                                    {% else %}
-                                                        <div class="profile-pic-thumbnail-small round-image"
-                                                             title="{{ member|best_name }}">
+                                                {% if group.gaccess.members|length > 5 %}
+                                                    <div>
+                                                        <small class="text-muted">
+                                                            and {{ group.gaccess.members|length|add:"-5" }} others have
+                                                            joined
+                                                        </small>
+                                                    </div>
+                                                {% endif %}
+
+                                                <!-- Members List Modal -->
+                                                <div class="modal fade members-modal" id="modal-members-list-{{ group.id }}"
+                                                    tabindex="-1" role="dialog"
+                                                    aria-labelledby="Invite">
+                                                    <div class="modal-dialog" role="document">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header">
+                                                                <button type="button" class="close" data-dismiss="modal"
+                                                                        aria-label="Close"><span
+                                                                        aria-hidden="true">&times;</span>
+                                                                </button>
+                                                                <h4 class="modal-title">Members</h4>
+                                                            </div>
+
+                                                            <div class="modal-body">
+                                                                <table class="table access-table members-table"
+                                                                    style="text-align: left;">
+                                                                    <tbody>
+                                                                    {% for u in group.gaccess.members %}
+                                                                        <tr id="row-id-{{ u.pk }}"
+                                                                            {% if owners|length == 1 or not self_access_level == 'owner' %}class="hide-actions"{% endif %}>
+                                                                            <td>
+                                                                                <div class="user-scope">
+                                                                                    {% if u.userprofile.picture %}
+                                                                                        <div style="background-image: url('{{ u.userprofile.picture.url }}');"
+                                                                                            class="profile-pic-thumbnail round-image"></div>
+                                                                                    {% else %}
+                                                                                        <div class="profile-pic-thumbnail round-image user-icon"></div>
+                                                                                    {% endif %}
+
+                                                                                    <a data-col="name"
+                                                                                    class="user-name">{{ u|contact }}</a>
+                                                                                    {% if u.pk == current_user.pk %}
+                                                                                        <span class="text-muted you-flag">(You)</span>
+                                                                                    {% endif %}
+                                                                                    <br>
+                                                                                    <span data-col="user-name"
+                                                                                        class="user-username-content">{{ u.username }}</span>
+                                                                                </div>
+                                                                            </td>
+                                                                        </tr>
+                                                                    {% endfor %}
+                                                                    </tbody>
+                                                                </table>
+                                                            </div>
+
+                                                            <div class="modal-footer">
+                                                                <button type="button" class="btn btn-default"
+                                                                        data-dismiss="modal">Close
+                                                                </button>
+                                                            </div>
 
                                                         </div>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </div>
-                                            {% if group.gaccess.members|length > 5 %}
-                                                <div>
-                                                    <small class="text-muted">
-                                                        and {{ group.gaccess.members|length|add:"-5" }} others have
-                                                        joined
-                                                    </small>
-                                                </div>
-                                            {% endif %}
-
-                                            <!-- Members List Modal -->
-                                            <div class="modal fade members-modal" id="modal-members-list-{{ group.id }}"
-                                                 tabindex="-1" role="dialog"
-                                                 aria-labelledby="Invite">
-                                                <div class="modal-dialog" role="document">
-                                                    <div class="modal-content">
-                                                        <div class="modal-header">
-                                                            <button type="button" class="close" data-dismiss="modal"
-                                                                    aria-label="Close"><span
-                                                                    aria-hidden="true">&times;</span>
-                                                            </button>
-                                                            <h4 class="modal-title">Members</h4>
-                                                        </div>
-
-                                                        <div class="modal-body">
-                                                            <table class="table access-table members-table"
-                                                                   style="text-align: left;">
-                                                                <tbody>
-                                                                {% for u in group.gaccess.members %}
-                                                                    <tr id="row-id-{{ u.pk }}"
-                                                                        {% if owners|length == 1 or not self_access_level == 'owner' %}class="hide-actions"{% endif %}>
-                                                                        <td>
-                                                                            <div class="user-scope">
-                                                                                {% if u.userprofile.picture %}
-                                                                                    <div style="background-image: url('{{ u.userprofile.picture.url }}');"
-                                                                                         class="profile-pic-thumbnail round-image"></div>
-                                                                                {% else %}
-                                                                                    <div class="profile-pic-thumbnail round-image user-icon"></div>
-                                                                                {% endif %}
-
-                                                                                <a data-col="name"
-                                                                                   class="user-name">{{ u|contact }}</a>
-                                                                                {% if u.pk == current_user.pk %}
-                                                                                    <span class="text-muted you-flag">(You)</span>
-                                                                                {% endif %}
-                                                                                <br>
-                                                                                <span data-col="user-name"
-                                                                                      class="user-username-content">{{ u.username }}</span>
-                                                                            </div>
-                                                                        </td>
-                                                                    </tr>
-                                                                {% endfor %}
-                                                                </tbody>
-                                                            </table>
-                                                        </div>
-
-                                                        <div class="modal-footer">
-                                                            <button type="button" class="btn btn-default"
-                                                                    data-dismiss="modal">Close
-                                                            </button>
-                                                        </div>
-
                                                     </div>
                                                 </div>
-                                            </div>
+                                            {% endif %}
                                         {% endif %}
 
                                         <br>

--- a/hs_core/templates/pages/groups-authenticated.html
+++ b/hs_core/templates/pages/groups-authenticated.html
@@ -44,7 +44,7 @@
                             {% endif %}
                             <div class="group-caption">
                                 <h3 class="group-name"><a href="/group/{{ group.id }}">{{ group.name }}</a></h3>
-                                <div class="group-purpose" style="overflow-y: auto">
+                                <div class="group-purpose">
                                     <p>{{ group.gaccess.purpose|linebreaks}}</p>
                                 </div>
                                 <div class="group-description"><p>{{ group.gaccess.description|linebreaks }}</p></div>
@@ -53,78 +53,80 @@
 
                                 <div class="text-center group-thumbnail-footer">
                                     {% if group.gaccess.public %}
-                                        <div class="users-joined height-fix">
-                                            <div class="link-members"><a class="text-muted" href="#" data-toggle="modal" data-target="#modal-members-list-{{ group.id }}">MEMBERS</a></div>
-                                            {% for member in group.gaccess.members|slice:":5" %}
-                                                {% if  member.userprofile.picture and member.userprofile.picture.url %}
-                                                    <div style="background-image: url('{{ member.userprofile.picture.url }}');"
-                                                         class="round-image profile-pic-thumbnail"
-                                                         title="{{ member|best_name }}">
-                                                    </div>
-                                                {% else %}
-                                                    <div class="profile-pic-thumbnail-small round-image"
-                                                         title="{{ member|best_name }}"></div>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </div>
-                                        {% if group.gaccess.members|length > 5 %}
-                                            <div>
-                                                <small class="text-muted">and {{ group.gaccess.members|length|add:"-5" }} others have joined</small>
+                                        {% if group.gaccess.members|length > 0 %}
+                                            <div class="users-joined height-fix">
+                                                <div class="link-members"><a class="text-muted" href="#" data-toggle="modal" data-target="#modal-members-list-{{ group.id }}">MEMBERS</a></div>
+                                                {% for member in group.gaccess.members|slice:":5" %}
+                                                    {% if  member.userprofile.picture and member.userprofile.picture.url %}
+                                                        <div style="background-image: url('{{ member.userprofile.picture.url }}');"
+                                                            class="round-image profile-pic-thumbnail"
+                                                            title="{{ member|best_name }}">
+                                                        </div>
+                                                    {% else %}
+                                                        <div class="profile-pic-thumbnail-small round-image"
+                                                            title="{{ member|best_name }}"></div>
+                                                    {% endif %}
+                                                {% endfor %}
                                             </div>
-                                        {% endif %}
+                                            {% if group.gaccess.members|length > 5 %}
+                                                <div>
+                                                    <small class="text-muted">and {{ group.gaccess.members|length|add:"-5" }} others have joined</small>
+                                                </div>
+                                            {% endif %}
 
-                                        <!-- Members List Modal -->
-                                        <div class="modal fade members-modal" id="modal-members-list-{{ group.id }}" tabindex="-1" role="dialog"
-                                             aria-labelledby="Invite">
-                                            <div class="modal-dialog" role="document">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <button type="button" class="close" data-dismiss="modal"
-                                                                aria-label="Close"><span aria-hidden="true">&times;</span>
-                                                        </button>
-                                                        <h4 class="modal-title">Members</h4>
+                                            <!-- Members List Modal -->
+                                            <div class="modal fade members-modal" id="modal-members-list-{{ group.id }}" tabindex="-1" role="dialog"
+                                                aria-labelledby="Invite">
+                                                <div class="modal-dialog" role="document">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                            <button type="button" class="close" data-dismiss="modal"
+                                                                    aria-label="Close"><span aria-hidden="true">&times;</span>
+                                                            </button>
+                                                            <h4 class="modal-title">Members</h4>
+                                                        </div>
+
+                                                        <div class="modal-body">
+                                                            <table class="table access-table members-table"
+                                                                style="text-align: left;">
+                                                                <tbody>
+                                                                {% for u in group.gaccess.members %}
+                                                                    <tr id="row-id-{{ u.pk }}"
+                                                                        {% if owners|length == 1 or not self_access_level == 'owner' %}class="hide-actions"{% endif %}>
+                                                                        <td>
+                                                                            <div class="user-scope">
+                                                                                {% if u.userprofile.picture %}
+                                                                                    <div style="background-image: url('{{ u.userprofile.picture.url }}');"
+                                                                                        class="profile-pic-thumbnail round-image"></div>
+                                                                                {% else %}
+                                                                                    <div class="profile-pic-thumbnail round-image user-icon"></div>
+                                                                                {% endif %}
+
+                                                                                <a data-col="name"
+                                                                                class="user-name">{{ u|contact }}</a>
+                                                                                {% if u.pk == current_user.pk %}
+                                                                                    <span class="text-muted you-flag">(You)</span>
+                                                                                {% endif %}
+                                                                                <br>
+                                                                                <span data-col="user-name" class="user-username-content">{{ u.username }}</span>
+                                                                            </div>
+                                                                        </td>
+                                                                    </tr>
+                                                                {% endfor %}
+                                                                </tbody>
+                                                            </table>
+                                                        </div>
+
+                                                        <div class="modal-footer">
+                                                            <button type="button" class="btn btn-default"
+                                                                    data-dismiss="modal">Close
+                                                            </button>
+                                                        </div>
+
                                                     </div>
-
-                                                    <div class="modal-body">
-                                                        <table class="table access-table members-table"
-                                                               style="text-align: left;">
-                                                            <tbody>
-                                                            {% for u in group.gaccess.members %}
-                                                                <tr id="row-id-{{ u.pk }}"
-                                                                    {% if owners|length == 1 or not self_access_level == 'owner' %}class="hide-actions"{% endif %}>
-                                                                    <td>
-                                                                        <div class="user-scope">
-                                                                            {% if u.userprofile.picture %}
-                                                                                <div style="background-image: url('{{ u.userprofile.picture.url }}');"
-                                                                                     class="profile-pic-thumbnail round-image"></div>
-                                                                            {% else %}
-                                                                                <div class="profile-pic-thumbnail round-image user-icon"></div>
-                                                                            {% endif %}
-
-                                                                            <a data-col="name"
-                                                                               class="user-name">{{ u|contact }}</a>
-                                                                            {% if u.pk == current_user.pk %}
-                                                                                <span class="text-muted you-flag">(You)</span>
-                                                                            {% endif %}
-                                                                            <br>
-                                                                            <span data-col="user-name" class="user-username-content">{{ u.username }}</span>
-                                                                        </div>
-                                                                    </td>
-                                                                </tr>
-                                                            {% endfor %}
-                                                            </tbody>
-                                                        </table>
-                                                    </div>
-
-                                                    <div class="modal-footer">
-                                                        <button type="button" class="btn btn-default"
-                                                                data-dismiss="modal">Close
-                                                        </button>
-                                                    </div>
-
                                                 </div>
                                             </div>
-                                        </div>
+                                        {% endif %}
                                     {% endif %}
 
                                     <br>

--- a/hs_core/templates/pages/groups-unauthenticated.html
+++ b/hs_core/templates/pages/groups-unauthenticated.html
@@ -45,7 +45,7 @@
                                 {% endif %}
                                 <div class="group-caption">
                                     <h3 class="group-name"><a href="/group/{{ group.id }}">{{ group.name }}</a></h3>
-                                    <div class="group-purpose" style="overflow-y: auto">
+                                    <div class="group-purpose">
                                         <p>{{ group.gaccess.purpose|linebreaks }}</p>
                                     </div>
                                     <div class="group-description"><p>{{ group.gaccess.description|linebreaks }}</p>
@@ -55,85 +55,87 @@
 
                                     <div class="text-center group-thumbnail-footer">
                                         {% if group.gaccess.public %}
-                                            <div class="users-joined height-fix">
-                                                <div class="link-members"><a class="text-muted" href="#"
-                                                                             data-toggle="modal"
-                                                                             data-target="#modal-members-list-{{ group.id }}">MEMBERS</a>
+                                            {% if group.gaccess.members|length > 0 %}
+                                                <div class="users-joined height-fix">
+                                                    <div class="link-members"><a class="text-muted" href="#"
+                                                                                data-toggle="modal"
+                                                                                data-target="#modal-members-list-{{ group.id }}">MEMBERS</a>
+                                                    </div>
+                                                    {% for member in group.gaccess.members|slice:":5" %}
+                                                        {% if  member.userprofile.picture and member.userprofile.picture.url %}
+                                                            <div style="background-image: url('{{ member.userprofile.picture.url }}');"
+                                                                class="round-image profile-pic-thumbnail"
+                                                                title="{{ member|best_name }}">
+                                                            </div>
+                                                        {% else %}
+                                                            <div class="profile-pic-thumbnail-small round-image"
+                                                                title="{{ member|best_name }}"></div>
+                                                        {% endif %}
+                                                    {% endfor %}
                                                 </div>
-                                                {% for member in group.gaccess.members|slice:":5" %}
-                                                    {% if  member.userprofile.picture and member.userprofile.picture.url %}
-                                                        <div style="background-image: url('{{ member.userprofile.picture.url }}');"
-                                                             class="round-image profile-pic-thumbnail"
-                                                             title="{{ member|best_name }}">
-                                                        </div>
-                                                    {% else %}
-                                                        <div class="profile-pic-thumbnail-small round-image"
-                                                             title="{{ member|best_name }}"></div>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </div>
-                                            {% if group.gaccess.members|length > 5 %}
-                                                <div>
-                                                    <small class="text-muted">
-                                                        and {{ group.gaccess.members|length|add:"-5" }} others have
-                                                        joined
-                                                    </small>
-                                                </div>
-                                            {% endif %}
+                                                {% if group.gaccess.members|length > 5 %}
+                                                    <div>
+                                                        <small class="text-muted">
+                                                            and {{ group.gaccess.members|length|add:"-5" }} others have
+                                                            joined
+                                                        </small>
+                                                    </div>
+                                                {% endif %}
 
-                                            <!-- Members List Modal -->
-                                            <div class="modal fade members-modal" id="modal-members-list-{{ group.id }}"
-                                                 tabindex="-1" role="dialog"
-                                                 aria-labelledby="Invite">
-                                                <div class="modal-dialog" role="document">
-                                                    <div class="modal-content">
-                                                        <div class="modal-header">
-                                                            <button type="button" class="close" data-dismiss="modal"
-                                                                    aria-label="Close"><span
-                                                                    aria-hidden="true">&times;</span>
-                                                            </button>
-                                                            <h4 class="modal-title">Members</h4>
-                                                        </div>
+                                                <!-- Members List Modal -->
+                                                <div class="modal fade members-modal" id="modal-members-list-{{ group.id }}"
+                                                    tabindex="-1" role="dialog"
+                                                    aria-labelledby="Invite">
+                                                    <div class="modal-dialog" role="document">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header">
+                                                                <button type="button" class="close" data-dismiss="modal"
+                                                                        aria-label="Close"><span
+                                                                        aria-hidden="true">&times;</span>
+                                                                </button>
+                                                                <h4 class="modal-title">Members</h4>
+                                                            </div>
 
-                                                        <div class="modal-body">
-                                                            <table class="table access-table members-table"
-                                                                   style="text-align: left;">
-                                                                <tbody>
-                                                                {% for u in group.gaccess.members %}
-                                                                    <tr id="row-id-{{ u.pk }}"
-                                                                        {% if owners|length == 1 or not self_access_level == 'owner' %}class="hide-actions"{% endif %}>
-                                                                        <td>
-                                                                            <div class="user-scope">
-                                                                                {% if u.userprofile.picture %}
-                                                                                    <div style="background-image: url('{{ u.userprofile.picture.url }}');"
-                                                                                         class="profile-pic-thumbnail round-image"></div>
-                                                                                {% else %}
-                                                                                    <div class="profile-pic-thumbnail round-image user-icon"></div>
-                                                                                {% endif %}
+                                                            <div class="modal-body">
+                                                                <table class="table access-table members-table"
+                                                                    style="text-align: left;">
+                                                                    <tbody>
+                                                                    {% for u in group.gaccess.members %}
+                                                                        <tr id="row-id-{{ u.pk }}"
+                                                                            {% if owners|length == 1 or not self_access_level == 'owner' %}class="hide-actions"{% endif %}>
+                                                                            <td>
+                                                                                <div class="user-scope">
+                                                                                    {% if u.userprofile.picture %}
+                                                                                        <div style="background-image: url('{{ u.userprofile.picture.url }}');"
+                                                                                            class="profile-pic-thumbnail round-image"></div>
+                                                                                    {% else %}
+                                                                                        <div class="profile-pic-thumbnail round-image user-icon"></div>
+                                                                                    {% endif %}
 
-                                                                                <a data-col="name"
-                                                                                   class="user-name">{{ u|contact }}</a>
-                                                                                {% if u.pk == current_user.pk %}
-                                                                                    <span class="text-muted you-flag">(You)</span>
-                                                                                {% endif %}
-                                                                                <br>
-                                                                                <span data-col="user-name"
-                                                                                      class="user-username-content">{{ u.username }}</span>
-                                                                            </div>
-                                                                        </td>
-                                                                    </tr>
-                                                                {% endfor %}
-                                                                </tbody>
-                                                            </table>
-                                                        </div>
-                                                        <div class="modal-footer">
-                                                            <button type="button" class="btn btn-default"
-                                                                    data-dismiss="modal">Close
-                                                            </button>
+                                                                                    <a data-col="name"
+                                                                                    class="user-name">{{ u|contact }}</a>
+                                                                                    {% if u.pk == current_user.pk %}
+                                                                                        <span class="text-muted you-flag">(You)</span>
+                                                                                    {% endif %}
+                                                                                    <br>
+                                                                                    <span data-col="user-name"
+                                                                                        class="user-username-content">{{ u.username }}</span>
+                                                                                </div>
+                                                                            </td>
+                                                                        </tr>
+                                                                    {% endfor %}
+                                                                    </tbody>
+                                                                </table>
+                                                            </div>
+                                                            <div class="modal-footer">
+                                                                <button type="button" class="btn btn-default"
+                                                                        data-dismiss="modal">Close
+                                                                </button>
+                                                            </div>
                                                         </div>
                                                     </div>
                                                 </div>
-                                            </div>
+                                            {% endif %}
                                         {% endif %}
                                         <br>
                                     </div>

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -3664,12 +3664,8 @@ input.no-style {
 
 div.group-thumbnails {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(min(33.3rem, 100%), 1fr));
-	gap: 1rem;
-}
-
-.group-container {
-    margin-bottom: 20px;
+	grid-template-columns: repeat(auto-fill, minmax(min(34rem, 100%), 1fr));
+	gap: 2rem;
 }
 
 .group-thumbnail img {
@@ -3685,7 +3681,7 @@ div.group-thumbnails {
 }
 
 .spacer {
-	flex: 1 1 auto;
+	flex: 1 2 auto;
 }
 
 .users-joined {
@@ -3694,9 +3690,13 @@ div.group-thumbnails {
 
 .group-description {
     margin-top:20px;
-	max-height:105px;
+	flex: 2 1 150px;
 	overflow-y: auto;
 	word-break: break-word;
+}
+
+.group-purpose {
+	overflow-y: auto;
 }
 
 .group-name {


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
Resolves #4590 

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. With a user you don't mind deactivating, create a new group
2. Add a long (>1000char) group description and make sure the group is PUBLIC
3. Deactivate the user account (using the profile -> deactivate)
4. navigate to `/groups`
5. See that the description can now flex-grow to take up more space since the "members" section is blank

NOTE: this PR also increases (just slightly) the `group-container` gap and the grid column width on the /groups page, so that the groups page more closely resembles the 3-columns that were used historically