### PR TITLE
[#4656] fixing wording in group related pages

### DIFF
--- a/hs_core/templates/pages/groups-authenticated.html
+++ b/hs_core/templates/pages/groups-authenticated.html
@@ -234,7 +234,7 @@
                             {# explanation #}
                             <fieldset class="col-sm-12">
                                 <input id="requires_explanation" type="checkbox"  name="requires_explanation">
-                                <label class="checkbox-label" for="requires_explanation">Require members to provide explanation when requesting membership</label>
+                                <label class="checkbox-label" for="requires_explanation">Require explanation when requesting membership</label>
                              </fieldset>
 
                             {# Picture #}

--- a/hs_core/templates/pages/my-groups.html
+++ b/hs_core/templates/pages/my-groups.html
@@ -254,7 +254,7 @@
                             {# explanation #}
                             <fieldset class="col-sm-12">
                                 <input id="requires_explanation" type="checkbox"  name="requires_explanation">
-                                <label class="checkbox-label" for="requires_explanation">Require members to provide explanation when requesting membership</label>
+                                <label class="checkbox-label" for="requires_explanation">Require explanation when requesting membership</label>
                              </fieldset>
 
                             {# Picture #}

--- a/theme/templates/pages/group.html
+++ b/theme/templates/pages/group.html
@@ -815,7 +815,7 @@
                                 <fieldset class="col-sm-12">
                                     <input id="requires_explanation" type="checkbox"  name="requires_explanation"
                                             {% if group.gaccess.requires_explanation %}checked{% endif %}>
-                                    <label class="checkbox-label" for="requires_explanation">Require members to provide explanation when requesting membership</label>
+                                    <label class="checkbox-label" for="requires_explanation">Require explanation when requesting membership</label>
                                 </fieldset>
 
                                 {# Picture #}


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a group. In the create group modal page, verify the text change as per the issue #4656 
2. Edit the group and verify the text change in the group edit modal page.

