### PR TITLE
[#4660] target self for APPS nav

### DIFF
--- a/theme/static/js/custom.js
+++ b/theme/static/js/custom.js
@@ -141,9 +141,6 @@ $(document).ready(function () {
         e.stopPropagation();
     });
 
-    // Make apps link open in new tab
-    $('a[href^="https://appsdev.hydroshare.org/apps"]').attr('target', '_blank');
-
 	// Close buttons for notification messages
 	$(".btn-close-message").click(function() {
 		$(this).parent().parent().parent().parent().hide(400);


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
Resolves #4660 

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
This is difficult to test until beta staging. The following **sed** command is run as part of deployment
```
sed -i s,\"https\:\/\/appsdev\.hydroshare\.org\/apps\",\"https\:\/\/www\.hydroshare\.org\/apps\",g theme/static/js/custom.js || exit 1
```
That is why "Apps" was opening a new tab in spite of the target seemingly being "_self":
https://github.com/hydroshare/hydroshare/blob/develop/theme/templates/includes/navbar.html#L294