### PR TITLE
[#4759] fix emply zip when nested directory name contains res_id

### DIFF
--- a/hs_core/views/utils.py
+++ b/hs_core/views/utils.py
@@ -1112,7 +1112,7 @@ def unzip_file(user, res_id, zip_with_rel_path, bool_remove_original,
         added_resource_files = []
         for file in res_files:
             destination_file = _get_destination_filename(file.name, unzipped_foldername)
-            destination_file = destination_file.replace(res_id + "/", "")
+            destination_file = destination_file.replace(res_id + "/", "", 1)
             destination_file = resource.get_irods_path(destination_file)
             res_file = link_irods_file_to_django(resource, destination_file)
             added_resource_files.append(res_file)


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case

1. Create new resource
2. Add a file
3. Download as zipped bagit
4. Upload the zip that you just downloaded back into the resource
5. Unzip in place withing the File browser
6. The directory created now contains the original files


Fixes #4759 
