### PR TITLE
[#4770] group invitation without explanation

### DIFF
--- a/hs_access_control/models/user.py
+++ b/hs_access_control/models/user.py
@@ -114,14 +114,14 @@ class UserAccess(models.Model):
         elif this_group.gaccess.members.filter(id=this_user.id).exists():
             raise PermissionDenied("User is already a member of this group")
 
-        if this_group.gaccess.requires_explanation:
-            if not explanation:
-                raise PermissionDenied("This group requires an explanation for requests")
-            elif len(explanation) > 300:
-                raise PermissionDenied("Explanation too long. Shorten to 300 characters")
-
         # user (self) requesting to join a group
         if this_user is None:
+            if this_group.gaccess.requires_explanation:
+                if not explanation:
+                    raise PermissionDenied("This group requires an explanation for requests")
+                elif len(explanation) > 300:
+                    raise PermissionDenied("Explanation too long. Shorten to 300 characters")
+
             # check if the user already has made a request to join this_group
             if GroupMembershipRequest.objects.filter(request_from=self.user,
                                                      group_to_join=this_group,

--- a/hs_access_control/tests/test_group_membership_request.py
+++ b/hs_access_control/tests/test_group_membership_request.py
@@ -446,6 +446,42 @@ class GroupMembershipRequest(MockIRODSTestCaseMixin, TestCase):
         self.assertEqual(
             self.modeling_group.gaccess.group_membership_requests.count(), 0)
 
+    def test_user_sending_invitation_without_explanation(self):
+        # require explanation on the group
+        self.modeling_group.gaccess.requires_explanation = True
+
+        # lisa should should not be one of the members
+        self.assertNotIn(
+            self.lisa_group_member,
+            self.modeling_group.gaccess.members)
+
+        # let john (group owner) invite lisa to join group without explanation
+        membership_request = self.john_group_owner.uaccess.create_group_membership_request(
+            self.modeling_group, self.lisa_group_member)
+
+        # modeling group should have 1 pending membership request
+        self.assertEqual(
+            self.modeling_group.gaccess.group_membership_requests.count(), 1)
+
+        # user lisa should have 1 request to join group
+        self.assertEqual(
+            self.lisa_group_member.uaccess.group_membership_requests.count(), 1)
+
+        # let lisa accept john's invitation
+        self.lisa_group_member.uaccess.act_on_group_membership_request(
+            membership_request, accept_request=True)
+
+        # user lisa should have no pending request to join group
+        self.assertEqual(
+            self.lisa_group_member.uaccess.group_membership_requests.count(), 0)
+
+        # modeling group should have no pending membership requests
+        self.assertEqual(
+            self.modeling_group.gaccess.group_membership_requests.count(), 0)
+
+        # there should be 5 members in the group
+        self.assertEqual(self.modeling_group.gaccess.members.count(), 5)
+
     def test_user_sending_request_auto_approval(self):
         # here we are testing auto approval of group membership request
 


### PR DESCRIPTION
Resolves #4770
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a new group, setting "Require explanation when requesting membership" = True
2. Invite a different user to the group
3. You will see that the invitation email is sent properly and that the invitation is added to the pending invitations within the group
