### PR TITLE
4784- Workaround for `fitBounce` and `restriction` option

### DIFF
--- a/theme/static/js/coverageMap.js
+++ b/theme/static/js/coverageMap.js
@@ -119,7 +119,7 @@ function drawInitialShape() {
             rectangle.setMap(coverageMap);
             allShapes.push(rectangle);
             zoomCoverageMap(bounds);
-             $("#coverageMap").on("click", "#resetZoomBtn", function () {
+            $("#coverageMap").on("click", "#resetZoomBtn", function () {
                 zoomCoverageMap(bounds);
             });
         }
@@ -455,5 +455,9 @@ function deleteAllShapes(){
 }
 
 function zoomCoverageMap(bounds) {
+    // Known bug in google maps while calling `fitBounds` while the map is using the `restriction` option.
+    // https://stackoverflow.com/questions/54712021/map-fitbounds-works-weird-when-map-has-restriction-option-set
+    // Only reliable workaround is to call it twice
+    coverageMap.fitBounds(bounds);
     coverageMap.fitBounds(bounds);
 }


### PR DESCRIPTION
#4784 There is a bug in google maps where calling `fitBounds` while the map is using the `restriction` option, will cause the method to set incorrect bounds. The only reliable workaround is to call the method twice.

https://stackoverflow.com/questions/54712021/map-fitbounds-works-weird-when-map-has-restriction-option-set

This change will fix this issue and allow the map to correctly zoom/center into the drawn coverage.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource.
2. Add a box spatial coverage.
3. Reload the page in both view and edit mode and verify that the map is initially centered/zoomed in correctly.
