### PR TITLE
[#4821] coverage map zoom

### DIFF
--- a/theme/static/js/coordinates-picker.js
+++ b/theme/static/js/coordinates-picker.js
@@ -7,6 +7,7 @@ var coordinatesPicker;
 var currentInstance; // Keeps track of the instance to work with
 var allOverlaysFileType = [];
 let leafletFeatureGroup;
+const coordPickerMaxZoom = 18;
 
 (function ($) {
   $.fn.coordinatesPicker = function () {
@@ -123,7 +124,7 @@ function drawPickerMarker(latLng) {
   marker.addTo(coordinatesPicker);
 
   // Center map at new marker
-  coordinatesPicker.fitBounds(leafletFeatureGroup.getBounds(), { maxZoom: 7 });
+  coordinatesPicker.fitBounds(leafletFeatureGroup.getBounds(), { maxZoom: coordPickerMaxZoom });
   processDrawingFileType(marker.getLatLng(), "marker");
 }
 
@@ -136,7 +137,7 @@ function drawPickerRectangle(bounds) {
 
   rectangle.addTo(coordinatesPicker);
 
-  coordinatesPicker.fitBounds(rectangle.getBounds(), { maxZoom: 7 });
+  coordinatesPicker.fitBounds(rectangle.getBounds(), { maxZoom: coordPickerMaxZoom });
   processDrawingFileType(rectangle.getBounds(), "rectangle");
 }
 
@@ -163,7 +164,7 @@ function initMapFileType() {
     {
       attribution:
         'Map tiles by <a href="http://stamen.com" target="_blank">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0" target="_blank">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org" target="_blank">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright" target="_blank">ODbL</a>.',
-      maxZoom: 18,
+      maxZoom: coordPickerMaxZoom,
     }
   );
 
@@ -172,14 +173,14 @@ function initMapFileType() {
     {
       attribution:
         'Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors',
-      maxZoom: 18,
+      maxZoom: coordPickerMaxZoom,
     }
   );
 
   const googleSat = L.tileLayer(
     "http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
     {
-      maxZoom: 20,
+      maxZoom: coordPickerMaxZoom,
       subdomains: ["mt0", "mt1", "mt2", "mt3"],
     }
   );

--- a/theme/static/js/coverageMap.js
+++ b/theme/static/js/coverageMap.js
@@ -6,6 +6,7 @@
 let coverageMap;
 let leafletMarkers;
 let allOverlays = [];
+const coverageMapMaxZoom = 18;
 
 $(document).ready(function () {
   // Draw marker on text change
@@ -184,7 +185,7 @@ function initMap() {
     {
       attribution:
         'Map tiles by <a href="http://stamen.com" target="_blank">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0" target="_blank">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org" target="_blank">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright" target="_blank">ODbL</a>.',
-      maxZoom: 18,
+      maxZoom: coverageMapMaxZoom,
     }
   );
 
@@ -193,14 +194,14 @@ function initMap() {
     {
       attribution:
         'Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors',
-      maxZoom: 18,
+      maxZoom: coverageMapMaxZoom,
     }
   );
 
   const googleSat = L.tileLayer(
     "http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
     {
-      maxZoom: 20,
+      maxZoom: coverageMapMaxZoom,
       subdomains: ["mt0", "mt1", "mt2", "mt3"],
     }
   );
@@ -316,7 +317,7 @@ function initMap() {
       L.DomEvent.on(recenterButton, "click", (e) => {
         e.stopPropagation();
         try {
-          coverageMap.fitBounds(leafletMarkers.getBounds(), { maxZoom: 7 });
+          coverageMap.fitBounds(leafletMarkers.getBounds(), { maxZoom: coverageMapMaxZoom });
         } catch (error) {
           coverageMap.setView([30, 0], 1);
         }
@@ -387,7 +388,7 @@ function drawMarker(latLng) {
   marker.addTo(coverageMap);
 
   // Center map at new marker
-  coverageMap.fitBounds(leafletMarkers.getBounds(), { maxZoom: 7 });
+  coverageMap.fitBounds(leafletMarkers.getBounds(), { maxZoom: coverageMapMaxZoom });
 }
 
 function drawRectangleOnTextChange() {
@@ -452,7 +453,7 @@ function drawRectangle(bounds) {
   leafletMarkers.addLayer(rectangle);
 
   rectangle.addTo(coverageMap);
-  coverageMap.fitBounds(rectangle.getBounds(), { maxZoom: 7 });
+  coverageMap.fitBounds(rectangle.getBounds(), { maxZoom: coverageMapMaxZoom });
 }
 
 function processDrawing(coordinates, shape) {


### PR DESCRIPTION
Fixes #4821 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource and zoom the coverage map in as far as it can go
2. Add a small BOX spatial coverage
3. Refresh the page
4. The zoom is no longer limited to level "7" -- it will zoom in as far as possible on your spatial coverage, limited by zoom level 18 which is the limit for the map tiles.
