### PR TITLE
4824 aggregation spatial coverage inputs

### DIFF
--- a/theme/static/js/coordinates-picker.js
+++ b/theme/static/js/coordinates-picker.js
@@ -142,6 +142,8 @@ function drawPickerRectangle(bounds) {
 }
 
 function initMapFileType() {
+  if (coordinatesPicker) return; // already initialized
+
   // Initialize Map
   leafletFeatureGroup = L.featureGroup();
 


### PR DESCRIPTION
Resolves #4824. Intended release as a hotfix 1.60.1
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create resource and add box resource level coverage
2. Create aggregation and add box coverage to its metadata. Click out of the FB so that the metadata inputs are hidden.
3. Modify the resource level coverage to be a POINT and save it
4. Expected input boxes (for either box OR point but not both) are shown. No error in js console

