### PR TITLE
[#4826] dont zoom max for point coverage

### DIFF
--- a/theme/static/js/coordinates-picker.js
+++ b/theme/static/js/coordinates-picker.js
@@ -7,7 +7,8 @@ var coordinatesPicker;
 var currentInstance; // Keeps track of the instance to work with
 var allOverlaysFileType = [];
 let leafletFeatureGroup;
-const coordPickerMaxZoom = 18;
+const coordPickerBoxMaxZoom = 18;
+const coordPickerPointMaxZoom = 7;
 
 (function ($) {
   $.fn.coordinatesPicker = function () {
@@ -124,7 +125,7 @@ function drawPickerMarker(latLng) {
   marker.addTo(coordinatesPicker);
 
   // Center map at new marker
-  coordinatesPicker.fitBounds(leafletFeatureGroup.getBounds(), { maxZoom: coordPickerMaxZoom });
+  coordinatesPicker.fitBounds(leafletFeatureGroup.getBounds(), { maxZoom: coordPickerPointMaxZoom });
   processDrawingFileType(marker.getLatLng(), "marker");
 }
 
@@ -137,7 +138,7 @@ function drawPickerRectangle(bounds) {
 
   rectangle.addTo(coordinatesPicker);
 
-  coordinatesPicker.fitBounds(rectangle.getBounds(), { maxZoom: coordPickerMaxZoom });
+  coordinatesPicker.fitBounds(rectangle.getBounds(), { maxZoom: coordPickerBoxMaxZoom });
   processDrawingFileType(rectangle.getBounds(), "rectangle");
 }
 
@@ -164,7 +165,7 @@ function initMapFileType() {
     {
       attribution:
         'Map tiles by <a href="http://stamen.com" target="_blank">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0" target="_blank">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org" target="_blank">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright" target="_blank">ODbL</a>.',
-      maxZoom: coordPickerMaxZoom,
+      maxZoom: coordPickerBoxMaxZoom,
     }
   );
 
@@ -173,14 +174,14 @@ function initMapFileType() {
     {
       attribution:
         'Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors',
-      maxZoom: coordPickerMaxZoom,
+      maxZoom: coordPickerBoxMaxZoom,
     }
   );
 
   const googleSat = L.tileLayer(
     "http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
     {
-      maxZoom: coordPickerMaxZoom,
+      maxZoom: coordPickerBoxMaxZoom,
       subdomains: ["mt0", "mt1", "mt2", "mt3"],
     }
   );

--- a/theme/static/js/coverageMap.js
+++ b/theme/static/js/coverageMap.js
@@ -6,7 +6,8 @@
 let coverageMap;
 let leafletMarkers;
 let allOverlays = [];
-const coverageMapMaxZoom = 18;
+const coverageMapBoxMaxZoom = 18;
+const coverageMapPointMaxZoom = 7;
 
 $(document).ready(function () {
   // Draw marker on text change
@@ -185,7 +186,7 @@ function initMap() {
     {
       attribution:
         'Map tiles by <a href="http://stamen.com" target="_blank">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0" target="_blank">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org" target="_blank">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright" target="_blank">ODbL</a>.',
-      maxZoom: coverageMapMaxZoom,
+      maxZoom: coverageMapBoxMaxZoom,
     }
   );
 
@@ -194,14 +195,14 @@ function initMap() {
     {
       attribution:
         'Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors',
-      maxZoom: coverageMapMaxZoom,
+      maxZoom: coverageMapBoxMaxZoom,
     }
   );
 
   const googleSat = L.tileLayer(
     "http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
     {
-      maxZoom: coverageMapMaxZoom,
+      maxZoom: coverageMapBoxMaxZoom,
       subdomains: ["mt0", "mt1", "mt2", "mt3"],
     }
   );
@@ -317,7 +318,14 @@ function initMap() {
       L.DomEvent.on(recenterButton, "click", (e) => {
         e.stopPropagation();
         try {
-          coverageMap.fitBounds(leafletMarkers.getBounds(), { maxZoom: coverageMapMaxZoom });
+          const checked = $("#div_id_type input:checked").val();
+          const spatialType = checked || spatial_coverage_type;
+          coverageMap.fitBounds(leafletMarkers.getBounds(), {
+            maxZoom:
+              spatialType === "point"
+                ? coverageMapPointMaxZoom
+                : coverageMapBoxMaxZoom,
+          });
         } catch (error) {
           coverageMap.setView([30, 0], 1);
         }
@@ -388,7 +396,7 @@ function drawMarker(latLng) {
   marker.addTo(coverageMap);
 
   // Center map at new marker
-  coverageMap.fitBounds(leafletMarkers.getBounds(), { maxZoom: coverageMapMaxZoom });
+  coverageMap.fitBounds(leafletMarkers.getBounds(), { maxZoom: coverageMapPointMaxZoom });
 }
 
 function drawRectangleOnTextChange() {
@@ -453,7 +461,7 @@ function drawRectangle(bounds) {
   leafletMarkers.addLayer(rectangle);
 
   rectangle.addTo(coverageMap);
-  coverageMap.fitBounds(rectangle.getBounds(), { maxZoom: coverageMapMaxZoom });
+  coverageMap.fitBounds(rectangle.getBounds(), { maxZoom: coverageMapBoxMaxZoom });
 }
 
 function processDrawing(coordinates, shape) {


### PR DESCRIPTION
Resolves #4826. Intended release as a hotfix 1.60.1
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Add point spatial coverage to a resource
2. Refresh the page
3. The map no longer zooms in so far that you can't tell where the point is

