### PR TITLE
[#4215] profile alert dismissable

### DIFF
--- a/theme/static/js/custom.js
+++ b/theme/static/js/custom.js
@@ -167,7 +167,7 @@ $(document).ready(function () {
                 + '<strong>' + missing_field_str + '</strong> fields'
                 + ' on the <a href="/user/' + uid + '/">User Profile</a> page';
 
-            customAlert("Profile", message, "info", 10000);
+            customAlert("Profile", message, "info", 10000, true);
     }
 
     $.ajax({
@@ -296,7 +296,7 @@ $(document).ready(function () {
 
 // Alert Types: "error", "success", "info"
 // pass a duration value of -1 for persistent alerts
-function customAlert(alertTitle, alertMessage, alertType, duration) {
+function customAlert(alertTitle, alertMessage, alertType, duration, dismissable=false) {
     alertType = alertType || "success";
     var el = document.createElement("div");
     var top = 200;
@@ -310,6 +310,10 @@ function customAlert(alertTitle, alertMessage, alertType, duration) {
     el.setAttribute("class", "custom-alert shadow-md " + alertTypes[alertType].class);
     alertMessage = '<i class="' + alertTypes[alertType].icon + '" aria-hidden="true"></i><strong> '
         + alertTitle + '</strong><br>' + alertMessage;
+    if(dismissable){
+        alertMessage = '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button> ' + alertMessage;
+        el.classList.add("alert-dissmissable");
+    }
     el.innerHTML = alertMessage;
     if (duration !== -1) {
         setTimeout(function () {


### PR DESCRIPTION
Resolves #4215 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Login as a user whose profile is not complete
2. Create a new resource
3. The blue alert indicating profile incomplete is now dismissable
![image](https://user-images.githubusercontent.com/17934193/202472930-37563792-e162-4aef-a6a7-bad4a298f228.png)

