### PR TITLE
[#4878] celery 2.0.2 hotfix

### DIFF
--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -71,7 +71,7 @@ class FileOverrideException(Exception):
         super(FileOverrideException, self).__init__(self, error_message)
 
 
-@celery_app.on_after_configure.connect
+@celery_app.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs):
     if (hasattr(settings, 'DISABLE_PERIODIC_TASKS') and settings.DISABLE_PERIODIC_TASKS):
         logger.debug("Periodic tasks are disabled in SETTINGS")


### PR DESCRIPTION
hotfix = 2.0.2
resolves #4878 which was introduced in 2.0 release by https://github.com/hydroshare/hydroshare/pull/4803
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
To test this, I deployed the following branch to beta inactive worker:
https://github.com/hydroshare/hydroshare/tree/no-merge-demo-tasks
This branch includes this hotfix plus the following commit:
https://github.com/hydroshare/hydroshare/commit/21ad7c935c54ceb88d39955eb0f73f8e8d92716a
in order to demonstrate that periodic tasks start running (and in this case, intentionally failing) again

Check the result:
beta inactive flower
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/17934193/206572218-a6d796be-a174-4b1c-aca0-60a14f292bff.png">

