### PR TITLE
[#4862] Conditional showing of Author sort icon

### DIFF
--- a/theme/templates/resource-landing-page/resource-header.html
+++ b/theme/templates/resource-landing-page/resource-header.html
@@ -61,18 +61,18 @@
                         {% endif %}
                       </div>
                       <div style="display:flex; align-items: center;" class="space-left gap-1x">
-                        {% if not cm.raccess.published %}
-                        <span data-toggle="tooltip" data-placement="auto"
-                              title='Drag and drop Authors to rearrange.'
-                              class="glyphicon glyphicon-info-sign text-muted">
-                        {% endif %}
-                        </span>
                         {% if resource_edit_mode %}
-                        <a data-toggle="tooltip" data-placement="auto"
-                            href="https://www.youtube.com/watch?v=5rYQjvnRXlI" target="_blank"
-                            title='How to: Authorship and Ownership'
-                            class="fa fa-youtube-play icon-red no-decoration icon-guide">
-                        </a>
+                            {% if not cm.raccess.published_or_review_pending %}
+                                <span data-toggle="tooltip" data-placement="auto"
+                                    title='Drag and drop Authors to rearrange.'
+                                    class="glyphicon glyphicon-info-sign text-muted">
+                                </span>
+                            {% endif %}
+                            <a data-toggle="tooltip" data-placement="auto"
+                                href="https://www.youtube.com/watch?v=5rYQjvnRXlI" target="_blank"
+                                title='How to: Authorship and Ownership'
+                                class="fa fa-youtube-play icon-red no-decoration icon-guide">
+                            </a>
                         {% endif %}
                       </div>
                     </td>


### PR DESCRIPTION
Resolves #4862 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case

1. Make a discoverable resource
2. In EDIT mode, the "i" info icon for Author Sorting is visible
3. In VIEW mode, the icon is not visible
5. Make the resource public
6. Submit a resource for metadata review / publication
7. The "i" info icon for Author Sorting is not visible in edit or view mode of the resource

#### Before:
![image](https://user-images.githubusercontent.com/17934193/207369588-c774210d-3271-4869-bffe-1b9797ece98a.png)


#### After:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/17934193/207369531-181ec756-e714-4b85-81e2-0286fcaafac0.png">
