### PR TITLE
[#4957] log/notify for unpublished pending res

### DIFF
--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -1104,6 +1104,7 @@ def publish_resource(user, pk):
         if not response.status_code == status.HTTP_200_OK:
             # resource metadata deposition failed from CrossRef - set failure flag to be retried in a
             # crontab celery task
+            logger.error(f"Received a {response.status_code} from Crossref while depositing metadata for res id {pk}")
             resource.doi = get_resource_doi(pk, 'failure')
             resource.save()
 

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -221,6 +221,12 @@ def manage_task_hourly():
             msg_lst.append("{res_id} does not have published date in its metadata.".format(
                 res_id=res.short_id))
 
+    pending_unpublished_resources = BaseResource.objects.filter(raccess__published=False,
+                                                                doi__contains='pending')
+    for res in pending_unpublished_resources:
+        msg_lst.append(f"{res.short_id} has pending in DOI but resource_acceess shows unpublished. "
+                       "This indicates an issue with the resource, please notify a developer")
+
     if msg_lst and not settings.DISABLE_TASK_EMAILS:
         email_msg = '\n'.join(msg_lst)
         subject = 'Notification of pending DOI deposition/activation of published resources'


### PR DESCRIPTION
Resolves #4957
by adding some additional logging and notification so that we can catch this issue when it happens again.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Because we don't know why resources are getting into a "pending" publication state and staying there (without XML being sent to Crossref), testing this locally is a bit convoluted.
2. Create a resource
3. Using python shell or directly editing the db, set `resource.doi="pending"`
4. Call [tasks.manage_task_hourly()](https://github.com/hydroshare/hydroshare/blob/4957-pending-publication/hs_core/tasks.py#L150) and ensure that it sends an email (to the logs for local dev) notifying that the resource is in a broken state. Or Enable celery tasks to run locally by setting `DISABLE_PERIODIC_TASKS = False` and wait for the celery job to run.
