### PR TITLE
[#4946] Sharing status shouldn't be modifiable during metadata review

### DIFF
--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -2113,7 +2113,7 @@ def metadata_review(request, shortkey, action, uidb36=None, token=None, **kwargs
                 request,
                 "Publication request was rejected. Please send an email to the resource owner indicating why.",
             )
-            res.metadata.dates.all().filter(type="review_started").delete()
+        res.metadata.dates.all().filter(type="review_started").delete()
     return HttpResponseRedirect(f"/resource/{ res.short_id }/")
 
 

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -1190,6 +1190,9 @@ def publish(request, shortkey, *args, **kwargs):
     if not request.user.is_superuser:
         raise ValidationError("Resource can only be published by an admin user")
     try:
+        res = get_resource_by_shortkey(shortkey)
+        res.raccess.review_pending = False
+        res.raccess.save()
         hydroshare.publish_resource(request.user, shortkey)
     except ValidationError as exp:
         request.session["validation_error"] = str(exp)

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -1224,7 +1224,9 @@ def submit_for_review(request, shortkey, *args, **kwargs):
                 Your resource is under review for appropriate minimum metadata and to ensure that it adheres to
                 community guidelines.
                 The review process will likely be complete within 1 business day, but not exceed 2 business days.
-                You will receive a notification via email once the review process has concluded."""
+                You will receive a notification via email once the review process has concluded.
+                If you decide that you no longer wish to have this resource reviewed for publication,
+                please contact help@cuahsi.org"""
         messages.success(request, message)
     return HttpResponseRedirect(request.META["HTTP_REFERER"])
 

--- a/theme/templates/resource-landing-page/manage-access.html
+++ b/theme/templates/resource-landing-page/manage-access.html
@@ -151,7 +151,7 @@
                             </div>
 
                             <template v-if="canChangeResourceFlags || '{{ cm.raccess.published }}'">
-                                {% if not cm.raccess.published %}
+                                {% if not cm.raccess.published_or_review_pending %}
                                     <div class="btn-group" role="group">
                                         {# -------- PUBLIC -------- #}
                                         <button


### PR DESCRIPTION
Resolves #4958
Resolves #4946 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource and add metadata to make public
2. Click the PUBLISH button and accept in the modals to put the res in "review_pending"
3. See that, once in "review pending" the resource can no longer be made discoverable/private
