### PR TITLE
[#4948] expose schema.org on dev, prevent robots

### DIFF
--- a/hs_core/management/commands/prevent_web_crawling.py
+++ b/hs_core/management/commands/prevent_web_crawling.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
 
         # a list of urls to disable
-        parser.add_argument('dissalowed_urls', nargs='*', type=str)
+        parser.add_argument('disallowed_urls', nargs='*', type=str)
 
     def handle(self, *args, **options):
         # django-robots model definitions:
@@ -26,15 +26,15 @@ class Command(BaseCommand):
         r.save()  # extra save here is necessary to do r.disallowed later
         r.sites.set(Site.objects.all())
 
-        if len(options['dissalowed_urls']) > 0:  # an array of urls to disable.
-            for url in options['dissalowed_urls']:
+        if len(options['disallowed_urls']) > 0:  # an array of urls to disable.
+            for url in options['disallowed_urls']:
                 try:
                     u = Url()
                     u.pattern = url
                     u.save()
                     r.disallowed.add(u)
                 except Exception:
-                    print(f"Dissalow url: {url} failed.")
+                    print(f"Disallow url: {url} failed.")
                     raise
         else:
             u = Url()

--- a/hs_core/management/commands/prevent_web_crawling.py
+++ b/hs_core/management/commands/prevent_web_crawling.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""
+Prevent web-crawlers from indexing the site
+"""
+
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+from robots.models import Url, Rule
+
+
+class Command(BaseCommand):
+    help = "Prevent web-crawlers from indexing the site. This command is intended to be run after dev deployments."
+
+    def add_arguments(self, parser):
+
+        # a list of urls to disable
+        parser.add_argument('dissalowed_urls', nargs='*', type=str)
+
+    def handle(self, *args, **options):
+        # django-robots model definitions:
+        # https://github.com/jazzband/django-robots/blob/5.0/src/robots/models.py
+        r = Rule()
+        r.robot = "*"
+        r.crawl_delay = 5
+        r.save()  # extra save here is necessary to do r.disallowed later
+        r.sites.set(Site.objects.all())
+
+        if len(options['dissalowed_urls']) > 0:  # an array of urls to disable.
+            for url in options['dissalowed_urls']:
+                try:
+                    u = Url()
+                    u.pattern = url
+                    u.save()
+                    r.disallowed.add(u)
+                except Exception:
+                    print(f"Dissalow url: {url} failed.")
+                    raise
+        else:
+            u = Url()
+            u.pattern = "/"
+            u.save()
+            r.disallowed.add(u)
+        r.save()

--- a/hs_core/templates/pages/baseresource.html
+++ b/hs_core/templates/pages/baseresource.html
@@ -15,7 +15,6 @@
     <link rel="stylesheet" href="{% static 'css/Leaflet.fullscreen.min.css' %}" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
 
-{% if not page|is_debug %}
 {# ======= JSON-LD Structure ======= #}
 <script id="schemaorg" type="application/ld+json">
 {
@@ -192,7 +191,6 @@
     }
 }
 </script>
-{% endif %}
 {% endblock %}
 
 {% block main %}

--- a/hsctl
+++ b/hsctl
@@ -372,6 +372,9 @@ rebuild_hs() {
     docker exec -u hydro-service hydroshare rm -f hydroshare/static/static/robots.txt
     migrate_hs
     sleep 3s
+    # prevent web crawling on development systems (ie beta) -- this should not be run on production
+    echo "  - docker exec -u hydro-service hydroshare python manage.py prevent_web_crawling"
+    docker exec -u hydro-service hydroshare python manage.py prevent_web_crawling
     thumbnail_cleanup
     solr_schema_hs
     sleep 2s

--- a/local-dev-first-start-only.sh
+++ b/local-dev-first-start-only.sh
@@ -411,6 +411,11 @@ echo
 docker $DOCKER_PARAM exec hydroshare python manage.py migrate --fake-initial --noinput
 
 echo
+echo "  - docker exec -u hydro-service hydroshare python manage.py prevent_web_crawling"
+echo
+docker $DOCKER_PARAM exec -u hydro-service hydroshare python manage.py prevent_web_crawling
+
+echo
 echo "  - docker exec -u hydro-service hydroshare python manage.py fix_permissions"
 echo
 docker $DOCKER_PARAM exec -u hydro-service hydroshare python manage.py fix_permissions

--- a/theme/templates/pages/homepage.html
+++ b/theme/templates/pages/homepage.html
@@ -253,7 +253,6 @@
 {% endblock %}
 
 {% block extra_head %}
-{% if not page|is_debug %}
 <script type="application/ld+json">
 {
     "@context": {
@@ -413,5 +412,4 @@
     ]
 }
 </script>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
Resolves #4984
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Rebuild your local containers
2. Visit http://localhost/admin/robots/rule and see that a Rule has been created to prevent webcrawlers to `/`
3. Visit http://localhost/robots.txt to see the dissallow rules

### NOTE:
This PR has changes to hsctl that will need update on beta and other test/dev systems
We also will update the ROBOTS_SITEMAP_URLS
https://github.com/hydroshare/hydroshare/blob/4948-robots/hydroshare/settings.py#L183
on production and beta local_settings.py. Currently they map to localhost:8000
