### PR TITLE
[#4987] Display org as first author on My Resources list

### DIFF
--- a/hs_core/templatetags/hydroshare_tags.py
+++ b/hs_core/templatetags/hydroshare_tags.py
@@ -116,20 +116,17 @@ def resource_first_author(content):
             first_creator = creator
             break
 
-    if first_creator.name and first_creator.relative_uri and first_creator.is_active_user:
-        return format_html('<a href="{desc}">{name}</a>',
-                           desc=first_creator.relative_uri,
-                           name=first_creator.name)
-    elif first_creator.name:
-        return format_html('<span>{name}</span>', name=first_creator.name)
-    else:
-        first_creator = content.metadata.creators.filter(order=1).first()
-        if first_creator.name:
+    if first_creator.name:
+        if first_creator.relative_uri and first_creator.is_active_user:
+            return format_html('<a href="{desc}">{name}</a>',
+                               desc=first_creator.relative_uri,
+                               name=first_creator.name)
+        else:
             return format_html('<span>{name}</span>', name=first_creator.name)
-        if first_creator.organization:
-            return format_html('<span>{name}</span>', name=first_creator.organization)
+    elif first_creator.organization:
+        return format_html('<span>{name}</span>', name=first_creator.organization)
 
-        return ''
+    return ''
 
 
 @register.filter

--- a/hs_core/templatetags/hydroshare_tags.py
+++ b/hs_core/templatetags/hydroshare_tags.py
@@ -116,13 +116,12 @@ def resource_first_author(content):
             first_creator = creator
             break
 
-    if first_creator:
-        if first_creator.name and first_creator.relative_uri and first_creator.is_active_user:
-            return format_html('<a href="{desc}">{name}</a>',
-                               desc=first_creator.relative_uri,
-                               name=first_creator.name)
-        elif first_creator.name:
-            return format_html('<span>{name}</span>', name=first_creator.name)
+    if first_creator.name and first_creator.relative_uri and first_creator.is_active_user:
+        return format_html('<a href="{desc}">{name}</a>',
+                            desc=first_creator.relative_uri,
+                            name=first_creator.name)
+    elif first_creator.name:
+        return format_html('<span>{name}</span>', name=first_creator.name)
     else:
         first_creator = content.metadata.creators.filter(order=1).first()
         if first_creator.name:

--- a/hs_core/templatetags/hydroshare_tags.py
+++ b/hs_core/templatetags/hydroshare_tags.py
@@ -118,8 +118,8 @@ def resource_first_author(content):
 
     if first_creator.name and first_creator.relative_uri and first_creator.is_active_user:
         return format_html('<a href="{desc}">{name}</a>',
-                            desc=first_creator.relative_uri,
-                            name=first_creator.name)
+                           desc=first_creator.relative_uri,
+                           name=first_creator.name)
     elif first_creator.name:
         return format_html('<span>{name}</span>', name=first_creator.name)
     else:


### PR DESCRIPTION
Resolves #4987 
by fixing a regression that I introduced in 
https://github.com/hydroshare/hydroshare/pull/4717
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource
2. Add an Organization as an author
3. Delete the original first author so that the Org is the sole author of the resource
4. Go to My Resources
5. My Resources now lists the ORG name instead of "None"
