### PR TITLE
handle custom text in geospatial relations

### DIFF
--- a/theme/static/js/hs-vue/geoconnex.js
+++ b/theme/static/js/hs-vue/geoconnex.js
@@ -201,7 +201,7 @@ const geoconnexApp = new Vue({
 
         geoconnexApp.ajaxRemoveFeatureFromResMetadata(remove);
         if (!this.isGeoconnexUrl(remove[0].value)) return;
-        
+
         try {
           geoconnexApp.selectedFeatureGroup.removeLayer(
             geoconnexApp.selectedLayerDictionary[remove[0].value]
@@ -233,12 +233,11 @@ const geoconnexApp = new Vue({
         for (const relation of geoconnexApp.metadataRelations) {
           if (this.isGeoconnexUrl(relation.value)) {
             promises.push(geoconnexApp.fetchSingleFeature(relation));
-          }
-          else{
+          } else {
             geoconnexApp.selectedReferenceFeatures.push(relation);
           }
         }
-        const results = await Promise.all(promises)
+        const results = await Promise.all(promises);
         const features = results.flat().filter(Boolean);
         if (!features) {
           throw new Error("No features returned from fetch");
@@ -277,7 +276,7 @@ const geoconnexApp = new Vue({
     },
     addSelectedFeatureToMap(feature) {
       const geoconnexApp = this;
-      if (typeof feature === 'string') return;
+      if (typeof feature === "string") return;
       if (!feature.geometry) {
         geoconnexApp.fetchGeometryForSingleFeature(feature).then((geometry) => {
           feature.geometry = geometry.geometry;
@@ -296,7 +295,7 @@ const geoconnexApp = new Vue({
       const data = {
         text: feature.text || feature,
         value: feature.uri ? feature.uri : feature,
-        type: "relation"
+        type: "relation",
       };
       let ajaxResult;
       $.ajax({
@@ -305,15 +304,15 @@ const geoconnexApp = new Vue({
         data: data,
         success: function (result) {
           // hsapi returns 200 even if the metadata creation fails
-          ajaxResult = result
+          ajaxResult = result;
         },
         complete: function (jqXHR, status) {
           const statusObj = JSON.parse(jqXHR.responseText);
-          if (statusObj.status === "error"){
+          if (statusObj.status === "error") {
             const message = "Error while attempting to save related feature";
             geoconnexApp.error(message, statusObj.message);
             geoconnexApp.generateAppMessage(`${message}: ${statusObj.message}`);
-          }else{
+          } else {
             geoconnexApp.log(
               `Added ${
                 feature.text ? feature.text : feature
@@ -325,7 +324,7 @@ const geoconnexApp = new Vue({
               text: feature.text ? feature.text : feature,
             });
           }
-        }
+        },
       });
     },
     ajaxRemoveFeatureFromResMetadata(relations) {
@@ -831,9 +830,7 @@ const geoconnexApp = new Vue({
           ? collectionOverride
           : feature.collection;
 
-        if (
-          geoconnexApp.ignoredFeatures[collection.id]?.includes(feature.id)
-        )
+        if (geoconnexApp.ignoredFeatures[collection.id]?.includes(feature.id))
           return;
 
         // check if layergroup exists in the "dictionary"
@@ -1260,7 +1257,9 @@ const geoconnexApp = new Vue({
       });
       const contexts = featureJsonLd["@context"];
       for (let context of contexts) {
-        const nameField = Object.keys(context).find((key) => context[key] === "schema:name");
+        const nameField = Object.keys(context).find(
+          (key) => context[key] === "schema:name"
+        );
         if (nameField) return nameField;
       }
       return "NAME";
@@ -1282,7 +1281,7 @@ const geoconnexApp = new Vue({
       });
       return feature;
     },
-    isUrl(stringToTest){
+    isUrl(stringToTest) {
       try {
         new URL(stringToTest);
       } catch (_) {
@@ -1291,7 +1290,7 @@ const geoconnexApp = new Vue({
       return true;
     },
     isGeoconnexUrl(stringToTest) {
-      return this.isUrl(stringToTest) && stringToTest.indexOf("geoconnex") > -1
+      return this.isUrl(stringToTest) && stringToTest.indexOf("geoconnex") > -1;
     },
     trimString(longString, append = "") {
       return longString.length + append.length > geoconnexApp.stringLengthLimit
@@ -1389,13 +1388,13 @@ const geoconnexApp = new Vue({
       geoconnexApp.resMode == "Edit" && geoconnexApp.fetchCollections(false);
       await geoconnexApp.loadResourceMetadataRelations();
 
-      if (geoconnexApp.resMode == "Edit"){
+      if (geoconnexApp.resMode == "Edit") {
         // wait for spatial coverage map to load before getting extent
         await geoconnexApp
-        .until((_) => coverageMap)
-        .then(() => {
-          geoconnexApp.updateAppWithResSpatialExtent();
-        });
+          .until((_) => coverageMap)
+          .then(() => {
+            geoconnexApp.updateAppWithResSpatialExtent();
+          });
       }
       geoconnexApp.fitMapToFeatures({ group: null, overrideShouldFit: true });
     }

--- a/theme/templates/resource-landing-page/geoconnex.html
+++ b/theme/templates/resource-landing-page/geoconnex.html
@@ -247,7 +247,7 @@
                         <table class="table hs-table info-table">
                             <tr v-for="value in selectedReferenceFeatures" style="padding-bottom: 20px">
                                 <td v-if="isUrl(value.value)" class="dataset-details">
-                                    <a v-if="isUrl(value.value)" target="_blank" :href="value.value"> ${value.text}</a>
+                                    <a target="_blank" :href="value.value"> ${value.text}</a>
                                     <i class="fa fa-external-link"></i>
                                 </td>
                                 <td v-else class="dataset-details">${value.text}</td>


### PR DESCRIPTION
Resolves #4994 by allowing custom text to be entered on Geoconnex Relations
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource
2. Attempt to add a Geospatial Relation with custom text (by typing in the second box) 
<img width="573" alt="image" src="https://user-images.githubusercontent.com/17934193/221325787-75e96766-6bb1-449d-9c17-8d3be594fa51.png">

3. No longer errors messages in UI/console

#### BEFORE
![image](https://user-images.githubusercontent.com/17934193/221325866-67900cfa-b271-4f2e-ba53-a43f343d0bc7.png)


