### PR TITLE
[#5019] don't query nameField for every feature

### DIFF
--- a/theme/static/js/hs-vue/geoconnex.js
+++ b/theme/static/js/hs-vue/geoconnex.js
@@ -957,8 +957,8 @@ const geoconnexApp = new Vue({
           if (!geojson.collection) {
             geojson.collection = "Search Bounds";
           }
-          if (!geoconnexApp.searchLayerGroupDictionary[geojson.collection]){
-            return
+          if (!geoconnexApp.searchLayerGroupDictionary[geojson.collection]) {
+            return;
           }
           geoconnexApp.searchLayerGroupDictionary[geojson.collection].addLayer(
             leafletLayer
@@ -1262,19 +1262,17 @@ const geoconnexApp = new Vue({
       if (feature.NAME) return;
       const geoconnexApp = this;
       let nameField;
-      if (feature.collection in geoconnexApp.featureNameMap){
-        nameField = geoconnexApp.featureNameMap[feature.collection]
-      }else{
-        nameField = await geoconnexApp.getFeatureNameField(
-          feature.collection
-        );
+      if (feature.collection in geoconnexApp.featureNameMap) {
+        nameField = geoconnexApp.featureNameMap[feature.collection];
+      } else {
+        nameField = await geoconnexApp.getFeatureNameField(feature.collection);
         geoconnexApp.featureNameMap[feature.collection] = nameField;
       }
       feature.NAME = feature.properties[nameField] || "";
     },
     async getFeatureNameField(collectionName) {
       const geoconnexApp = this;
-      if (collectionName in geoconnexApp.featureNameMap){
+      if (collectionName in geoconnexApp.featureNameMap) {
         return geoconnexApp.featureNameMap[collectionName];
       }
       const url = `${geoconnexApp.geoconnexUrl}/${collectionName}/items?f=jsonld&lang=en-US&skipGeometry=true&limit=1`;
@@ -1288,7 +1286,7 @@ const geoconnexApp = new Vue({
         const nameField = Object.keys(context).find(
           (key) => context[key] === "schema:name"
         );
-        if (nameField){
+        if (nameField) {
           geoconnexApp.featureNameMap[collectionName] = nameField;
           return nameField;
         }

--- a/theme/static/js/hs-vue/geoconnex.js
+++ b/theme/static/js/hs-vue/geoconnex.js
@@ -20,6 +20,7 @@ const geoconnexApp = new Vue({
         nat_aq: ["N9999OTHER"],
         principal_aq: [999],
       },
+      featureNameMap: {},
 
       ////// Resource-level data //////
       resShortId: SHORT_ID,
@@ -1258,14 +1259,24 @@ const geoconnexApp = new Vue({
       }
     },
     async setFeatureName(feature) {
+      if (feature.NAME) return;
       const geoconnexApp = this;
-      const nameField = await geoconnexApp.getFeatureNameField(
-        feature.collection
-      );
+      let nameField;
+      if (feature.collection in geoconnexApp.featureNameMap){
+        nameField = geoconnexApp.featureNameMap[feature.collection]
+      }else{
+        nameField = await geoconnexApp.getFeatureNameField(
+          feature.collection
+        );
+        geoconnexApp.featureNameMap[feature.collection] = nameField;
+      }
       feature.NAME = feature.properties[nameField] || "";
     },
     async getFeatureNameField(collectionName) {
       const geoconnexApp = this;
+      if (collectionName in geoconnexApp.featureNameMap){
+        return geoconnexApp.featureNameMap[collectionName];
+      }
       const url = `${geoconnexApp.geoconnexUrl}/${collectionName}/items?f=jsonld&lang=en-US&skipGeometry=true&limit=1`;
       // don't fetch the contexts from cache, get it direct from Geoconnex api
       const featureJsonLd = await geoconnexApp.fetchURLFromCacheOrGeoconnex({
@@ -1277,7 +1288,10 @@ const geoconnexApp = new Vue({
         const nameField = Object.keys(context).find(
           (key) => context[key] === "schema:name"
         );
-        if (nameField) return nameField;
+        if (nameField){
+          geoconnexApp.featureNameMap[collectionName] = nameField;
+          return nameField;
+        }
       }
       return geoconnexApp.getFirstFeatureNameField(collectionName);
     },
@@ -1297,7 +1311,12 @@ const geoconnexApp = new Vue({
       const match = Object.keys(properties).filter((key) =>
         /.*name.*/i.test(key)
       );
-      return match[0] || "";
+      let first = match[0];
+      if (first) {
+        geoconnexApp.featureNameMap[collectionName] = first;
+        return first;
+      }
+      return "";
     },
     async getFeatureProperties(feature) {
       const geoconnexApp = this;


### PR DESCRIPTION
Resolves #5019 
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. On a resource, open browser console and select a Geoconnex collection to search
2. Note that there are at most 3 requests sent to the Geoconnex API, instead of a separate request for every single feature in the collection
