### PR TITLE
[#5028] Move aggregation endpoint fix

### DIFF
--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -853,11 +853,20 @@ def move_aggregation_task(res_id, file_type_id, file_type, tgt_path):
     aggregation = file_type_obj.objects.get(id=file_type_id)
     res_files.extend(aggregation.files.all())
     orig_aggregation_name = aggregation.aggregation_name
+    tgt_path = tgt_path.strip()
     for file in res_files:
-        tgt_full_path = os.path.join(res.file_path, tgt_path, os.path.basename(file.storage_path))
+        if tgt_path:
+            tgt_full_path = os.path.join(res.file_path, tgt_path, os.path.basename(file.storage_path))
+        else:
+            tgt_full_path = os.path.join(res.file_path, os.path.basename(file.storage_path))
+
         istorage.moveFile(file.storage_path, tgt_full_path)
         rename_irods_file_or_folder_in_django(res, file.storage_path, tgt_full_path)
-    new_aggregation_name = os.path.join(tgt_path, os.path.basename(orig_aggregation_name))
+    if tgt_path:
+        new_aggregation_name = os.path.join(tgt_path, os.path.basename(orig_aggregation_name))
+    else:
+        new_aggregation_name = os.path.basename(orig_aggregation_name)
+
     res.set_flag_to_recreate_aggregation_meta_files(orig_path=orig_aggregation_name,
                                                     new_path=new_aggregation_name)
     return res.get_absolute_url()

--- a/hs_file_types/views.py
+++ b/hs_file_types/views.py
@@ -239,7 +239,9 @@ def move_aggregation_public(request, resource_id, hs_file_type, file_path, tgt_p
     res_file = get_res_file(resource_id, file_path)
     if isinstance(res_file, Response):
         return res_file
-    return move_aggregation(request, resource_id, hs_file_type, res_file.logical_file.id, tgt_path, **kwargs)
+
+    return move_aggregation(request, resource_id=resource_id, hs_file_type=hs_file_type,
+                            file_type_id=res_file.logical_file.id, tgt_path=tgt_path)
 
 
 @swagger_auto_schema(method="get", responses={200: serializers.ModelProgramMetaTemplateSchemaSerializer})

--- a/hs_rest_api/tests/http/test_aggregation.py
+++ b/hs_rest_api/tests/http/test_aggregation.py
@@ -1,0 +1,68 @@
+import tempfile
+
+from django.urls import reverse
+
+from hs_core.models import ResourceFile
+from hs_core.tests.api.rest.base import HSRESTTestCase
+from hs_file_types.models import NetCDFLogicalFile
+from hs_file_types.tests.utils import CompositeResourceTestMixin
+
+
+class TestFileSetEndpoint(HSRESTTestCase, CompositeResourceTestMixin):
+
+    def setUp(self):
+        super(TestFileSetEndpoint, self).setUp()
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.resources_to_delete = []
+
+        self.res_title = "Test NetCDF File Type"
+        self.logical_file_type_name = "NetCDFLogicalFile"
+        base_file_path = 'hs_file_types/tests/{}'
+        self.netcdf_file_name = 'netcdf_valid.nc'
+        self.netcdf_file = base_file_path.format(self.netcdf_file_name)
+
+    def test_move_aggregation(self):
+        """Test that we can move an aggregation from one folder location to another through the api"""
+
+        self.create_composite_resource()
+        # upload the netcdf file
+        self.add_file_to_resource(file_to_add=self.netcdf_file)
+        # there should be one resource file
+        self.assertEqual(self.composite_resource.files.all().count(), 1)
+        res_file = self.composite_resource.files.first()
+        # check that the resource file is not part of an aggregation
+        self.assertEqual(res_file.has_logical_file, False)
+        self.assertEqual(NetCDFLogicalFile.objects.count(), 0)
+
+        # set nc file to NetCDF aggregation
+        set_type_url = reverse('set_file_type_public', kwargs={"pk": self.composite_resource.short_id,
+                                                               "file_path": res_file.short_path,
+                                                               "hs_file_type": "NetCDF"})
+        self.client.post(set_type_url, data={"folder_path": ""})
+        res_file = self.composite_resource.files.first()
+        self.assertEqual(res_file.has_logical_file, True)
+        self.assertEqual(NetCDFLogicalFile.objects.count(), 1)
+        nc_aggr = NetCDFLogicalFile.objects.first()
+
+        # create a folder where we will move the netcdf aggregation
+        new_folder = 'netcdf_aggregation'
+        ResourceFile.create_folder(self.composite_resource, new_folder)
+        move_aggr_url = reverse('move_aggregation_public', kwargs={"resource_id": self.composite_resource.short_id,
+                                                               "file_path": nc_aggr.aggregation_name,
+                                                               "tgt_path": new_folder,
+                                                               "hs_file_type": "NetCDFLogicalFile"})
+        self.client.post(move_aggr_url, data={})
+        self.assertEqual(NetCDFLogicalFile.objects.count(), 1)
+        nc_aggr = NetCDFLogicalFile.objects.first()
+        self.assertTrue(nc_aggr.aggregation_name.startswith(new_folder))
+
+        # move the aggregation back to root of the resource
+        move_aggr_url = reverse('move_aggregation_public', kwargs={"resource_id": self.composite_resource.short_id,
+                                                                   "file_path": nc_aggr.aggregation_name,
+                                                                   "tgt_path": "",
+                                                                   "hs_file_type": "NetCDFLogicalFile"})
+        self.client.post(move_aggr_url, data={})
+        self.assertEqual(NetCDFLogicalFile.objects.count(), 1)
+        nc_aggr = NetCDFLogicalFile.objects.first()
+        self.assertFalse(nc_aggr.aggregation_name.startswith(new_folder))

--- a/hs_rest_api/tests/http/test_aggregation.py
+++ b/hs_rest_api/tests/http/test_aggregation.py
@@ -49,9 +49,9 @@ class TestFileSetEndpoint(HSRESTTestCase, CompositeResourceTestMixin):
         new_folder = 'netcdf_aggregation'
         ResourceFile.create_folder(self.composite_resource, new_folder)
         move_aggr_url = reverse('move_aggregation_public', kwargs={"resource_id": self.composite_resource.short_id,
-                                                               "file_path": nc_aggr.aggregation_name,
-                                                               "tgt_path": new_folder,
-                                                               "hs_file_type": "NetCDFLogicalFile"})
+                                                                   "file_path": nc_aggr.aggregation_name,
+                                                                   "tgt_path": new_folder,
+                                                                   "hs_file_type": "NetCDFLogicalFile"})
         self.client.post(move_aggr_url, data={})
         self.assertEqual(NetCDFLogicalFile.objects.count(), 1)
         nc_aggr = NetCDFLogicalFile.objects.first()


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Locally create a resource. Create a folder in that resource. Create a raster or netcdf aggregation at the root of the resource.
2. Access the REST API swagger UI at localhost:8000/hsapi
3. Use the endpoint (`/resource/{resource_id}/{hs_file_type}/{file_path}/functions/move-file-type/{tgt_path}`) to move the aggregation to the folder. Verify the endpoint post request response status code is 200. 
4. Using the resource landing page verify that the aggregation exists inside the folder.