### PR TITLE
[#5082] add user agent for metrics

### DIFF
--- a/hs_tracking/tests/test_tracking.py
+++ b/hs_tracking/tests/test_tracking.py
@@ -321,11 +321,11 @@ class TrackingTests(TestCase):
 
         kvp = dict(tuple(pair.split('=')) for pair in var1.value.split('|'))
         self.assertEqual(var1.name, 'begin_session')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 5)
 
         kvp = dict(tuple(pair.split('=')) for pair in var2.value.split('|'))
         self.assertEqual(var2.name, 'login')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 5)
 
         client.logout()
 
@@ -333,7 +333,7 @@ class TrackingTests(TestCase):
         var = Variable.objects.latest('timestamp')
         kvp = dict(tuple(pair.split('=')) for pair in var.value.split('|'))
         self.assertEqual(var.name, 'logout')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 5)
 
     def test_activity_parsing(self):
 
@@ -345,7 +345,7 @@ class TrackingTests(TestCase):
 
         kvp = dict(tuple(pair.split('=')) for pair in var1.value.split('|'))
         self.assertEqual(var1.name, 'begin_session')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 5)
 
         client.logout()
 
@@ -375,7 +375,7 @@ class UtilsTests(TestCase):
     def test_std_log_fields(self):
 
         log_fields = utils.get_std_log_fields(self.request, self.session)
-        self.assertTrue(len(list(log_fields.keys())) == 3)
+        self.assertTrue(len(list(log_fields.keys())) == 5)
         self.assertTrue('user_ip' in log_fields)
         self.assertTrue('user_type' in log_fields)
         self.assertTrue('user_email_domain' in log_fields)

--- a/hs_tracking/utils.py
+++ b/hs_tracking/utils.py
@@ -37,7 +37,10 @@ def get_std_log_fields(request, session=None):
     """ returns a standard set of metadata that to each receiver function.
     This ensures that all activities are reporting a consistent set of metrics
     """
-    user_agent = request.META['HTTP_USER_AGENT']
+    try:
+        user_agent = request.META['HTTP_USER_AGENT']
+    except KeyError as e:
+        user_agent = None
     user_type = None
     user_email = None
     if session is not None:

--- a/hs_tracking/utils.py
+++ b/hs_tracking/utils.py
@@ -37,6 +37,7 @@ def get_std_log_fields(request, session=None):
     """ returns a standard set of metadata that to each receiver function.
     This ensures that all activities are reporting a consistent set of metrics
     """
+    user_agent = request.META['HTTP_USER_AGENT']
     user_type = None
     user_email = None
     if session is not None:
@@ -47,6 +48,8 @@ def get_std_log_fields(request, session=None):
         'user_ip': get_client_ip(request),
         'user_type': user_type,
         'user_email_domain': user_email,
+        'is_human': is_human(user_agent),
+        'user_agent': user_agent
     }
 
 

--- a/hs_tracking/utils.py
+++ b/hs_tracking/utils.py
@@ -39,8 +39,10 @@ def get_std_log_fields(request, session=None):
     """
     try:
         user_agent = request.META['HTTP_USER_AGENT']
-    except KeyError as e:
+        human = is_human(user_agent)
+    except KeyError:
         user_agent = None
+        human = None
     user_type = None
     user_email = None
     if session is not None:
@@ -51,7 +53,7 @@ def get_std_log_fields(request, session=None):
         'user_ip': get_client_ip(request),
         'user_type': user_type,
         'user_email_domain': user_email,
-        'is_human': is_human(user_agent),
+        'is_human': human,
         'user_agent': user_agent
     }
 


### PR DESCRIPTION
Resolves #5082
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Interact with a resource (say download it)
2. Run some SQL `SELECT * FROM "public"."hs_tracking_variable" ORDER BY "timestamp" DESC LIMIT 100 OFFSET 0;`
3. See that the user_agent is recorded (not for every visit, just for begin_session, delete, create, download)
