### PR TITLE
add full email domain for metrics

### DIFF
--- a/hs_tracking/middleware.py
+++ b/hs_tracking/middleware.py
@@ -72,7 +72,7 @@ class Tracking(MiddlewareMixin):
         # get user info that will be recorded in the visit log
         session = Session.objects.for_request(request)
         usertype = utils.get_user_type(session)
-        emaildomain = utils.get_user_email_domain(session)
+        email_tld = utils.get_user_email_tld(session)
         ip = utils.get_client_ip(request)
 
         # build the message string (key:value pairs)
@@ -81,7 +81,7 @@ class Tracking(MiddlewareMixin):
                          'http_method=%s' % request.method,
                          'http_code=%s' % response.status_code,
                          'user_type=%s' % usertype,
-                         'user_email_domain=%s' % emaildomain,
+                         'user_email_domain=%s' % email_tld,
                          'request_url=%s' % request.path]])
 
         resource_id = get_resource_id_from_url(request.path)

--- a/hs_tracking/tests/test_tracking.py
+++ b/hs_tracking/tests/test_tracking.py
@@ -107,6 +107,7 @@ class ViewTests(TestCase):
         self.assertTrue('res_type' in list(values.keys()))
         self.assertTrue('name' in list(values.keys()))
         self.assertTrue('user_email_domain' in list(values.keys()))
+        self.assertTrue('user_email_domain_full' in list(values.keys()))
         self.assertTrue('user_type' in list(values.keys()))
         self.assertTrue('user_ip' in list(values.keys()))
         self.assertTrue('res_id' in list(values.keys()))
@@ -114,6 +115,7 @@ class ViewTests(TestCase):
         self.assertTrue(values['res_type'] == res_type)
         self.assertTrue(values['name'] == app_name)
         self.assertTrue(values['user_email_domain'] == self.user.email[-3:])
+        self.assertTrue(values['user_email_domain_full'] == self.user.email.split('@')[-1])
         self.assertTrue(values['user_type'] == 'Unspecified')
         self.assertTrue(values['user_ip'] == '198.84.193.157')
         self.assertTrue(values['res_id'] == res_id)
@@ -321,11 +323,11 @@ class TrackingTests(TestCase):
 
         kvp = dict(tuple(pair.split('=')) for pair in var1.value.split('|'))
         self.assertEqual(var1.name, 'begin_session')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 4)
 
         kvp = dict(tuple(pair.split('=')) for pair in var2.value.split('|'))
         self.assertEqual(var2.name, 'login')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 4)
 
         client.logout()
 
@@ -333,7 +335,7 @@ class TrackingTests(TestCase):
         var = Variable.objects.latest('timestamp')
         kvp = dict(tuple(pair.split('=')) for pair in var.value.split('|'))
         self.assertEqual(var.name, 'logout')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 4)
 
     def test_activity_parsing(self):
 
@@ -345,7 +347,7 @@ class TrackingTests(TestCase):
 
         kvp = dict(tuple(pair.split('=')) for pair in var1.value.split('|'))
         self.assertEqual(var1.name, 'begin_session')
-        self.assertEqual(len(list(kvp.keys())), 3)
+        self.assertEqual(len(list(kvp.keys())), 4)
 
         client.logout()
 
@@ -375,10 +377,11 @@ class UtilsTests(TestCase):
     def test_std_log_fields(self):
 
         log_fields = utils.get_std_log_fields(self.request, self.session)
-        self.assertTrue(len(list(log_fields.keys())) == 3)
+        self.assertTrue(len(list(log_fields.keys())) == 4)
         self.assertTrue('user_ip' in log_fields)
         self.assertTrue('user_type' in log_fields)
         self.assertTrue('user_email_domain' in log_fields)
+        self.assertTrue('user_email_domain_full' in log_fields)
 
     def test_ishuman(self):
 
@@ -426,8 +429,8 @@ class UtilsTests(TestCase):
             visitor = Visitor.objects.create()
             visitor.user = user
             session = Session.objects.create(visitor=visitor)
-            emaildom = utils.get_user_email_domain(session)
-            self.assertTrue(emaildom == dom)
+            emailtld = utils.get_user_email_tld(session)
+            self.assertTrue(emailtld == dom)
             user.delete()
 
     def test_client_ip(self):

--- a/hs_tracking/utils.py
+++ b/hs_tracking/utils.py
@@ -21,10 +21,20 @@ def get_user_email_domain(session):
     try:
         user = session.visitor.user
         emaildomain = user.email.split('@')[-1]
-        shortdomain = '.'.join(emaildomain.split('.')[1:])
     except AttributeError:
-        shortdomain = None
-    return shortdomain
+        emaildomain = None
+    return emaildomain
+
+
+def get_user_email_tld(session, emaildomain=None):
+    try:
+        if not emaildomain:
+            emaildomain = get_user_email_domain(session)
+        if emaildomain:
+            shortdomain = '.'.join(emaildomain.split('.')[1:])
+            return shortdomain
+    except AttributeError:
+        return None
 
 
 def is_human(user_agent):
@@ -38,15 +48,18 @@ def get_std_log_fields(request, session=None):
     This ensures that all activities are reporting a consistent set of metrics
     """
     user_type = None
-    user_email = None
+    user_email_tld = None
+    full_domain = None
     if session is not None:
         user_type = get_user_type(session)
-        user_email = get_user_email_domain(session)
+        full_domain = get_user_email_domain(session)
+        user_email_tld = get_user_email_tld(session, full_domain)
 
     return {
         'user_ip': get_client_ip(request),
         'user_type': user_type,
-        'user_email_domain': user_email,
+        'user_email_domain': user_email_tld,
+        'user_email_domain_full': full_domain
     }
 
 


### PR DESCRIPTION
Resolves #5089
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Interact with a resource (say download it)
2. Run some SQL `SELECT * FROM "public"."hs_tracking_variable" ORDER BY "timestamp" DESC LIMIT 100 OFFSET 0;`
3. See that the `user_email_domain_full` is recorded (not for every visit, just for begin_session, delete, create, download)
