### PR TITLE
[#5092] Discover search return short_id

### DIFF
--- a/hs_rest_api/discovery.py
+++ b/hs_rest_api/discovery.py
@@ -13,6 +13,7 @@ class DiscoveryResourceSerializer(HaystackSerializer):
     class Meta:
         index_classes = [BaseResourceIndex]
         fields = [
+            "short_id",
             "title",
             "author",
             "contributor",


### PR DESCRIPTION
Resolves #5092

As part of this work, I tried to update discovery tests
https://github.com/hydroshare/hydroshare/blob/5092-haystack-endpoint/hs_rest_api/tests/http/test_discover.py#L18
but was unable to get them to run. Seems like for some reason these tests don't use the test database? The assertions around resource numbers are wrong because it finds existing resources in my database.

I'm not sure if the testing issues are related to https://github.com/hydroshare/hydroshare/issues/5099
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource
2. GET [http://localhost:8000/hsapi/resource/search](http://localhost:8000/hsapi/resource/search) now returns the `short_id` for the discovered resource
