### PR TITLE
[#5111] Fix for resource file list endpoint timeout error

### DIFF
--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -777,7 +777,6 @@ class ResourceFileListCreate(ResourceFileToListItemMixin, generics.ListCreateAPI
 
         return resource.files.all()
 
-
     def get_serializer_class(self):
         return serializers.ResourceFileSerializer
 

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -756,13 +756,27 @@ class ResourceFileListCreate(ResourceFileToListItemMixin, generics.ListCreateAPI
         """
         return self.list(request)
 
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            resource_file_info_list = []
+            for f in page:
+                resource_file_info_list.append(self.resourceFileToListItem(f))
+
+            serializer = self.get_serializer(resource_file_info_list, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
     def get_queryset(self):
         resource, _, _ = view_utils.authorize(self.request, self.kwargs['pk'],
                                               needed_permission=ACTION_TO_AUTHORIZE.VIEW_RESOURCE)
-        resource_file_info_list = []
-        for f in resource.files.all():
-            resource_file_info_list.append(self.resourceFileToListItem(f))
-        return resource_file_info_list
+
+        return resource.files.all()
+
 
     def get_serializer_class(self):
         return serializers.ResourceFileSerializer


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. In order to test locally, you have to create a resource and add around 300 files to that resource. 
2. Then access the Swagger UI at localhost:8000/resource/hsapi
3. Using the Swagger UI, access the endpoint for file list (**GET /resource/{id}/files**)
4. For id, enter the resource id and then click the Execute button. 
5. Verify, that you don't see a 504 timeout error when the server sends the response. You should see a list of 100 files in the response. Note down the response time.
6. In order to list only 10 files, enter 10 in the count field. Then execute the endpoint. You should see 10 files in the response. Verify the response time to list 10 files is much less than for 100 files.

Alternatively, test using beta. 
1. Use this resource id (**b7b75f28536a4bc79af80a51763f05b7**) to test the file list endpoint.
2. You should see 504 timeout error.
3. Deploy this branch to beta.
4. Then use the same resource id to test file list endpoint. Verify you don't see 504 timeout error. You should see a list of 100 files in the response. 