### PR TITLE
[#5126] optimize search for readme file

### DIFF
--- a/hs_composite_resource/tests/test_composite_resource.py
+++ b/hs_composite_resource/tests/test_composite_resource.py
@@ -10,45 +10,40 @@ from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import UploadedFile
 from django.test import TransactionTestCase
 from django.urls import reverse
-from django.db import reset_queries, connection
 from rest_framework import status
 
 from hs_composite_resource.models import CompositeResource
 from hs_core import hydroshare
 from hs_core.hydroshare.utils import (
-    resource_file_add_process,
-    get_resource_by_shortkey,
     ResourceVersioningException,
-    add_file_to_resource,
-    get_file_from_irods,
+    add_file_to_resource, get_file_from_irods,
+    get_resource_by_shortkey, resource_file_add_process
 )
 from hs_core.models import BaseResource, ResourceFile
+from hs_core.tasks import FileOverrideException
 from hs_core.testing import MockIRODSTestCaseMixin
 from hs_core.views.utils import (
-    create_folder,
+    add_reference_url_to_resource,
+    create_folder, delete_resource_file,
+    edit_reference_url_in_resource,
     move_or_rename_file_or_folder,
     remove_folder,
-    unzip_file,
-    add_reference_url_to_resource,
-    edit_reference_url_in_resource,
-    delete_resource_file,
-    zip_by_aggregation_file,
+    unzip_file, zip_by_aggregation_file
 )
 from hs_file_types.models import (
-    GenericLogicalFile,
-    GeoRasterLogicalFile,
-    GenericFileMetaData,
-    RefTimeseriesLogicalFile,
     FileSetLogicalFile,
-    NetCDFLogicalFile,
-    TimeSeriesLogicalFile,
+    GenericFileMetaData,
+    GenericLogicalFile,
     GeoFeatureLogicalFile,
+    GeoRasterLogicalFile,
     ModelInstanceLogicalFile,
     ModelProgramLogicalFile,
+    NetCDFLogicalFile,
+    RefTimeseriesLogicalFile,
+    TimeSeriesLogicalFile
 )
 from hs_file_types.models.base import METADATA_FILE_ENDSWITH, RESMAP_FILE_ENDSWITH
 from hs_file_types.tests.utils import CompositeResourceTestMixin
-from hs_core.tasks import FileOverrideException
 
 
 class CompositeResourceTest(
@@ -3931,7 +3926,6 @@ class CompositeResourceTest(
         with self.assertNumQueries(_LANDING_PAGE_NO_RES_FILE_QUERY_COUNT):
             response = self.client.get(f'/resource/{self.composite_resource.short_id}', follow=True)
             self.assertTrue(response.status_code == 200)
-
 
         # test resource landing page with resource files
         # add a file to the resource

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -120,12 +120,10 @@ def res_has_web_reference(res):
     if res.resource_type != "CompositeResource":
         return False
 
-    for f in ResourceFile.objects.filter(object_id=res.id):
-        if f.has_logical_file:
-            if 'url' in f.logical_file.extra_data:
-                return True
+    for lf in res.get_logical_files('GenericLogicalFile'):
+        if 'url' in lf.extra_data:
+            return True
     return False
-
 
 def get_science_metadata(pk):
     """

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -125,6 +125,7 @@ def res_has_web_reference(res):
             return True
     return False
 
+
 def get_science_metadata(pk):
     """
     Describes the resource identified by the pid by returning the associated science metadata

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2679,10 +2679,14 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
         res_files_at_root = self.files.filter(file_folder='')
         readme_txt_file = None
         readme_md_file = None
+        def get_file_name(f):
+            return os.path.basename(f.get_storage_path(resource=self)).lower()
+
         for res_file in res_files_at_root:
-            if res_file.file_name.lower() == 'readme.md':
+            file_name = get_file_name(res_file)
+            if file_name == 'readme.md':
                 readme_md_file = res_file
-            elif res_file.file_name.lower() == 'readme.txt':
+            elif file_name == 'readme.txt':
                 readme_txt_file = res_file
             if readme_md_file is not None:
                 break
@@ -3135,6 +3139,13 @@ class ResourceFile(ResourceFileIRODSMixin):
         # instance.content_object can be stale after changes.
         # Re-fetch based upon key; bypass type system; it is not relevant
         resource = self.resource
+        return self.get_storage_path(resource)
+
+    def get_storage_path(self, resource):
+        """Return the qualified name for a file in the storage hierarchy.
+        Note: This is the preferred way to get the storage path for a file when we are trying to find
+        the storage path for more than one file in a resource.
+        """
         if resource.is_federated:  # false if None or empty
             if __debug__:
                 assert self.resource_file.name is None or \

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2679,6 +2679,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
         res_files_at_root = self.files.filter(file_folder='')
         readme_txt_file = None
         readme_md_file = None
+
         def get_file_name(f):
             return os.path.basename(f.get_storage_path(resource=self)).lower()
 


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource. Upload a readme.md or readme.txt file to the root of the resource. Upload few other files.
2. Create an external web reference aggregation, by right clicking inside the file list area of the UI and selecting the option "Add content from the web"
3. Access the resource landing page. Verify that the contents of the readme file are displayed as well as the aggregation that you created is displayed.

