### PR TITLE
[#5135] bag_modified->False after create zip

### DIFF
--- a/django_irods/views.py
+++ b/django_irods/views.py
@@ -280,7 +280,7 @@ def download(request, path, use_async=True, use_reverse_proxy=True,
             bag_modified = res.getAVU("bag_modified")
             if bag_modified is None or bag_modified or not istorage.exists(irods_output_path):
                 res.setAVU("bag_modified", True)  # ensure bag_modified is set when irods_output_path does not exist
-                create_bag_by_irods(res_id, False)
+                create_bag_by_irods(res_id, create_zip=False)
 
         # send signal for pre download file
         # TODO: does not contain subdirectory information: duplicate refreshes possible

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -723,6 +723,7 @@ def add_resource_files(pk, *files, **kwargs):
     else:
         if resource.resource_type == "CompositeResource" and auto_aggregate:
             utils.check_aggregations(resource, ret)
+        utils.resource_modified(resource, user, overwrite_bag=False)
 
     return ret
 

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -992,8 +992,6 @@ def resource_file_add_process(resource, files, user, extract_metadata=False,
                                     res_files=resource_file_objects, **kwargs)
 
     check_file_dict_for_error(file_validation_dict)
-
-    resource_modified(resource, user, overwrite_bag=False)
     return resource_file_objects
 
 

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -540,7 +540,6 @@ def create_bag_by_irods(resource_id, create_zip=True):
     bag_modified = bag_modified is None or bag_modified
     if metadata_dirty or bag_modified:
         create_bagit_files_by_irods(res, istorage)
-        res.setAVU("bag_modified", False)
 
     if create_zip:
         irods_bagit_input_path = res.get_irods_path(resource_id, prepend_short_id=False)
@@ -557,6 +556,7 @@ def create_bag_by_irods(resource_id, create_zip=True):
                     # compute checksum to meet DataONE distribution requirement
                     chksum = istorage.checksum(bag_path)
                     res.bag_checksum = chksum
+                res.setAVU("bag_modified", False)
                 return res.bag_url
             except SessionException as ex:
                 raise SessionException(-1, '', ex.stderr)

--- a/hs_core/tests/api/native/test_add_resource_files.py
+++ b/hs_core/tests/api/native/test_add_resource_files.py
@@ -121,3 +121,16 @@ class TestAddResourceFiles(MockIRODSTestCaseMixin, unittest.TestCase):
         except QuotaException as ex:
             self.fail("add resource file action should not raise QuotaException for "
                       "over quota cases if quota is not enforced - Quota Exception: " + str(ex))
+
+    def test_add_files_toggles_bag_flag(self):
+        # create a resource
+        self.res = create_resource(resource_type='CompositeResource',
+                                   owner=self.user,
+                                   title='Test Resource',
+                                   metadata=[], )
+        self.res.setAVU('bag_modified', 'false')
+        self.assertFalse(self.res.getAVU('bag_modified'))
+        # add files - this is the api we are testing
+        add_resource_files(self.res.short_id, self.myfile1, self.myfile2, self.myfile3)
+
+        self.assertTrue(self.res.getAVU('bag_modified'))

--- a/hs_core/tests/api/native/test_bagit.py
+++ b/hs_core/tests/api/native/test_bagit.py
@@ -8,7 +8,12 @@ from hs_core.tasks import create_bag_by_irods
 from hs_core.models import BaseResource
 from django_irods.storage import IrodsStorage
 from hs_core.task_utils import _retrieve_task_id
+from hs_core.tests.api.utils import prepare_resource as prepare_resource_util
 
+def prepare_resource(self, folder, upload_to=""):
+    test_bag_path = 'hs_core/tests/data/test_resource_metadata_files.zip'
+    extracted_directory = 'hs_core/tests/data/test_resource_metadata_files/'
+    prepare_resource_util(folder, self.test_res, self.user, extracted_directory, test_bag_path, upload_to)
 
 class TestBagIt(TestCase):
     def setUp(self):
@@ -59,6 +64,19 @@ class TestBagIt(TestCase):
         istorage = self.test_res.get_irods_storage()
         bag_path = self.test_res.bag_path
         self.assertFalse(istorage.exists(bag_path))
+
+    def test_bag_file_create_zip(self):
+        bag_modified = lambda: self.test_res.getAVU('bag_modified')
+
+        create_bag_by_irods(self.test_res.short_id, create_zip=True)
+        self.assertFalse(bag_modified())
+
+        prepare_resource(self, 'single_file')
+        self.assertTrue(bag_modified())
+
+        create_bag_by_irods(self.test_res.short_id, create_zip=False)
+        # Bag modified doesn't get toggled when create_zip = False
+        self.assertTrue(bag_modified())
 
     def test_retrieve_create_bag_by_irods_task_id(self):
         mock_res_id = '84d1b8b60f274ba4be155881129561a9'

--- a/hs_core/tests/api/native/test_bagit.py
+++ b/hs_core/tests/api/native/test_bagit.py
@@ -9,11 +9,8 @@ from hs_core.tasks import create_bag_by_irods
 from hs_core.models import BaseResource
 from django_irods.storage import IrodsStorage
 from hs_core.task_utils import _retrieve_task_id
-from hs_core.tests.api.utils import prepare_resource as prepare_resource_util
-
-
-def prepare_resource(self, folder, upload_to=""):
-    prepare_resource_util(folder, self.test_res, self.user, self.extracted_directory, self.test_bag_path, upload_to)
+from django.core.files.uploadedfile import UploadedFile
+from hs_core.hydroshare.resource import add_resource_files
 
 
 class TestBagIt(TestCase):
@@ -35,18 +32,18 @@ class TestBagIt(TestCase):
             self.user,
             'My Test Resource'
         )
-        self.test_bag_path = 'hs_core/tests/data/test_resource_metadata_files.zip'
-        self.extracted_directory = 'hs_core/tests/data/test_resource_metadata_files/'
+        self.readme_md = "readme.md"
+        self.readme_md_file = open(self.readme_md, 'w')
+        self.readme_md_file.write("##This is a readme markdown file")
+        self.readme_md_file.close()
 
     def tearDown(self):
         super(TestBagIt, self).tearDown()
-        try:
-            os.remove(self.test_bag_path)
-        except OSError:
-            pass
         if self.test_res:
             self.test_res.delete()
         BaseResource.objects.all().delete()
+        self.readme_md_file.close()
+        os.remove(self.readme_md_file.name)
 
     def test_create_bag_files(self):
         # this is the api call we are testing
@@ -79,7 +76,8 @@ class TestBagIt(TestCase):
         create_bag_by_irods(self.test_res.short_id, create_zip=True)
         self.assertFalse(bag_modified())
 
-        prepare_resource(self, 'single_file')
+        files_to_add = [self.readme_md]
+        self._add_files_to_resource(files_to_add)
         self.assertTrue(bag_modified())
 
         create_bag_by_irods(self.test_res.short_id, create_zip=False)
@@ -126,3 +124,12 @@ class TestBagIt(TestCase):
                                                                       "mock_active_and_reserved_job_id")
         ret_id = _retrieve_task_id(job_name, mock_res_id, mock_scheduled_jobs)
         self.assertEqual(ret_id, mock_scheduled_job_id, msg="retrieved task id not equal to mock_scheduled_job_id")
+
+    def _add_files_to_resource(self, files_to_add, upload_folder=''):
+        files_to_upload = []
+        for fl in files_to_add:
+            file_to_upload = UploadedFile(file=open(fl, 'rb'), name=os.path.basename(fl))
+            files_to_upload.append(file_to_upload)
+        added_resource_files = add_resource_files(self.test_res.short_id,
+                                                  *files_to_upload, folder=upload_folder)
+        return added_resource_files

--- a/hs_core/tests/api/native/test_bagit.py
+++ b/hs_core/tests/api/native/test_bagit.py
@@ -1,3 +1,4 @@
+import os
 from django.contrib.auth.models import Group
 from django.test import TestCase
 
@@ -10,10 +11,10 @@ from django_irods.storage import IrodsStorage
 from hs_core.task_utils import _retrieve_task_id
 from hs_core.tests.api.utils import prepare_resource as prepare_resource_util
 
+
 def prepare_resource(self, folder, upload_to=""):
-    test_bag_path = 'hs_core/tests/data/test_resource_metadata_files.zip'
-    extracted_directory = 'hs_core/tests/data/test_resource_metadata_files/'
-    prepare_resource_util(folder, self.test_res, self.user, extracted_directory, test_bag_path, upload_to)
+    prepare_resource_util(folder, self.test_res, self.user, self.extracted_directory, self.test_bag_path, upload_to)
+
 
 class TestBagIt(TestCase):
     def setUp(self):
@@ -34,9 +35,15 @@ class TestBagIt(TestCase):
             self.user,
             'My Test Resource'
         )
+        self.test_bag_path = 'hs_core/tests/data/test_resource_metadata_files.zip'
+        self.extracted_directory = 'hs_core/tests/data/test_resource_metadata_files/'
 
     def tearDown(self):
         super(TestBagIt, self).tearDown()
+        try:
+            os.remove(self.test_bag_path)
+        except OSError:
+            pass
         if self.test_res:
             self.test_res.delete()
         BaseResource.objects.all().delete()
@@ -66,7 +73,8 @@ class TestBagIt(TestCase):
         self.assertFalse(istorage.exists(bag_path))
 
     def test_bag_file_create_zip(self):
-        bag_modified = lambda: self.test_res.getAVU('bag_modified')
+        def bag_modified():
+            return self.test_res.getAVU('bag_modified')
 
         create_bag_by_irods(self.test_res.short_id, create_zip=True)
         self.assertFalse(bag_modified())


### PR DESCRIPTION
This PR is a replica of https://github.com/hydroshare/hydroshare/pull/5136 but uses a rebase to avoid other issues merged to Develop branch.

Intent is to release this as hotfix 2.7.1

Resolves #5135 
I think it will also resolve #5128
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a new resource
2. Add a file to the resource
3. Download the resourcemap.xml using for example: http://localhost:8000/resource/RESID/data/resourcemap.xml
4. Use the File Browser UI to download the resource as a zip
5. See that the zip data/contents/ contains the file that you added to the resource
