### PR TITLE
[#5157] Add CUAHSI SSO messaging

### DIFF
--- a/hs_core/middleware.py
+++ b/hs_core/middleware.py
@@ -1,0 +1,27 @@
+class SunsetMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        from django.utils.http import http_date
+        from datetime import datetime
+
+        response = self.get_response(request)
+        auth = request.headers.get('Authorization')
+        if not auth or 'Basic' not in auth:
+            return response
+
+        deprecation_date = datetime(2024, 4, 1)
+        http_deprecation = http_date(deprecation_date.timestamp())
+
+        if datetime.now() > deprecation_date:
+            response['Deprecation'] = http_deprecation
+            # TODO: link to help page re CUAHSI SSO
+            response['Link'] = '''<https://help.hydroshare.org>; rel="deprecation"; type="text/html"'''
+        else:
+            # https://datatracker.ietf.org/doc/html/rfc8594
+            response['Sunset'] = http_deprecation
+            # TODO: link to help page re CUAHSI SSO
+            response['Link'] = '''<https://help.hydroshare.org>; rel="sunset"; type="text/html"'''
+        return response

--- a/hs_core/middleware.py
+++ b/hs_core/middleware.py
@@ -14,14 +14,12 @@ class SunsetMiddleware:
 
         deprecation_date = datetime(2024, 4, 1)
         http_deprecation = http_date(deprecation_date.timestamp())
-
+        help_link = "https://help.hydroshare.org/about-hydroshare/cuahsi-single-sign-on/"
         if datetime.now() > deprecation_date:
             response['Deprecation'] = http_deprecation
-            # TODO: link to help page re CUAHSI SSO
-            response['Link'] = '''<https://help.hydroshare.org>; rel="deprecation"; type="text/html"'''
+            response['Link'] = f'''<{help_link}>; rel="deprecation"; type="text/html"'''
         else:
             # https://datatracker.ietf.org/doc/html/rfc8594
             response['Sunset'] = http_deprecation
-            # TODO: link to help page re CUAHSI SSO
-            response['Link'] = '''<https://help.hydroshare.org>; rel="sunset"; type="text/html"'''
+            response['Link'] = f'''<{help_link}>; rel="sunset"; type="text/html"'''
         return response

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -439,6 +439,7 @@ MIDDLEWARE = (
     "mezzanine.core.middleware.FetchFromCacheMiddleware",
     "hs_core.robots.RobotFilter",
     "hs_tracking.middleware.Tracking",
+    "hs_core.middleware.SunsetMiddleware",
 )
 
 # security settings

--- a/theme/templates/accounts/account_login.html
+++ b/theme/templates/accounts/account_login.html
@@ -25,8 +25,9 @@
                     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
                     <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
                     <strong> Attention:</strong>
-                    <br>Hydroshare will soon migrate to 
-                    <a href="https://help.hydroshare.org/about-hydroshare/cuahsi-single-sign-on/" target="_blank">CUAHSI single sign-on</a>.
+                    <br>
+                    <a href="https://help.hydroshare.org/about-hydroshare/cuahsi-single-sign-on/" target="_blank">CUAHSI single sign-on</a>
+                    will soon be available in HydroShare.
                 </div>
 
                 {% if form.non_field_errors %}

--- a/theme/templates/accounts/account_login.html
+++ b/theme/templates/accounts/account_login.html
@@ -24,8 +24,9 @@
                 <div class="col-md-12 alert alert-success alert-dissmissable">
                     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
                     <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-                    <!-- TODO: update help link for CUAHSI SSO -->
-                    <strong> Attention:</strong><br>Hydroshare will soon migrate to <a href="https://help.hydroshare.org" target="_blank">CUAHSI single sign-on</a>.
+                    <strong> Attention:</strong>
+                    <br>Hydroshare will soon migrate to 
+                    <a href="https://help.hydroshare.org/about-hydroshare/cuahsi-single-sign-on/" target="_blank">CUAHSI single sign-on</a>.
                 </div>
 
                 {% if form.non_field_errors %}

--- a/theme/templates/accounts/account_login.html
+++ b/theme/templates/accounts/account_login.html
@@ -26,7 +26,6 @@
                     <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
                     <!-- TODO: update help link for CUAHSI SSO -->
                     <strong> Attention:</strong><br>Hydroshare will soon migrate to <a href="https://help.hydroshare.org" target="_blank">CUAHSI single sign-on</a>.
-                    If you want, you can <a href="{% url 'oidc_authentication_init' %}">try it now</a>.
                 </div>
 
                 {% if form.non_field_errors %}

--- a/theme/templates/accounts/account_login.html
+++ b/theme/templates/accounts/account_login.html
@@ -15,13 +15,19 @@
         </div>
         {% else %}
             {{ block.super }}
-
         <div class="col-xs-12">
             <h2 class="page-title">Sign In</h2>
         </div>
         <div class="col-xs-12 col-sm-6">
             <form class="account-form has-space-bottom" method="post"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
                 {% csrf_token %}
+                <div class="col-md-12 alert alert-success alert-dissmissable">
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                    <!-- TODO: update help link for CUAHSI SSO -->
+                    <strong> Attention:</strong><br>Hydroshare will soon migrate to <a href="https://help.hydroshare.org" target="_blank">CUAHSI single sign-on</a>.
+                    If you want, you can <a href="{% url 'oidc_authentication_init' %}">try it now</a>.
+                </div>
 
                 {% if form.non_field_errors %}
                     <div class="form-errors">


### PR DESCRIPTION
Partially resolves #5157 by 

- adding sunset headers for requests made with basic auth
- adding notification of impending CUAHSI SSO migration on the sign-in page

Intent is that this PR be released as 2.9.2 minor release ASAP to be followed by https://github.com/hydroshare/hydroshare/pull/5152 a couple weeks later as 2.10

In addition to deploying this PR, we would add banner notification:
“Attention: HydroShare login will soon transition to CUAHSI single sign on. Click here to learn more.”

![image](https://github.com/hydroshare/hydroshare/assets/17934193/ec514a22-3ddd-4eef-9c83-b7ede3131679)

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Make a request with basic auth to any hsapi endpoint.
2. Response headers should contain the sunset header
``` allow: GET,HEAD,OPTIONS  content-language: en  content-length: 112  content-type: application/json  date: Thu,14 Sep 2023 15:22:15 GMT  link: <https://help.hydroshare.org>; rel="sunset"; type="text/html"  server: WSGIServer/0.2 CPython/3.9.16  sunset: Mon,01 Apr 2024 00:00:00 GMT  vary: Accept,Origin,Accept-Language,Cookie ```
