### PR TITLE
[#4091] my resources optimization

### DIFF
--- a/hs_composite_resource/tests/test_composite_resource.py
+++ b/hs_composite_resource/tests/test_composite_resource.py
@@ -3882,33 +3882,75 @@ class CompositeResourceTest(
                 self.assertIn(f, aggr_files)
             shutil.rmtree(os.path.dirname(temp_zip_file))
 
-    def test_composite_resource_my_resources_scales(self):
-        # test that db queries for "my_resources" remain constant when adding more resources
+    def test_composite_resource_my_resources_one(self):
+        # test that only a fixed number of db queries (based on the number of resources) are
+        # generated for "my_resources" page - this test is with one resource.
 
         # there should not be any resource at this point
         self.assertEqual(BaseResource.objects.count(), 0)
 
+        self.client.login(username='user1', password='mypassword1')
         # navigating to home page for initializing db queries
         response = self.client.get(reverse("home"), follow=True)
         self.assertTrue(response.status_code == 200)
-        my_resources_query_count = 7
-        self.create_composite_resource()
-        with self.assertNumQueries(my_resources_query_count):
-            response = self.client.get(reverse("my_resources"), follow=True)
-            self.assertTrue(response.status_code == 200)
 
+        # create 1 composite resource
+        self.create_composite_resource()
         # there should be one resource at this point
-        self.assertEqual(BaseResource.objects.count(), 1)
-        self.assertEqual(self.composite_resource.resource_type, "CompositeResource")
-
-        self.create_composite_resource()
-
-        with self.assertNumQueries(my_resources_query_count):
+        number_of_resources = BaseResource.objects.count()
+        self.assertEqual(number_of_resources, 1)
+        expected_query_count = self._get_expected_query_count(number_of_resources)
+        with self.assertNumQueries(expected_query_count):
             response = self.client.get(reverse("my_resources"), follow=True)
             self.assertTrue(response.status_code == 200)
 
-        # there should be two resources at this point
-        self.assertEqual(BaseResource.objects.count(), 2)
+    def test_composite_resource_my_resources_two(self):
+        # test that only a fixed number of db queries (based on the number of resources) are
+        # generated for "my_resources" page - this test is with two resources.
+
+        # there should not be any resource at this point
+        self.assertEqual(BaseResource.objects.count(), 0)
+
+        self.client.login(username='user1', password='mypassword1')
+        # navigating to home page for initializing db queries
+        response = self.client.get(reverse("home"), follow=True)
+        self.assertTrue(response.status_code == 200)
+
+        # create 2 composite resources
+        for _ in range(2):
+            self.create_composite_resource()
+
+        # there should be 2 resources at this point
+        number_of_resources = BaseResource.objects.count()
+        self.assertEqual(number_of_resources, 2)
+        expected_query_count = self._get_expected_query_count(number_of_resources)
+        with self.assertNumQueries(expected_query_count):
+            response = self.client.get(reverse("my_resources"), follow=True)
+            self.assertTrue(response.status_code == 200)
+
+    def test_composite_resource_my_resources_three(self):
+        # test that only a fixed number of db queries (based on the number of resources) are
+        # generated for "my_resources" page - this test is with three resources.
+
+        # there should not be any resource at this point
+        self.assertEqual(BaseResource.objects.count(), 0)
+
+        self.client.login(username='user1', password='mypassword1')
+        # navigating to home page for initializing db queries
+        response = self.client.get(reverse("home"), follow=True)
+        self.assertTrue(response.status_code == 200)
+
+        # create 3 composite resources
+        for _ in range(3):
+            self.create_composite_resource()
+
+        # there should be 3 resources at this point
+        number_of_resources = BaseResource.objects.count()
+        self.assertEqual(number_of_resources, 3)
+        expected_query_count = self._get_expected_query_count(number_of_resources)
+        with self.assertNumQueries(expected_query_count):
+            response = self.client.get(reverse("my_resources"), follow=True)
+            self.assertTrue(response.status_code == 200)
 
     def test_composite_resource_landing_scales(self):
         # test that db queries for landing page have constant time complexity
@@ -3969,3 +4011,19 @@ class CompositeResourceTest(
         # accessing the readme file should only be 1 db query
         with self.assertNumQueries(1):
             _ = self.composite_resource.readme_file
+
+    def _get_expected_query_count(self, number_of_resources):
+        # this is the expected number of queries for "my_resources" page with no resources
+        base_query_count = 15
+
+        # this is additional number of queries per resource
+        # 3 are mezzanine queries (can't do much about it)
+        # 3 queries are our code in template
+        per_resource_query_count = 6
+
+        # these are additional queries generated by get_my_resources_list() function
+        pre_template_query_count = 4 + number_of_resources
+
+        expected_query_count = base_query_count + pre_template_query_count
+        expected_query_count += per_resource_query_count * number_of_resources
+        return expected_query_count

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2085,7 +2085,9 @@ class AbstractResource(ResourcePermissionsMixin, ResourceIRODSMixin):
     @property
     def last_updated(self):
         """Return the last updated date stored in metadata"""
-        return self.metadata.dates.all().filter(type='modified')[0].start_date
+        for dt in self.metadata.dates.all():
+            if dt.type == 'modified':
+                return dt.start_date
 
     @property
     def has_required_metadata(self):
@@ -4245,7 +4247,7 @@ class CoreMetaData(models.Model, RDF_MetaData_Mixin):
     @property
     def title(self):
         """Return the first title object from metadata."""
-        return self._title.all().first()
+        return self._title.all()[0]
 
     @property
     def description(self):

--- a/hs_core/templates/pages/my-resources.html
+++ b/hs_core/templates/pages/my-resources.html
@@ -67,29 +67,32 @@
             </tr>
           </thead>
           <tbody>
-            {% if user.ulabels.saved_labels %}
-            {% for label in user.ulabels.saved_labels %}
-            <tr>
-              <td class="user-label" data-label="{{ label }}">{{ label }}</td>
-              <td>
-                <form class="hidden-form" data-id="form-delete-label-{{ label }}"
-                  action="/hsapi/_internal/label-resource-action/" method="post">
-                  {% csrf_token %}
-                  <input type="hidden" name="label" value="{{ label }}">
-                  <input type="hidden" name="label_type" value="SAVEDLABEL">
-                  <input type="hidden" name="action" value="DELETE">
-                </form>
-                <span data-label="{{ label }}" data-form-type="delete-label"
-                  class="btn-label-remove glyphicon glyphicon-remove"
-                  data-form-id="form-delete-label-{{ label }}"></span>
-              </td>
-            </tr>
-            {% endfor %}
-            {% else %}
-            <tr class="no-items-found">
-              <td>No labels found.</td>
-            </tr>
-            {% endif %}
+            {# QUERY COUNT: this generates 2 queries - not dependent of the number of resources #}
+            {%  with saved_labels=user.ulabels.saved_labels %}
+                {% if saved_labels %}
+                {% for label in saved_labels %}
+                <tr>
+                  <td class="user-label" data-label="{{ label }}">{{ label }}</td>
+                  <td>
+                    <form class="hidden-form" data-id="form-delete-label-{{ label }}"
+                      action="/hsapi/_internal/label-resource-action/" method="post">
+                      {% csrf_token %}
+                      <input type="hidden" name="label" value="{{ label }}">
+                      <input type="hidden" name="label_type" value="SAVEDLABEL">
+                      <input type="hidden" name="action" value="DELETE">
+                    </form>
+                    <span data-label="{{ label }}" data-form-type="delete-label"
+                      class="btn-label-remove glyphicon glyphicon-remove"
+                      data-form-id="form-delete-label-{{ label }}"></span>
+                  </td>
+                </tr>
+                {% endfor %}
+                {% else %}
+                <tr class="no-items-found">
+                  <td>No labels found.</td>
+                </tr>
+                {% endif %}
+          {% endwith %}
           </tbody>
         </table>
       </div>
@@ -124,6 +127,7 @@
 {% endblock %}
 
 {# To be used for querying the table in javascrip t#}
+{# QUERY COUNT: this generates 1 query - not dependent on the number of resources #}
 <input id="currentUserName" value="{{ user|best_name }}" style="display:none">
 <span id="csrf">{% csrf_token %}</span>
 

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -2743,7 +2743,7 @@ def my_resources(request, *args, **kwargs):
     """
     View for listing resources that belong to a given user.
 
-    Renders either a full my-resources page, or just a table of new resorces
+    Renders either a full my-resources page, or just a table of new resources
     """
 
     if not request.is_ajax():

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -968,6 +968,8 @@ def delete_resource(request, shortkey, usertext, *args, **kwargs):
             "An obsoleted resource in the middle of the obsolescence chain cannot be deleted.",
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+    res_title = res.metadata.title
     if request.is_ajax():
         task_id = get_resource_delete_task(shortkey)
         if not task_id:
@@ -989,7 +991,7 @@ def delete_resource(request, shortkey, usertext, *args, **kwargs):
             user=user,
             resource_shortkey=shortkey,
             resource=res,
-            resource_title=res.metadata.title,
+            resource_title=res_title,
             resource_type=res.resource_type,
             **kwargs,
         )
@@ -1005,7 +1007,7 @@ def delete_resource(request, shortkey, usertext, *args, **kwargs):
                 user=user,
                 resource_shortkey=shortkey,
                 resource=res,
-                resource_title=res.metadata.title,
+                resource_title=res_title,
                 resource_type=res.resource_type,
                 **kwargs,
             )

--- a/theme/templates/includes/my-resources-trows.html
+++ b/theme/templates/includes/my-resources-trows.html
@@ -73,7 +73,7 @@
     {% endif %}
     {% endfor %}
   </td>
-   {# QUERY COUNT: this generates (res|get_user_privilege:user) generates 3 queries per resource)  #}
+   {# QUERY COUNT: this (res|get_user_privilege:user) generates 3 queries per resource)  #}
   <td>{% if request.user.is_authenticated %}{{ res|get_user_privilege:user }}{% endif %}</td>
   <td class="col-labels">
     {# QUERY COUNT: this will generate 1 query only if the user has labels for the resource #}

--- a/theme/templates/includes/my-resources-trows.html
+++ b/theme/templates/includes/my-resources-trows.html
@@ -73,8 +73,10 @@
     {% endif %}
     {% endfor %}
   </td>
+   {# QUERY COUNT: this generates (res|get_user_privilege:user) generates 3 queries per resource)  #}
   <td>{% if request.user.is_authenticated %}{{ res|get_user_privilege:user }}{% endif %}</td>
   <td class="col-labels">
+    {# QUERY COUNT: this will generate 1 query only if the user has labels for the resource #}
     {% for label in res|user_resource_labels:user %}
     {% if forloop.counter0 > 0 %},{% endif %}{{ label }}
     {% endfor %}


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. The query optimization implemented in this PR, will be noticeable in terms of page load time for the 'my-resources' page by users who have large number of owned resources (~200).
2. For the purpose of testing page load improvement, you have to create at least 100 resources. Then compare the page load time for the 'my-resources' page between this branch and develop branch. You should see better page load time with this branch compared to the develop branch. 