### PR TITLE
include resource id in stats command

### DIFF
--- a/hs_tracking/management/commands/stats.py
+++ b/hs_tracking/management/commands/stats.py
@@ -149,7 +149,8 @@ class Command(BaseCommand):
             'size',
             'publication status',
             'user type',
-            'user id'
+            'user id',
+            'resource id'
         ]
         w.writerow(fields)
         failed_resource_ids = []
@@ -163,7 +164,8 @@ class Command(BaseCommand):
                     r.size,
                     r.raccess.sharing_status,
                     r.user.userprofile.user_type,
-                    r.user_id
+                    r.user_id,
+                    r.short_id
                 ]
                 w.writerow([str(v) for v in values])
 


### PR DESCRIPTION
Will require updating Jenkins job with proper headers and same for docker-elk logstash ingestion
resolves #5216
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource
2. run `./hsctl managepy stats --resources-details`
3. See that the resource id is included on the stdout
