### PR TITLE
[#5240] disable spatial query in hsapi

### DIFF
--- a/hs_core/tests/api/rest/test_resource_list.py
+++ b/hs_core/tests/api/rest/test_resource_list.py
@@ -3,6 +3,7 @@ import os
 
 from django.core.files.uploadedfile import UploadedFile
 from rest_framework import status
+from unittest import skip
 
 from hs_core.hydroshare import resource
 from hs_file_types.models import GenericLogicalFile, GenericFileMetaData
@@ -149,6 +150,7 @@ class TestResourceList(HSRESTTestCase):
         self.assertIn(gen_res_one.short_id, result_res_id_list,
                       msg='obsoleted resource id is not included in returned resource list')
 
+    @skip("re-enable after resolution of https://github.com/hydroshare/hydroshare/issues/5240")
     def test_resource_list_by_bounding_box(self):
         metadata_dict_one = [{'coverage': {'type': 'point', 'value': {'north': '70',
                                                                       'east': '70',

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -261,6 +261,11 @@ class ResourceListCreate(generics.ListCreateAPIView):
             raise ValidationError(detail=resource_list_request_validator.errors)
 
         filter_parms = resource_list_request_validator.validated_data
+
+        if filter_parms['coverage_type']:
+            site_url = hydroshare.utils.current_site_url()
+            message = f"Spatial query is currently disabled in hsapi. Please use discover: {site_url}/search"
+            raise ValidationError(detail=message)
         filter_parms['user'] = (self.request.user if self.request.user.is_authenticated else None)
         if len(filter_parms['type']) == 0:
             filter_parms['type'] = None

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -262,7 +262,7 @@ class ResourceListCreate(generics.ListCreateAPIView):
 
         filter_parms = resource_list_request_validator.validated_data
 
-        if filter_parms['coverage_type']:
+        if 'coverage_type' in filter_parms:
             site_url = hydroshare.utils.current_site_url()
             message = f"Spatial query is currently disabled in hsapi. Please use discover: {site_url}/search"
             raise ValidationError(detail=message)


### PR DESCRIPTION
Right now spatial queries of any kind on `/hsapi/resource` endpoint will timeout.
This causes one of our gunicorn workers to remain at 100% CPU for ~300sec.
If multiple such requests are made in a short period of time, all of our gunicorn workers get tied and HS stops responding to any other requests.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. try a hsapi spatial query like the following `/hsapi/resource/?coverage_type=box`
2. see a validation error
