### PR TITLE
add ability to repair_resource as admin user

### DIFF
--- a/hs_core/management/commands/repair_resource.py
+++ b/hs_core/management/commands/repair_resource.py
@@ -100,6 +100,12 @@ class Command(BaseCommand):
             res_url = site_url + resource.absolute_url
             print("*" * 100)
             print(f"{current_resource}/{total_res_to_check}: Checking resource {res_url}")
+            if resource.raccess.published:
+                print("This Resource is published")
+                if admin:
+                    print("Command running with --admin. Published resources will be repaired if needed.")
+                else:
+                    print("Command running without --admin. Fixing a published resource raise ValidationError")
             _, missing_in_django, dangling_in_django = repair_resource(resource, logger, dry_run=dry_run, user=user)
             if dangling_in_django > 0 or missing_in_django > 0:
                 impacted_resources += 1

--- a/hs_core/management/utils.py
+++ b/hs_core/management/utils.py
@@ -267,7 +267,7 @@ def fix_resourcefile_duplicates(dry_run=False, logger=None, get_model=False):
 def check_irods_files(resource, stop_on_error=False, log_errors=True,
                       echo_errors=False, return_errors=False,
                       sync_ispublic=False, clean_irods=False, clean_django=False,
-                      dry_run=False):
+                      dry_run=False, user=None):
     """Check whether files in resource.files and on iRODS agree.
 
     :param resource: resource to check
@@ -319,7 +319,9 @@ def check_irods_files(resource, stop_on_error=False, log_errors=True,
                 msg = "check_irods_files: django file {} does not exist in iRODS"\
                     .format(file_storage_path)
                 if clean_django and not dry_run:
-                    delete_resource_file(resource.short_id, f.short_path, resource.creator,
+                    if not user:
+                        user = resource.creator
+                    delete_resource_file(resource.short_id, f.short_path, user,
                                          delete_logical_file=False)
                     msg += " (DELETED FROM DJANGO)"
                 if echo_errors:
@@ -729,7 +731,7 @@ class CheckJSONLD(object):
             return
 
 
-def repair_resource(resource, logger, dry_run=False):
+def repair_resource(resource, logger, dry_run=False, user=None):
 
     print("CHECKING IF RESOURCE {} NEEDS REPAIR".format(resource.short_id))
     now = timezone.now()
@@ -742,7 +744,8 @@ def repair_resource(resource, logger, dry_run=False):
                                                                            clean_irods=False,
                                                                            clean_django=True,
                                                                            sync_ispublic=True,
-                                                                           dry_run=dry_run)
+                                                                           dry_run=dry_run,
+                                                                           user=user)
     if ecount:
         print("... affected resource {} has type {}, title '{}'"
               .format(resource.short_id, resource.resource_type,


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource and add some files
2. Use the database or shell to remove some of the files from django to put the resource in  a "broken" state
3. Publish the resource
4. Run the `repair_resource --published --admin` management command and see that the published resource can now be fixed by the management script
