### PR TITLE
[#5265] failed celery task -- change notification email

### DIFF
--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -81,15 +81,16 @@ class FileOverrideException(Exception):
 
 class HydroshareRequest(Request):
     '''A Celery custom request to log failures.
-    https://docs.celeryq.dev/en/v4.4.7/userguide/tasks.html?#requests-and-custom-requests
+    https://docs.celeryq.dev/en/v5.2.7/userguide/tasks.html#requests-and-custom-requests
     '''
     def on_failure(self, exc_info, send_failed_event=True, return_ok=False):
         super(HydroshareRequest, self).on_failure(
             exc_info,
-            send_failed_event=send_failed_event,
-            return_ok=return_ok
+            # always mark failed
+            send_failed_event=True,
+            return_ok=False
         )
-        warning_message = f'Failure detected for task {self.task.name}'
+        warning_message = f"Failure detected for task {self.task.name}. Exception: {exc_info}"
         logger.warning(warning_message)
         if not settings.DISABLE_TASK_EMAILS:
             subject = 'Notification of failing Celery task'

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -93,7 +93,7 @@ class HydroshareRequest(Request):
         logger.warning(warning_message)
         if not settings.DISABLE_TASK_EMAILS:
             subject = 'Notification of failing Celery task'
-            send_mail(subject, warning_message, settings.DEFAULT_FROM_EMAIL, [settings.DEFAULT_SUPPORT_EMAIL])
+            send_mail(subject, warning_message, settings.DEFAULT_FROM_EMAIL, [settings.DEFAULT_FROM_EMAIL])
 
 
 class HydroshareTask(Task):


### PR DESCRIPTION
Related to #5265 we have some tasks that are failing (in that case due to iRods recursion)
Rather than emailing HELP on task failure, here we send email to `DEFAULT_FROM_EMAIL`
Also small change to make sure that tasks get marked FAILED.


<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
