### PR TITLE
[#5291] pin vue version @2.7.15

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -35,7 +35,10 @@
 {% compress js %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script type="text/javascript" src="{% static 'js/custom.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
+
+{# vue 2.7.16-beta.1 will break typeahead https://github.com/vuejs/vue/blob/main/CHANGELOG.md #}
+<script src="https://cdn.jsdelivr.net/npm/vue@2.7.15"></script>
+
 <script type="text/javascript" src="{% static 'js/scrolltopcontrol.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/jqcsrf.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/jquery-ui.js' %}"></script>


### PR DESCRIPTION
Resolves #5291 by pinning version of Vue that we fetch from CDN

The last version of Vue2 is 2.7.16. It was released last week. This caused issues with our bootstrap-typeahead implementation.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Start typing a Subject Keyword
2. See that the existing keywords no longer disappear 
