### PR TITLE
[#5321] Update timestamp in XML generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 
 RUN pip install mozilla-django-oidc
 RUN pip install spam_patterns@git+https://github.com/CUAHSI/spam_patterns.git@0.0.4
+RUN pip install freezegun
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -4023,8 +4023,7 @@ class BaseResource(Page, AbstractResource):
         # create the head sub element
         head_node = etree.SubElement(ROOT, 'head')
         etree.SubElement(head_node, 'doi_batch_id').text = self.short_id
-        etree.SubElement(head_node, 'timestamp').text = arrow.get(self.updated)\
-            .format("YYYYMMDDHHmmss")
+        etree.SubElement(head_node, 'timestamp').text = arrow.now().format("YYYYMMDDHHmmss")
         depositor_node = etree.SubElement(head_node, 'depositor')
         etree.SubElement(depositor_node, 'depositor_name').text = 'HydroShare'
         etree.SubElement(depositor_node, 'email_address').text = settings.DEFAULT_SUPPORT_EMAIL


### PR DESCRIPTION
Resolves #5321 by changing the `timestamp` in the XML deposited with Crossref
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Use the Crossref test API to submit a resource for publication
2. Then use the `update_crossref_metadata_deposit` management command to re-submit the XML for the resource (without any changes to the metadata)
3. See that the record in Crossref does not have a failure due to timestamp duplication
