### PR TITLE
[ #5335] Filter to ignored_repaired_since when repairing resource

### DIFF
--- a/hs_core/management/commands/repair_resource.py
+++ b/hs_core/management/commands/repair_resource.py
@@ -75,11 +75,13 @@ class Command(BaseCommand):
             print(f"FILTERING TO INCLUDE RESOURCES UPDATED IN LAST {updated_since} DAYS")
             if resources_ids:
                 print("Your supplied resource_ids will be filtered by the --updated_since days that you provided. ")
-            cuttoff_time = timezone.now() - timedelta(updated_since)
+            cuttoff_time = timezone.now() - timedelta(days=updated_since)
             resources = resources.filter(updated__gte=cuttoff_time)
 
         if ignore_repaired_since:
             print(f"FILTERING TO INCLUDE RESOURCES NOT REPAIRED IN THE LAST {ignore_repaired_since} DAYS")
+            if resources_ids:
+                print("Your supplied resource_ids will be filtered by the --ignore_repaired_since days provided. ")
             cuttoff_time = timezone.now() - timedelta(days=ignore_repaired_since)
             resources = resources.filter(Q(repaired__lt=cuttoff_time) | Q(repaired__isnull=True))
 

--- a/hs_core/management/commands/repair_resource.py
+++ b/hs_core/management/commands/repair_resource.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         parser.add_argument('resource_ids', nargs='*', type=str)
         parser.add_argument('--updated_since', type=int, dest='updated_since',
                             help='include only resources updated in the last X days')
-        parser.add_argument('--ingored_repaired_since', type=int, dest='ingored_repaired_since',
+        parser.add_argument('--ignore_repaired_since', type=int, dest='ignore_repaired_since',
                             help='ignore resources repaired since X days ago')
         parser.add_argument(
             '--admin',
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         dry_run = options['dry_run']
         published = options['published']
         site_url = hydroshare.utils.current_site_url()
-        ingored_repaired_since = options['ingored_repaired_since']
+        ignore_repaired_since = options['ignore_repaired_since']
 
         if resources_ids:  # an array of resource short_id to check.
             print("CHECKING RESOURCES PROVIDED")
@@ -78,9 +78,9 @@ class Command(BaseCommand):
             cuttoff_time = timezone.now() - timedelta(updated_since)
             resources = resources.filter(updated__gte=cuttoff_time)
 
-        if ingored_repaired_since:
-            print(f"FILTERING TO INCLUDE RESOURCES NOT REPAIRED IN THE LAST {ingored_repaired_since} DAYS")
-            cuttoff_time = timezone.now() - timedelta(days=ingored_repaired_since)
+        if ignore_repaired_since:
+            print(f"FILTERING TO INCLUDE RESOURCES NOT REPAIRED IN THE LAST {ignore_repaired_since} DAYS")
+            cuttoff_time = timezone.now() - timedelta(days=ignore_repaired_since)
             resources = resources.filter(repaired__lt=cuttoff_time)
 
         if dry_run:

--- a/hs_core/management/commands/repair_resource.py
+++ b/hs_core/management/commands/repair_resource.py
@@ -17,7 +17,7 @@ from hs_core.management.utils import repair_resource
 from hs_core.views.utils import get_default_admin_user
 from hs_core import hydroshare
 from django.utils import timezone
-from django.db.models import F
+from django.db.models import F, Q
 from datetime import timedelta
 
 import logging
@@ -81,7 +81,7 @@ class Command(BaseCommand):
         if ignore_repaired_since:
             print(f"FILTERING TO INCLUDE RESOURCES NOT REPAIRED IN THE LAST {ignore_repaired_since} DAYS")
             cuttoff_time = timezone.now() - timedelta(days=ignore_repaired_since)
-            resources = resources.filter(repaired__lt=cuttoff_time)
+            resources = resources.filter(Q(repaired__lt=cuttoff_time) | Q(repaired__isnull=True))
 
         if dry_run:
             print("CONDUCTING A DRY RUN: FIXES WILL NOT BE SAVED")


### PR DESCRIPTION
Resolves #5335 by adding ability to ignore recently repaired resources
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Create a resource and add some files
2. Use the database or shell to remove some of the files from django to put the resource in  a "broken" state
3. Publish the resource
4. Run the `hsctl managepy repair_resource --published --admin --ignore_repaired_since 7` management command and see that the published resource is repaired
5. Use the database or shell to remove some of the files from django to put the resource in  a "broken" state
6. Run the `hsctl managepy repair_resource --published --admin --ignore_repaired_since 7` management command and see that the resource is not repaired because you chose to `--ignore_repaired_since`
