### PR TITLE
Revert "Shift the node build work to the Hydroshare image build (multi-stage …"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,4 @@
-FROM node:14.14.0 as node-build
-
-ADD . /hydroshare
-
-WORKDIR /hydroshare/hs_discover
-
-RUN rm -rf static templates && \
-    mkdir static templates && \
-    mkdir templates/hs_discover && \
-    mkdir static/js && \
-    mkdir static/css && \
-    npm install && \
-    npm run build && \
-    mkdir -p static/js && \
-    mkdir -p static/css && \
-    cp -rp templates/hs_discover/js static/ && \
-    cp -rp templates/hs_discover/css static/ && \
-    cp -p templates/hs_discover/map.js static/js/ && \
-    echo "----------------js--------------------" && \
-    ls -l static/js && \
-    echo "--------------------------------------" && \
-    echo "----------------css-------------------" && \
-    ls -l static/css && \
-    echo "--------------------------------------" && \
-    cd static/ && \
-    cp js/app.*.js js/app.js && \
-    cp js/chunk-vendors.*.js js/chunk-vendors.js
-
 FROM hydroshare/hs_docker_base:7a6c581
-
-COPY --from=node-build /hydroshare /hydroshare
 
 # Set the locale. TODO - remove once we have a better alternative worked out
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/hs_discover/deploy.sh
+++ b/hs_discover/deploy.sh
@@ -1,0 +1,15 @@
+npm run build
+rm static/css/*.css
+rm static/js/*.js
+rm static/js/*.map
+mkdir -p static/css
+mkdir -p static/js
+cp templates/hs_discover/css/app*.css static/css/app.css
+cp templates/hs_discover/css/chunk-vendors*.css static/css/chunk-vendors.css
+cp templates/hs_discover/css/*.css static/css
+cp templates/hs_discover/js/app*.js static/js/app.js
+cp templates/hs_discover/js/*.js static/js
+cp templates/hs_discover/map.js static/js/map.js
+cp templates/hs_discover/js/*.map static/js/
+cp templates/hs_discover/js/chunk-vendors*.js static/js/chunk-vendors.js
+docker exec -it hydroshare python manage.py collectstatic --no-input

--- a/hsctl
+++ b/hsctl
@@ -360,6 +360,7 @@ rebuild_hs() {
     if [ "$2" == "--db" ]; then
         loaddb_hs;
     fi
+    dis_build
     echo "  - docker exec hydroshare chown -R hydro-service:storage-hydro /hydroshare /tmp /shared_tmp"
     docker exec hydroshare chown -R hydro-service:storage-hydro /hydroshare /tmp /shared_tmp
     if [ "${USE_NGINX}" = true ]; then
@@ -438,6 +439,54 @@ reset_all_hs() {
     if [[ -f run-server ]]; then rm -f run-server; fi
     if [[ -f schema.xml ]]; then rm -f schema.xml; fi
     mkdir -p hydroshare/static/media
+}
+
+dis_build() {
+#### Set version pin variable ####
+#n_ver="15.0.0"
+n_ver="14.14.0"
+
+echo "Starting Node Build .... "
+
+### Create Directory structure outside to maintain correct permissions
+cd hs_discover
+rm -rf static templates
+mkdir static templates
+mkdir templates/hs_discover
+mkdir static/js
+mkdir static/css
+
+# Start Docker container and Run build
+docker run -i -v $HS_PATH:/hydroshare --name=nodejs node:$n_ver /bin/bash << eof
+
+cd hydroshare
+cd hs_discover
+npm install
+npm run build
+mkdir -p static/js
+mkdir -p static/css
+cp -rp templates/hs_discover/js static/
+cp -rp templates/hs_discover/css static/
+cp -p templates/hs_discover/map.js static/js/
+echo "----------------js--------------------"
+ls -l static/js
+echo "--------------------------------------"
+echo "----------------css-------------------"
+ls -l static/css
+echo "--------------------------------------"
+cd static/
+mv js/app.*.js js/app.js
+mv js/chunk-vendors.*.js js/chunk-vendors.js
+cd ..
+eof
+
+echo "Node Build completed ..."
+echo
+echo "Removing node container"
+docker container rm nodejs
+cd $HS_PATH
+sleep 1
+
 }
 
 ### Display usage if exactly one argument is not provided ###

--- a/local-build-discover.sh
+++ b/local-build-discover.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# Helper script intended for use when developing on hs_discover
+# Rebuild Discover as a static app without rebuilding other Hydroshare components
+
+machine="`uname -s`"
+case "$machine" in
+  Linux*)  export SED_EXT=''   ;;
+  Darwin*) export SED_EXT='.hydro-bk' ;;
+  *)       export SED_EXT=''   ;;
+esac
+
+### Local Config ###
+CONFIG_DIRECTORY='./config'
+CONFIG_FILE=${CONFIG_DIRECTORY}'/hydroshare-config.yaml'
+
+# This might be needed if the file has changed. 
+# git checkout -- $CONFIG_FILE  # refresh this in case overridden otherwise
+
+# Discover user and group under which this shell is running
+HS_UID=`id -u`
+HS_GID=`id -g`
+
+# Set this user and group in hydroshare-config.yaml
+sed -i 's/HS_SERVICE_UID:.*$/HS_SERVICE_UID: '$HS_UID'/' $CONFIG_DIRECTORY/hydroshare-config.yaml
+sed -i 's/HS_SERVICE_GID:.*$/HS_SERVICE_GID: '$HS_GID'/' $CONFIG_DIRECTORY/hydroshare-config.yaml
+
+# Read hydroshare-config.yaml into hydroshare-config.sh
+sed -e "s/:[^:\/\/]/=/g;s/$//g;s/ *=/=/g" ${CONFIG_FILE} | grep -v '^#' | grep -v ^$ > $CONFIG_DIRECTORY/hydroshare-config.sh
+
+# import hydroshare-config.sh into working environment
+while read line; do export $line; done < <(cat ${CONFIG_DIRECTORY}/hydroshare-config.sh)
+
+### Add color scheme to text | result output
+
+function blue() {
+    local TEXT="$1"
+    echo -n "\x1B[1;34m${TEXT}\x1B[0m"
+}
+
+function green() {
+    local TEXT
+    if [ "$1" == "" ]; then
+        TEXT=Done
+    else
+        TEXT="$1"
+    fi
+    echo -n "\x1B[1;32m${TEXT}\x1B[0m"
+}
+
+function red() {
+    local TEXT
+    if [ "$1" == "" ]; then
+        TEXT=Failure
+    else
+        TEXT="$1"
+    fi
+    echo -n "\x1B[31m${TEXT}\x1B[0m"
+}
+
+function getImageID() {
+    docker $DOCKER_PARAM images | grep $1 | tr -s ' ' | cut -f3 -d' '
+}
+
+##nodejs build for discovery
+
+node_build() {
+
+HS_PATH=`pwd`
+#### Set version pin variable ####
+#n_ver="15.0.0"
+n_ver="14.14.0"
+
+echo '####################################################################################################'
+echo "Starting Node Build .... "
+echo '####################################################################################################'
+
+### Create Directory structure outside to maintain correct permissions
+cd hs_discover
+rm -rf static templates
+mkdir static templates
+mkdir templates/hs_discover
+mkdir static/js
+mkdir static/css
+
+# Start Docker container and Run build
+docker run -i -v $HS_PATH:/hydroshare --name=nodejs --user=$HS_UID:$HS_GID node:$n_ver /bin/bash << eof
+
+cd hydroshare
+cd hs_discover
+npm install
+npm run build
+mkdir -p static/js
+mkdir -p static/css
+cp -rp templates/hs_discover/js static/
+cp -rp templates/hs_discover/css static/
+cp -p templates/hs_discover/map.js static/js/
+echo "----------------js--------------------"
+ls -l static/js
+echo "--------------------------------------"
+echo "----------------css-------------------"
+ls -l static/css
+echo "--------------------------------------"
+cd static/
+cd ..
+eof
+
+echo "Node Build completed ..."
+echo
+echo "Removing node container"
+docker container rm nodejs
+cd $HS_PATH
+sleep 1
+
+}
+
+
+echo
+echo '########################################################################################################################'
+echo " Building Node for Discovery"
+echo '########################################################################################################################'
+echo
+
+node_build
+
+echo
+echo '########################################################################################################################'
+echo " Migrating data"
+echo '########################################################################################################################'
+echo
+
+# docker exec hydroshare bash scripts/chown-root-items
+
+echo "  -docker exec -u hydro-service hydroshare python manage.py collectstatic -v0 --noinput"
+echo
+docker exec -u hydro-service hydroshare python manage.py collectstatic -v0 --noinput
+
+# echo
+# echo "  - docker exec -u hydro-service hydroshare python manage.py fix_permissions"
+# echo
+# docker $DOCKER_PARAM exec -u hydro-service hydroshare python manage.py fix_permissions
+
+echo
+echo '########################################################################################################################'
+echo -e " `green 'ALL DONE!'` "
+echo '########################################################################################################################'
+echo
+


### PR DESCRIPTION
Reverts hydroshare/hydroshare#5368

Problem with putting the node build in the Docker image is that we later mount the codebase in to `/hydroshare` and that eclipses the dis build in the image.

That PR builds fine locally because `local-dev-first-start-only` does it's own node build on the host (so it exists in the host when the volume is mounted).

But the PR fails to build discover properly on beta/prod deploy because those deploys don't have a duplicate node build on the vm host, so none of the built files for hs_discover end up in the final container.