### PR TITLE
[#5339] Improve Party validation messaging during resource creation

### DIFF
--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -62,6 +62,7 @@ from hs_core.models import (
     Subject,
     TaskNotification,
     resource_processor,
+    PartyValidationError,
 )
 from hs_core.task_utils import (
     dismiss_task_by_id,
@@ -1768,6 +1769,11 @@ def create_resource(request, *args, **kwargs):
             full_paths=full_paths,
             auto_aggregate=auto_aggregate,
         )
+    except PartyValidationError as ex:
+        party_message = "Validation issue in Party metadata. " + \
+            f"One of the authors or owners has invalid identifiers in their profile: {str(ex)}."
+        ajax_response_data["message"] = party_message
+        return JsonResponse(ajax_response_data)
     except SessionException as ex:
         ajax_response_data["message"] = ex.stderr
         return JsonResponse(ajax_response_data)

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -1770,8 +1770,8 @@ def create_resource(request, *args, **kwargs):
             auto_aggregate=auto_aggregate,
         )
     except PartyValidationError as ex:
-        party_message = "Validation issue in Party metadata. " + \
-            f"One of the authors or owners has invalid identifiers in their profile: {str(ex)}."
+        party_message = "Validation issue in Creator or Contributor metadata. " + \
+            f"One of the profiles contains invalid identifiers: {str(ex)}."
         ajax_response_data["message"] = party_message
         return JsonResponse(ajax_response_data)
     except SessionException as ex:

--- a/theme/templates/includes/navbar.html
+++ b/theme/templates/includes/navbar.html
@@ -461,7 +461,7 @@
         customAlert(alertTitle, "Please wait...", "success", -1); // Persistent alert
         $("html").css("cursor", "progress");
 
-        const errorMsg = "Failed to create " + contentType + ".";
+        let errorMsg = "Failed to create " + contentType + ".";
 
         $.ajax({
             type: "POST",
@@ -475,6 +475,9 @@
                 }
                 else {
                     console.log(response);
+                    if (response.hasOwnProperty('message')) {
+                        errorMsg = `${errorMsg} ${response.message}`;
+                    }
                     $(".custom-alert").alert('close');  // Dismiss previous alert
                     customAlert("Error", errorMsg, "error", 6000);
                     $("html").css("cursor", "initial");


### PR DESCRIPTION
Resolves #5339
![image](https://github.com/hydroshare/hydroshare/assets/17934193/d0347804-22aa-4b30-b79a-86a7905d14af)

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Checkout 2.13.4 or earlier hs
2. Create a user with an ORCID identifier that is invalid
3. Checkout this PR
4. Now attempt to create a resource
5. See that resource creation fails but now provides a more informative message about what action needs to be taken
