### PR TITLE
Irods cleanup strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ FROM hydroshare/hs_docker_base:305f2fa
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
 
-RUN pip install google-cloud-pubsub
-RUN pip install pandas
-RUN pip install django-storages[google]
+RUN pip install google-cloud-pubsub==2.21.2
+RUN pip install numpy==1.26.4
+RUN pip install pandas==2.2.2
+RUN pip install django-storages[google]==1.14.3
 
 # https://www.digicert.com/kb/digicert-root-certificates.htm
 # Get the .pem file from digicert and add it to the bundle used by certifi

--- a/Dockerfile-multistage-node
+++ b/Dockerfile-multistage-node
@@ -36,9 +36,10 @@ COPY --from=node-build /hydroshare /hydroshare
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
 
-RUN pip install google-cloud-pubsub
-RUN pip install pandas
-RUN pip install django-storages[google]
+RUN pip install google-cloud-pubsub==2.21.2
+RUN pip install numpy==1.26.4
+RUN pip install pandas==2.2.2
+RUN pip install django-storages[google]==1.14.3
 
 # https://www.digicert.com/kb/digicert-root-certificates.htm
 # Get the .pem file from digicert and add it to the bundle used by certifi

--- a/hs_core/management/commands/repair_resource.py
+++ b/hs_core/management/commands/repair_resource.py
@@ -127,7 +127,8 @@ class Command(BaseCommand):
                 else:
                     print("Command running without --admin. Fixing a published resource raise ValidationError")
             try:
-                _, missing_in_django, dangling_in_django = repair_resource(resource, logger, dry_run=dry_run, user=user, clean_irods=clean_irods)
+                _, missing_in_django, dangling_in_django = repair_resource(resource, logger, dry_run=dry_run,
+                                                                           user=user, clean_irods=clean_irods)
             except ValidationError as ve:
                 failed_resources.append(res_url)
                 print("Exception while attempting to repair resource:")

--- a/hs_core/management/commands/repair_resource.py
+++ b/hs_core/management/commands/repair_resource.py
@@ -45,6 +45,12 @@ class Command(BaseCommand):
             help='run process without saving changes',
         )
         parser.add_argument(
+            '--clean_irods',
+            action='store_true',  # True for presence, False for absence
+            dest='clean_irods',  # value is options['dry_run']
+            help='run process with iRODS file cleanup strategy',
+        )
+        parser.add_argument(
             '--published',
             action='store_true',  # True for presence, False for absence
             dest='published',  # value is options['published']
@@ -58,6 +64,7 @@ class Command(BaseCommand):
         updated_since = options['updated_since']
         admin = options['admin']
         dry_run = options['dry_run']
+        clean_irods = options['clean_irods']
         published = options['published']
         site_url = hydroshare.utils.current_site_url()
         ignore_repaired_since = options['ignore_repaired_since']

--- a/hs_core/management/commands/repair_resource.py
+++ b/hs_core/management/commands/repair_resource.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
                 else:
                     print("Command running without --admin. Fixing a published resource raise ValidationError")
             try:
-                _, missing_in_django, dangling_in_django = repair_resource(resource, logger, dry_run=dry_run, user=user)
+                _, missing_in_django, dangling_in_django = repair_resource(resource, logger, dry_run=dry_run, user=user, clean_irods=clean_irods)
             except ValidationError as ve:
                 failed_resources.append(res_url)
                 print("Exception while attempting to repair resource:")

--- a/hs_core/management/utils.py
+++ b/hs_core/management/utils.py
@@ -763,7 +763,7 @@ class CheckJSONLD(object):
             return
 
 
-def repair_resource(resource, logger, dry_run=False, user=None):
+def repair_resource(resource, logger, dry_run=False, user=None, clean_irods=False):
 
     print("CHECKING IF RESOURCE {} NEEDS REPAIR".format(resource.short_id))
     now = timezone.now()
@@ -773,8 +773,8 @@ def repair_resource(resource, logger, dry_run=False, user=None):
                                                                            echo_errors=True,
                                                                            log_errors=True,
                                                                            return_errors=True,
-                                                                           clean_irods=False,
-                                                                           clean_django=True,
+                                                                           clean_irods=clean_irods,
+                                                                           clean_django=not clean_irods,
                                                                            sync_ispublic=True,
                                                                            dry_run=dry_run,
                                                                            user=user,


### PR DESCRIPTION
Adds the --clean_irods option to the repair_resource management command. This option uses the already developed ability to identify and remove files in irods that do not have a reference in django. Using this command along with the --updated_since (days) option, we can delete files that were removed at RENCI as the irods sweeper does not removed synchronize deletes

To use:

```
# List files to be deleted as a dry run
python manage.py repair_resource --updated_since=1 --dryrun 

# delete the identified files
python manage.py repair_resource --updated_since=1 --clean_irods
```