### PR TITLE
Update defaultworker PostGIS configuration in local-dev.yml to use pgbouncer and disable server-side cursors

### DIFF
--- a/local-dev.yml
+++ b/local-dev.yml
@@ -144,7 +144,8 @@ services:
       RABBITMQ_PORT_5672_TCP_ADDR: rabbitmq
       SOLR_PORT_8983_TCP_ADDR: solr
       SOLR_HOST: solr
-      POSTGIS_PORT_5432_TCP_ADDR: postgis
+      POSTGIS_PORT_5432_TCP_ADDR: pgbouncer
+      POSTGIS_DISABLE_SERVER_SIDE_CURSORS: "True"
       HS_PATH: ${PWD}
       PYTHONPATH: /hydroshare
       DJANGO_SETTINGS_MODULE: hydroshare.settings


### PR DESCRIPTION
Resolves a regression for local dev introduced in https://github.com/hydroshare/hydroshare/pull/5662
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [ ] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Checkout `develop` branch at commit https://github.com/hydroshare/hydroshare/commit/22e3d8c78ed5b793bb0a2fbecc122f6ee42f8f7c
2. Build the whole project with `local-dev-first-start-only` and choose to rebuild all images
3. Attempt to create a resource version (or any other async task)
4. See that the task never gets processed (this is because the defaultworker service fails to run)
5. Now checkout this PR
6. Rebuild the project
7. See that the defaultworker service is now up and running: `docker ps | grep defaultworker`
8. In the UI at https://localhost, login
9. See that resource versioning is now succdesful
