### PR TITLE
[#5825] Endpoint for retrieving resource sharing status

### DIFF
--- a/hs_rest_api2/serializers.py
+++ b/hs_rest_api2/serializers.py
@@ -21,6 +21,7 @@ from hsmodels.schemas.aggregations import (FileSetMetadataIn,
 from hsmodels.schemas.resource import ResourceMetadataIn
 from pydantic import ConfigDict
 from rest_framework.serializers import Serializer
+from rest_framework import serializers
 
 
 def get_schema_open_api_v2(schema):
@@ -205,3 +206,6 @@ class NestedSchemaGenerator(OpenAPISchemaGenerator):
             for d in schema['definitions']:
                 swagger.definitions.update({d: schema['definitions'][d]})
         return swagger
+
+class ResourceSharingStatusSerializer(Serializer):
+    sharing_status = serializers.ChoiceField(choices=['public', 'private', 'discoverable', 'published'])

--- a/hs_rest_api2/serializers.py
+++ b/hs_rest_api2/serializers.py
@@ -207,5 +207,6 @@ class NestedSchemaGenerator(OpenAPISchemaGenerator):
                 swagger.definitions.update({d: schema['definitions'][d]})
         return swagger
 
+
 class ResourceSharingStatusSerializer(Serializer):
     sharing_status = serializers.ChoiceField(choices=['public', 'private', 'discoverable', 'published'])

--- a/hs_rest_api2/tests/test_resource_sharing_status.py
+++ b/hs_rest_api2/tests/test_resource_sharing_status.py
@@ -1,0 +1,44 @@
+import json
+
+from rest_framework import status
+
+from hs_core.hydroshare import resource
+from hs_core.tests.api.rest.base import HSRESTTestCase
+
+
+class TestResourceSharingStatus(HSRESTTestCase):
+    def setUp(self):
+        super(TestResourceSharingStatus, self).setUp()
+        self.res = resource.create_resource(
+            resource_type='CompositeResource',
+            owner=self.user,
+            title='Test Resource for testing Sharing Status',
+        )
+        self.url = "/hsapi2/resource/{}/sharing_status/json/".format(self.res.short_id)
+
+    def test_get_sharing_status(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['sharing_status'], 'private')
+        # set the resource to discoverable
+        self.res.raccess.discoverable = True
+        self.res.raccess.save()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['sharing_status'], 'discoverable')
+        # set the resource to public
+        self.res.raccess.public = True
+        self.res.raccess.save()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['sharing_status'], 'public')
+        # set the resource to published
+        self.res.raccess.published = True
+        self.res.raccess.save()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['sharing_status'], 'published')

--- a/hs_rest_api2/urls.py
+++ b/hs_rest_api2/urls.py
@@ -14,7 +14,8 @@ from .views.metadata import (
     resource_metadata_json,
     single_file_metadata_json,
     time_series_metadata_json,
-    csv_file_metadata_json
+    csv_file_metadata_json,
+    resource_sharing_status_json,
 )
 
 app_name = "hsapi2"
@@ -42,6 +43,9 @@ urlpatterns = [
     path('', schema_view_yasg.with_ui('swagger', cache_timeout=None),
          name='schema-swagger-ui'),
     path('redoc/', schema_view_yasg.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
+
+    re_path(r'^resource/(?P<pk>[0-9a-f-]+)/sharing_status/json/$', resource_sharing_status_json,
+            name='resource_sharing_status_json'),
 
     re_path(r'^resource/(?P<pk>[0-9a-f-]+)/json/$',
             resource_metadata_json,


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Locally run this branch. 
2. Create a resource. Keep the resource in private sharing status (default status)
3. Navigate to API UI page at: `localhost:8000/hsapi2/`
4. Look for the endpoint: `/resource/{id}/sharing_status/json`
5. Use this endpoint to get the sharing status for the resource you created. You should see the response from the api call as: {"sharing_status": "private"}
6. Upload a file and add necessary metadata to make the resource discoverable. Again use the above endpoint and verify the api response.
7. Make the resource public. Use the above endpoint to check the sharing status. 
