### PR TITLE
[#5221] Add download button to top right toolbar in resource landing page

### DIFF
--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -1283,6 +1283,10 @@ body > .main-container {
     width: auto !important;
 }
 
+#btn-toolbar-download-all.icon-button {
+	padding: 0;
+}
+
 .icon-button:hover{
     text-decoration: none;
 }

--- a/theme/static/js/hs_file_browser.js
+++ b/theme/static/js/hs_file_browser.js
@@ -1851,7 +1851,7 @@ function onUploadSuccess(file, response) {
 
 $(document).ready(function () {
     // Download All method
-    $("#btn-download-all, #download-bag-btn").click(function (event) {
+    $("#btn-download-all, #download-bag-btn, #btn-toolbar-download-all").click(function (event) {
         const btnDownloadAll = $("#btn-download-all");
         const icon = $('#btn-download-all > span:first-child');
         const initialClass = icon.attr("class");

--- a/theme/templates/resource-landing-page/top-right-buttons.html
+++ b/theme/templates/resource-landing-page/top-right-buttons.html
@@ -11,6 +11,21 @@
             </a>
         {% endif %}
         {% if not resource_edit_mode %}
+            {% if show_content_files %}
+                <button id="btn-toolbar-download-all"
+                    {% if cm.raccess.require_download_agreement %}
+                    data-target="#license-agree-dialog-bag" data-toggle="modal"
+                    data-placement="auto"
+                    {% endif %}
+                    class="icon-button"
+                    data-bag-url="{{ cm.bag_url }}"
+                >
+                    <span data-toggle="tooltip" data-placement="bottom"
+                            title="Download all content as Zipped BagIt Archive"
+                            class="fa fa-briefcase icon-blue icon-button">
+                    </span>
+                </button>
+            {% endif %}
             {% if not self_access_level == 'None' and cm.raccess.public %}
                 {% if resource_is_mine %}
                     <form data-id="form-add-to-my-resources"


### PR DESCRIPTION
[#5221] Adds a download button to the top right toolbar of the resource landing page. The button behaves exactly as the BagIt download button in the file explorer, and is subject to the same conditionals.

![image](https://github.com/user-attachments/assets/99ec32ed-3a6f-470f-95d5-b736ddea7104)


<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Go to the resource landing page.
2. Notice new button in the top right. 
![image](https://github.com/user-attachments/assets/07929d88-9524-46f7-bb6b-8ef31e78bac4)
3. Click the new button to download the resource content.
4. Go to the resource edit mode. Scroll to the bottom of the edit form and toggle the option to require agreement before download.
5. Go back to view mode and click the download button again.
6. Verify that the confirm dialog is hidden or shown as appropriate.
