### PR TITLE
5908 endpoint for user permission on resource

### DIFF
--- a/hs_access_control/models/utilities.py
+++ b/hs_access_control/models/utilities.py
@@ -1,5 +1,9 @@
+from django.contrib.auth.models import User
+from django.db.models import Q
+
 from hs_access_control.models.privilege import UserResourcePrivilege, GroupResourcePrivilege, \
-    UserGroupPrivilege, GroupCommunityPrivilege
+    UserGroupPrivilege, GroupCommunityPrivilege, PrivilegeCodes
+from hs_core.models import BaseResource
 
 
 def coarse_permissions(u, r):
@@ -97,3 +101,47 @@ def access_provenance(u, r):
                               .format(verbs[e.privilege], e.group.name)
 
     return output
+
+
+def get_user_resource_privilege(user_id, short_id):
+    """
+    Determine the privilege level (permission) of a user for a specific resource.
+
+    Args:
+        user_id (int): The ID of the user.
+        short_id (str): The unique identifier of the resource.
+
+    Returns:
+        int: The privilege code representing the user's access level.
+    """
+
+    if user_id is None:
+        return PrivilegeCodes.NONE
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return PrivilegeCodes.NONE
+    try:
+        resource = BaseResource.objects.get(short_id=short_id)
+    except BaseResource.DoesNotExist:
+        return PrivilegeCodes.NONE
+
+    # public access
+    if resource.raccess.public or resource.raccess.allow_private_sharing:
+        public = PrivilegeCodes.VIEW
+    else:
+        public = PrivilegeCodes.NONE
+    # user access
+    user_privilege = UserResourcePrivilege.get_privilege(user=user, resource=resource)
+
+    group_privilege = GroupResourcePrivilege.objects.filter(
+        Q(resource=resource,
+          group__gaccess__active=True,
+          group__g2ugp__user__id=user_id)).values_list('privilege', flat=True)
+
+    if len(group_privilege) > 0:
+        group_privilege = min(group_privilege)
+    else:
+        group_privilege = PrivilegeCodes.NONE
+
+    return min(public, user_privilege, group_privilege)

--- a/hs_rest_api2/serializers.py
+++ b/hs_rest_api2/serializers.py
@@ -210,3 +210,7 @@ class NestedSchemaGenerator(OpenAPISchemaGenerator):
 
 class ResourceSharingStatusSerializer(Serializer):
     sharing_status = serializers.ChoiceField(choices=['public', 'private', 'discoverable', 'published'])
+
+
+class ResourcePermissionSerializer(Serializer):
+    permission = serializers.ChoiceField(choices=['owner', 'edit', 'view', 'none'])

--- a/hs_rest_api2/tests/test_resource_permission.py
+++ b/hs_rest_api2/tests/test_resource_permission.py
@@ -1,0 +1,99 @@
+import json
+
+from django.contrib.auth.models import User
+from rest_framework import status
+
+from hs_core.hydroshare import resource
+from hs_core.tests.api.rest.base import HSRESTTestCase
+from hs_access_control.models.privilege import PrivilegeCodes
+
+
+class TestResourcePermission(HSRESTTestCase):
+    def setUp(self):
+        super(TestResourcePermission, self).setUp()
+
+        # Create a test resource owned by the default user
+        self.res = resource.create_resource(
+            resource_type='CompositeResource',
+            owner=self.user,
+            title='Test Resource for testing Permission',
+        )
+
+        # Create additional users with different permission levels
+        self.edit_user = User.objects.create_user(
+            username='edituser',
+            email='edituser@example.com',
+            password='edituser'
+        )
+
+        self.view_user = User.objects.create_user(
+            username='viewuser',
+            email='viewuser@example.com',
+            password='viewuser'
+        )
+
+        self.no_perm_user = User.objects.create_user(
+            username='nopermuser',
+            email='nopermuser@example.com',
+            password='nopermuser'
+        )
+
+        # Set permissions for users
+        self.user.uaccess.share_resource_with_user(
+            self.res, self.edit_user, PrivilegeCodes.CHANGE)
+
+        self.user.uaccess.share_resource_with_user(
+            self.res, self.view_user, PrivilegeCodes.VIEW)
+
+        # URL for the permission endpoint
+        self.url = "/hsapi2/resource/{}/permission/json/".format(self.res.short_id)
+
+    def test_get_permission_owner(self):
+        # Test owner permission
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['permission'], 'owner')
+
+    def test_get_permission_edit(self):
+        # Test edit permission
+        self.client.logout()
+        self.client.login(username='edituser', password='edituser')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['permission'], 'edit')
+
+    def test_get_permission_view(self):
+        # Test view permission
+        self.client.logout()
+        self.client.login(username='viewuser', password='viewuser')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['permission'], 'view')
+
+    def test_get_permission_none(self):
+        # Test no permission
+        self.client.logout()
+        self.client.login(username='nopermuser', password='nopermuser')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['permission'], 'none')
+
+    def test_get_permission_nonexistent_resource(self):
+        # Test with non-existent resource
+        nonexistent_url = "/hsapi2/resource/abc123/permission/json/"
+        response = self.client.get(nonexistent_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['permission'], 'none')
+
+    def test_get_permission_anonymous_user(self):
+        # Test no permission
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
+        self.assertEqual(response_json['permission'], 'none')

--- a/hs_rest_api2/tests/test_resource_permission.py
+++ b/hs_rest_api2/tests/test_resource_permission.py
@@ -1,6 +1,6 @@
 import json
 
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import User
 from rest_framework import status
 
 from hs_core.hydroshare import resource
@@ -64,12 +64,12 @@ class TestResourcePermission(HSRESTTestCase):
         self.user.uaccess.share_group_with_user(
             self.edit_group,
             self.edit_user_via_group,
-            PrivilegeCodes.VIEW # edit_user_via_group has view permission on edit_group
+            PrivilegeCodes.VIEW  # edit_user_via_group has view permission on edit_group
         )
         self.user.uaccess.share_group_with_user(
             self.view_group,
             self.view_user_via_group,
-            PrivilegeCodes.CHANGE # view_user_via_group has edit permission on view_group
+            PrivilegeCodes.CHANGE  # view_user_via_group has edit permission on view_group
         )
 
         # Set individual permissions
@@ -167,7 +167,7 @@ class TestResourcePermission(HSRESTTestCase):
         self.user.uaccess.share_group_with_user(
             self.edit_group,
             self.view_user,
-            PrivilegeCodes.CHANGE # view_user has edit permission on edit_group
+            PrivilegeCodes.CHANGE  # view_user has edit permission on edit_group
         )
 
         self.client.logout()

--- a/hs_rest_api2/tests/test_resource_permission.py
+++ b/hs_rest_api2/tests/test_resource_permission.py
@@ -20,28 +20,40 @@ class TestResourcePermission(HSRESTTestCase):
         )
 
         # Create test groups
-        self.edit_group = self.user.uaccess.create_group(
-            title='edit_group',
+        # a group that will have edit permission on the resource
+        self.res_edit_group = self.user.uaccess.create_group(
+            title='res_edit_group',
             description='Group for resource edit permission testing'
         )
-        self.view_group = self.user.uaccess.create_group(
-            title='view_group',
+        # a group that will have view permission on the resource
+        self.res_view_group = self.user.uaccess.create_group(
+            title='res_view_group',
             description='Group for resource view permission testing'
         )
 
         # Create users
-        self.edit_user = User.objects.create_user(
-            username='edituser',
-            email='edituser@example.com',
-            password='edituser'
+        # a user that will have edit permission on the resource
+        self.res_edit_user = User.objects.create_user(
+            username='res-edit-user',
+            email='res-edit-user@example.com',
+            password='res-edit-user'
         )
 
-        self.view_user = User.objects.create_user(
-            username='viewuser',
-            email='viewuser@example.com',
-            password='viewuser'
+        # a user that will have view permission on the resource
+        self.res_view_user = User.objects.create_user(
+            username='res-view-user',
+            email='res-view-user@example.com',
+            password='res-view-user'
         )
 
+        # a user that will have either view or edit permission on the resource
+        self.res_view_or_edit_user = User.objects.create_user(
+            username='res-view-or-edit-user',
+            email='res-view-or-edit-user@example.com',
+            password='res-view-or-edit-user'
+        )
+
+        # a user that will have no permission on the resource
         self.no_perm_user = User.objects.create_user(
             username='nopermuser',
             email='nopermuser@example.com',
@@ -49,45 +61,59 @@ class TestResourcePermission(HSRESTTestCase):
         )
 
         # Create group users
-        self.edit_user_via_group = User.objects.create_user(
-            username='groupedituser',
-            email='groupedituser@example.com',
-            password='groupedituser'
+        # a user that will have edit permission on the resource via group membership
+        self.res_edit_user_via_group = User.objects.create_user(
+            username='res-edit-user-via-group',
+            email='res-edit-user-via-group@example.com',
+            password='res-edit-user-via-group'
         )
-        self.view_user_via_group = User.objects.create_user(
-            username='groupviewuser',
-            email='groupviewuser@example.com',
-            password='groupviewuser'
+        # a user that will have view permission on the resource via group membership
+        self.res_view_user_via_group = User.objects.create_user(
+            username='res-view-user-via-group',
+            email='res-view-user-via-group@example.com',
+            password='res-view-user-via-group'
         )
 
         # Add users to groups using proper access control
+        # user res_edit_user_via_group has view permission (PrivilegeCodes.VIEW) on res_edit_group (won't be
+        # able to edit group membership)
         self.user.uaccess.share_group_with_user(
-            self.edit_group,
-            self.edit_user_via_group,
-            PrivilegeCodes.VIEW  # edit_user_via_group has view permission on edit_group
-        )
-        self.user.uaccess.share_group_with_user(
-            self.view_group,
-            self.view_user_via_group,
-            PrivilegeCodes.CHANGE  # view_user_via_group has edit permission on view_group
+            self.res_edit_group,
+            self.res_edit_user_via_group,
+            PrivilegeCodes.VIEW
         )
 
-        # Set individual permissions
-        self.user.uaccess.share_resource_with_user(
-            self.res, self.edit_user, PrivilegeCodes.CHANGE)
-
-        self.user.uaccess.share_resource_with_user(
-            self.res, self.view_user, PrivilegeCodes.VIEW)
-
-        # Set group permissions
-        self.user.uaccess.share_resource_with_group(
-            self.res,
-            self.edit_group,
+        # user res_view_user_via_group has edit permission (PrivilegeCodes.CHANGE) on res_view_group (will be
+        # able to edit group membership)
+        self.user.uaccess.share_group_with_user(
+            self.res_view_group,
+            self.res_view_user_via_group,
             PrivilegeCodes.CHANGE
         )
+
+        # Set individual permissions on the resource
+        # grant res_edit_user edit permission on the resource
+        self.user.uaccess.share_resource_with_user(
+            self.res, self.res_edit_user, PrivilegeCodes.CHANGE)
+
+        # grant res_view_user view permission on the resource
+        self.user.uaccess.share_resource_with_user(
+            self.res, self.res_view_user, PrivilegeCodes.VIEW)
+
+        # Set group permissions on the resource
+        # grant res_edit_group edit permission on the resource - members of res_edit_group have edit
+        # permission on the resource
         self.user.uaccess.share_resource_with_group(
             self.res,
-            self.view_group,
+            self.res_edit_group,
+            PrivilegeCodes.CHANGE
+        )
+
+        # grant res_view_group view permission on the resource - members of res_view_group have view
+        # permission on the resource
+        self.user.uaccess.share_resource_with_group(
+            self.res,
+            self.res_view_group,
             PrivilegeCodes.VIEW
         )
 
@@ -95,32 +121,32 @@ class TestResourcePermission(HSRESTTestCase):
         self.url = "/hsapi2/resource/{}/permission/json/".format(self.res.short_id)
 
     def test_get_permission_owner(self):
-        # Test owner permission
+        # Test owner permission on the resource
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json['permission'], 'owner')
 
     def test_get_permission_edit(self):
-        # Test edit permission
+        # Test edit permission on the resource
         self.client.logout()
-        self.client.login(username='edituser', password='edituser')
+        self.client.login(username='res-edit-user', password='res-edit-user')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json['permission'], 'edit')
 
     def test_get_permission_view(self):
-        # Test view permission
+        # Test view permission on the resource
         self.client.logout()
-        self.client.login(username='viewuser', password='viewuser')
+        self.client.login(username='res-view-user', password='res-view-user')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json['permission'], 'view')
 
     def test_get_permission_none(self):
-        # Test no permission
+        # Test no permission on the resource
         self.client.logout()
         self.client.login(username='nopermuser', password='nopermuser')
         response = self.client.get(self.url)
@@ -137,7 +163,7 @@ class TestResourcePermission(HSRESTTestCase):
         self.assertEqual(response_json['permission'], 'none')
 
     def test_get_permission_anonymous_user(self):
-        # Test no permission
+        # Test no permission on the resource
         self.client.logout()
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -145,18 +171,18 @@ class TestResourcePermission(HSRESTTestCase):
         self.assertEqual(response_json['permission'], 'none')
 
     def test_get_permission_group_edit(self):
-        # Test edit permission through group membership
+        # Test edit permission on the resource through group membership
         self.client.logout()
-        self.client.login(username='groupedituser', password='groupedituser')
+        self.client.login(username='res-edit-user-via-group', password='res-edit-user-via-group')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json['permission'], 'edit')
 
     def test_get_permission_group_view(self):
-        # Test view permission through group membership
+        # Test view permission on the resource through group membership
         self.client.logout()
-        self.client.login(username='groupviewuser', password='groupviewuser')
+        self.client.login(username='res-view-user-via-group', password='res-view-user-via-group')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content.decode())
@@ -164,16 +190,30 @@ class TestResourcePermission(HSRESTTestCase):
 
     def test_get_permission_highest_privilege(self):
         # Test user gets highest privilege when they have both direct and group permissions
-        self.user.uaccess.share_group_with_user(
-            self.edit_group,
-            self.view_user,
-            PrivilegeCodes.CHANGE  # view_user has edit permission on edit_group
-        )
 
+        # grant res_view_or_edit_user view permission on the resource
+        self.user.uaccess.share_resource_with_user(
+            self.res, self.res_view_or_edit_user, PrivilegeCodes.VIEW)
+
+        # test res_view_or_edit_user has view permission on the resource
         self.client.logout()
-        self.client.login(username='viewuser', password='viewuser')
+        self.client.login(username='res-view-or-edit-user', password='res-view-or-edit-user')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.content.decode())
-        # view_user has both edit (via group) and view (direct) permission on the resource
+        self.assertEqual(response_json['permission'], 'view')
+
+        # make res_view_or_edit_user a member of res_edit_group - with membership edit permission
+        self.user.uaccess.share_group_with_user(
+            self.res_edit_group,
+            self.res_view_or_edit_user,
+            PrivilegeCodes.CHANGE
+        )
+
+        # test res_view_or_edit_user has edit permission on the resource via group membership
+        self.client.logout()
+        self.client.login(username='res-view-or-edit-user', password='res-view-or-edit-user')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = json.loads(response.content.decode())
         self.assertEqual(response_json['permission'], 'edit')

--- a/hs_rest_api2/urls.py
+++ b/hs_rest_api2/urls.py
@@ -16,6 +16,7 @@ from .views.metadata import (
     time_series_metadata_json,
     csv_file_metadata_json,
     resource_sharing_status_json,
+    resource_permission_json,
 )
 
 app_name = "hsapi2"
@@ -46,6 +47,9 @@ urlpatterns = [
 
     re_path(r'^resource/(?P<pk>[0-9a-f-]+)/sharing_status/json/$', resource_sharing_status_json,
             name='resource_sharing_status_json'),
+
+    re_path(r'^resource/(?P<pk>[0-9a-f-]+)/permission/json/$', resource_permission_json,
+            name='resource_permission_json'),
 
     re_path(r'^resource/(?P<pk>[0-9a-f-]+)/json/$',
             resource_metadata_json,


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. Run this branch locally.
2. Create a resource
3. Access the OpenAPI site by navigating to: `/hsapi2`
4. Look for the endpoint `/resource/{id}/permission/json`
5. Test this endpoint using the id of the resource. Verify the json response is `{"permission": "owner"}`.
6. Logout from the site. Test again the endpoint using the same resource id. Verify the json response is `{"permission": "none"}`
7.  For testing edit permission on a resource, you need to use another user account to create a new resource. Then give edit permission to the 1st user account. Then login using the 1st account. Now when you test the same endpoint using the id of the 2nd resource, you should get response as `{"permission": "edit"}`.
8. For testing view permission, change the permission for 1st user on 2nd resource to view. Login as the 1st user and test the endpoint using the id of the 2nd resource and you should get response as `{"permission": "view"}`.
9. For testing view permission on a public resource, remove 1st user permission on the 2nd resource. Make the 2nd resource public. Login as the 1st user and test the endpoint using the id of the 2nd resource. You should get response as `{"permission": "view"}`
