### PR TITLE
[#5950] add default quota size when no resources are held

### DIFF
--- a/hs_core/tests/api/native/test_add_resource_files.py
+++ b/hs_core/tests/api/native/test_add_resource_files.py
@@ -68,16 +68,18 @@ class TestAddResourceFiles(MockS3TestCaseMixin, unittest.TestCase):
         Test that when a user is a quota_holder for no resources/files, the quota size defaults to 0.
         """
         uquota = self.user.quotas.first()
-        self.assertEqual(uquota.data_zone_value, 0)
+        self.assertAlmostEqual(uquota.data_zone_value, 0.0, places=6)
         self.assertEqual(uquota.unit, 'GB')
 
         # check that the resource has no files
         self.assertEqual(self.res.files.all().count(), 0)
         self.assertEqual(self.res.size, 0)
 
-        # check that the user is a quota holder for just this resource
-        self.assertTrue(self.user.is_quota_holder(self.res.short_id))
-        self.assertEqual(self.user.quotas.count(), 1)
+        # check that the user is a quota holder for only this one resource
+        self.assertEqual(self.user, self.res.quota_holder)
+        owned_resources = self.user.uaccess.owned_resources.all()
+        self.assertEqual(owned_resources.count(), 1)
+        self.assertIn(self.res, owned_resources)
 
     def test_add_files(self):
 

--- a/hs_core/tests/api/native/test_add_resource_files.py
+++ b/hs_core/tests/api/native/test_add_resource_files.py
@@ -63,6 +63,22 @@ class TestAddResourceFiles(MockS3TestCaseMixin, unittest.TestCase):
         self.myfile3.close()
         os.remove(self.myfile3.name)
 
+    def test_no_files_default_size(self):
+        """
+        Test that when a user is a quota_holder for no resources/files, the quota size defaults to 0.
+        """
+        uquota = self.user.quotas.first()
+        self.assertEqual(uquota.size, 0)
+        self.assertEqual(uquota.unit, 'GB')
+
+        # check that the resource has no files
+        self.assertEqual(self.res.files.all().count(), 0)
+        self.assertEqual(self.res.size, 0)
+
+        # check that the user is a quota holder for just this resource
+        self.assertTrue(self.user.is_quota_holder(self.res.short_id))
+        self.assertEqual(self.user.quotas.count(), 1)
+
     def test_add_files(self):
 
         self.assertEqual(0, self.res.size)

--- a/hs_core/tests/api/native/test_add_resource_files.py
+++ b/hs_core/tests/api/native/test_add_resource_files.py
@@ -68,7 +68,7 @@ class TestAddResourceFiles(MockS3TestCaseMixin, unittest.TestCase):
         Test that when a user is a quota_holder for no resources/files, the quota size defaults to 0.
         """
         uquota = self.user.quotas.first()
-        self.assertEqual(uquota.size, 0)
+        self.assertEqual(uquota.data_zone_value, 0)
         self.assertEqual(uquota.unit, 'GB')
 
         # check that the resource has no files

--- a/theme/models.py
+++ b/theme/models.py
@@ -295,7 +295,8 @@ class UserQuota(models.Model):
                 text=True,
             )
         except (subprocess.CalledProcessError, ValueError, IndexError):
-            raise ValidationError("Error retrieving quota information.")
+            # return a default value of 0 and default unit
+            return float(0), settings.DEFAULT_QUOTA_UNIT
         size_with_unit_str = result.stdout.split("Total size: ")[1].split("\n")[0]
         size_and_unit = size_with_unit_str.split(" ")
         size = size_and_unit[0]


### PR DESCRIPTION
Resolves #5950
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

<!-- Please email your positive test case lbrazil@cuahsi.org, who will make the decision regarding user documentation. -->

- [x] Passing Jenkins Build

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Every test must pass, including PEP8 code formatting tests. -->

- [x] Peer Code review and approval

<!-- This is the process by which a peer developer on the HydroShare team will read the changeset, provide feedback, and ultimately give a formal approval to the code before it passes PR status. -->

### Positive Test Case
1. [Enter positive test case here]
