### PR TITLE
5967 published zips

### DIFF
--- a/hs_core/management/commands/check_published_bags.py
+++ b/hs_core/management/commands/check_published_bags.py
@@ -2,24 +2,11 @@
 Check for published resources and create bags if necessary.
 """
 from django.core.management.base import BaseCommand
-from hs_core.models import BaseResource
-from django_s3.storage import S3Storage
-from hs_core.tasks import create_bag_by_s3
+from hs_core.tasks import ensure_published_resources_have_bags
 
 
 class Command(BaseCommand):
     help = "Check for published resources and create bags if necessary."
 
     def handle(self, *args, **options):
-        published_res = BaseResource.objects.filter(raccess__published=True)
-        istorage = S3Storage()
-        for res in published_res:
-            print(f"Checking resource {res.short_id} for bag creation...")
-            if res.getAVU("bag_modified") or not istorage.exists(res.bag_path):
-                print(f"Resource {res.short_id} has been modified, creating bag...")
-                try:
-                    create_bag_by_s3(res.short_id)
-                except Exception as e:
-                    print(f"Error creating bag for resource {res.short_id}: {e}")
-            else:
-                print(f"Resource {res.short_id} has not been modified and bag exists, skipping bag creation.")
+        ensure_published_resources_have_bags()

--- a/hs_core/management/commands/check_published_bags.py
+++ b/hs_core/management/commands/check_published_bags.py
@@ -1,0 +1,25 @@
+"""
+Check for published resources and create bags if necessary.
+"""
+from django.core.management.base import BaseCommand
+from hs_core.models import BaseResource
+from django_s3.storage import S3Storage
+from hs_core.tasks import create_bag_by_s3
+
+
+class Command(BaseCommand):
+    help = "Check for published resources and create bags if necessary."
+
+    def handle(self, *args, **options):
+        published_res = BaseResource.objects.filter(raccess__published=True)
+        istorage = S3Storage()
+        for res in published_res:
+            print(f"Checking resource {res.short_id} for bag creation...")
+            if res.getAVU("bag_modified") == True or not istorage.exists(res.bag_path):
+                print(f"Resource {res.short_id} has been modified, creating bag...")
+                try:
+                    create_bag_by_s3(res.short_id)
+                except Exception as e:
+                    print(f"Error creating bag for resource {res.short_id}: {e}")
+            else:
+                print(f"Resource {res.short_id} has not been modified and bag exists, skipping bag creation.")

--- a/hs_core/management/commands/check_published_bags.py
+++ b/hs_core/management/commands/check_published_bags.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         istorage = S3Storage()
         for res in published_res:
             print(f"Checking resource {res.short_id} for bag creation...")
-            if res.getAVU("bag_modified") == True or not istorage.exists(res.bag_path):
+            if res.getAVU("bag_modified") == True or istorage.exists(res.bag_path) == False:
                 print(f"Resource {res.short_id} has been modified, creating bag...")
                 try:
                     create_bag_by_s3(res.short_id)

--- a/hs_core/management/commands/check_published_bags.py
+++ b/hs_core/management/commands/check_published_bags.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         istorage = S3Storage()
         for res in published_res:
             print(f"Checking resource {res.short_id} for bag creation...")
-            if res.getAVU("bag_modified") == True or istorage.exists(res.bag_path) == False:
+            if res.getAVU("bag_modified") or not istorage.exists(res.bag_path):
                 print(f"Resource {res.short_id} has been modified, creating bag...")
                 try:
                     create_bag_by_s3(res.short_id)

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -904,11 +904,11 @@ def create_bag_by_s3(resource_id, create_zip=True):
                 if istorage.exists(bag_path):
                     istorage.delete(bag_path)
                 istorage.zipup(bagit_input_path, bag_path)
+                res.setAVU("bag_modified", False)
                 if res.raccess.published:
                     # compute checksum to meet DataONE distribution requirement
                     chksum = istorage.checksum(bag_path)
                     res.bag_checksum = chksum
-                res.setAVU("bag_modified", False)
                 return istorage.signed_url(bag_path)
             except SessionException as ex:
                 raise SessionException(-1, '', ex.stderr)

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -147,6 +147,8 @@ def setup_periodic_tasks(sender, **kwargs):
                                  options={'queue': 'periodic'})
         sender.add_periodic_task(crontab(minute=0, hour=8), check_bucket_names.s(),
                                  options={'queue': 'periodic'})
+        sender.add_periodic_task(crontab(minute=0, hour=9), ensure_published_resources_have_bags.s(),
+                                 options={'queue': 'periodic'})
 
         # Monthly
         sender.add_periodic_task(crontab(minute=30, hour=7, day_of_month=1), update_from_geoconnex_task.s(),
@@ -166,6 +168,27 @@ def clear_tokens():
     """
     from oauth2_provider.models import clear_expired
     clear_expired()
+
+
+@celery_app.task(ignore_result=True, base=HydroshareTask)
+def ensure_published_resources_have_bags():
+    """
+    Ensure that all published resources have bags created.
+    This task is run periodically to ensure that all published resources
+    have bags created for them.
+    """
+    published_res = BaseResource.objects.filter(raccess__published=True)
+    istorage = S3Storage()
+    for res in published_res:
+        logger.info(f"Checking resource {res.short_id} for bag creation...")
+        if res.getAVU("bag_modified") or not istorage.exists(res.bag_path):
+            logger.info(f"Resource {res.short_id} has been modified, creating bag...")
+            try:
+                create_bag_by_s3(res.short_id)
+            except Exception as e:
+                logger.error(f"Error creating bag for resource {res.short_id}: {e}")
+        else:
+            logger.info(f"Resource {res.short_id} has not been modified and bag exists, skipping bag creation.")
 
 
 @celery_app.task(ignore_result=True, base=HydroshareTask)


### PR DESCRIPTION
This fixes #5967 in 2 ways. First, the management command ensures all published resources have a bag generated and that the checksum is set. We should have a bag for published resources because it is used in the json-ld from the landing page.

The backup solution will set the bag modified flag to False before reading the checksum for a newly created bag. The user will still experience a problem for large published resources without an existing bag for the first download attempt, but all following download attempts will succeed. 

I'm open to suggestions to better ensure published resources have bags generated and avoid the possibility of an initial download failure on the first attempt.
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Run the management command and ensure all published resources have a bag and checksum.
