### PR TITLE
[#5686] uppy direct uploads to S3

### DIFF
--- a/hs_core/templates/uppy.html
+++ b/hs_core/templates/uppy.html
@@ -11,7 +11,6 @@
 {% block extra_js %}
   <script>
     const FILE_UPLOAD_MAX_SIZE = {{ file_upload_max_size|default:26843545600 }};
-    const MAX_CHUNK_SIZE = {{ max_chunk_size|default:2621440 }};
     const MAX_NUMBER_OF_FILES_IN_SINGLE_LOCAL_UPLOAD = {{ max_number_of_files_in_single_local_upload|default:50 }};
     const PARALLEL_UPLOADS_LIMIT = {{ parallel_uploads_limit|default:10 }};
     const COMPANION_URL = "{{ companion_url }}";

--- a/hs_core/views/resource_rest_api.py
+++ b/hs_core/views/resource_rest_api.py
@@ -1,6 +1,5 @@
 import os
 import mimetypes
-import base64
 import copy
 import tempfile
 import shutil
@@ -8,16 +7,11 @@ import logging
 import json
 
 from django.urls import reverse
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, SuspiciousFileOperation
 from django.core.exceptions import ValidationError as CoreValidationError
-from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponseNotFound
+from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
-from django.contrib.sessions.models import Session
-from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from django.views.decorators.csrf import csrf_exempt
-from django.utils.decorators import method_decorator
 
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.views import APIView
@@ -27,9 +21,6 @@ from rest_framework.request import Request
 from rest_framework.exceptions import ValidationError, NotAuthenticated, PermissionDenied, NotFound
 
 from django_s3.exceptions import SessionException
-from django_tus.views import TusUpload
-from django_tus.tusfile import TusFile, TusChunk
-from django_tus.response import TusResponse
 from hs_core import hydroshare
 from hs_core.models import AbstractResource
 from hs_core.hydroshare.utils import get_resource_by_shortkey, get_resource_types, \
@@ -891,115 +882,3 @@ def _validate_metadata(metadata_list):
         if k.lower() in ('title', 'subject', 'description', 'publisher', 'format', 'date', 'type'):
             err_message = err_message.format(k.lower())
             raise ValidationError(detail=err_message)
-
-
-class CustomTusUpload(TusUpload):
-
-    @method_decorator(csrf_exempt)
-    def dispatch(self, *args, **kwargs):
-        # check that the user has permission to upload a file to the resource
-        from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
-        metadata = self.get_metadata(self.request)
-        if not metadata:
-            # get the tus resource_id from the request
-            tus_resource_id = self.kwargs['resource_id']
-            try:
-                tus_file = TusFile(str(tus_resource_id))
-                # get the resource id from the tus metadata
-                metadata = tus_file.metadata
-            except Exception as ex:
-                err_msg = f"Error in getting metadata for the tus upload: {str(ex)}"
-                logger.error(err_msg)
-                # https://tus.io/protocols/resumable-upload#head
-                # return a 404 not found response
-                return HttpResponseNotFound(err_msg)
-
-        # get the hydroshare resource id from the metadata
-        hs_res_id = metadata.get('hs_res_id')
-
-        if not self.request.user.is_authenticated:
-            sessionid = self.request.headers.get('HS-SID', None)
-            # use the cookie to get the django session and user
-            if sessionid:
-                try:
-                    # get the user from the session
-                    session = Session.objects.get(session_key=sessionid)
-                    user_id = session.get_decoded().get('_auth_user_id')
-                    user = User.objects.get(pk=user_id)
-                    self.request.user = user
-                except Exception as ex:
-                    err_msg = f"Error in getting user from session: {str(ex)}"
-                    logger.error(err_msg)
-                    return HttpResponseForbidden(err_msg)
-
-        # check that the user has permission to upload a file to the resource
-        try:
-            view_utils.authorize(self.request, hs_res_id,
-                                 needed_permission=ACTION_TO_AUTHORIZE.EDIT_RESOURCE)
-        except DjangoPermissionDenied:
-            return HttpResponseForbidden()
-
-        return super(CustomTusUpload, self).dispatch(*args, **kwargs)
-
-    def patch(self, request, resource_id, *args, **kwargs):
-
-        tus_file = TusFile.get_tusfile_or_404(str(resource_id))
-
-        # when using the google file picker api, the file size is initially set to 0
-        http_upload_length = request.META.get('HTTP_UPLOAD_LENGTH', None)
-        if tus_file.file_size == 0 and http_upload_length:
-            tus_file.file_size = int(http_upload_length)
-        chunk = TusChunk(request)
-
-        if not tus_file.is_valid():
-            return TusResponse(status=410)
-
-        if chunk.offset != tus_file.offset:
-            return TusResponse(status=409)
-
-        if chunk.offset > tus_file.file_size and tus_file.file_size != 0:
-            return TusResponse(status=413)
-
-        tus_file.write_chunk(chunk=chunk)
-
-        # https://github.com/alican/django-tus/blob/2aac2e7c0e6bac79a1cb07721947a48d9cc40ec8/django_tus/tusfile.py#L151-L152
-        # here we modify from django_tus to allow for the file to be marked as complete
-        if tus_file.is_complete():
-            # file transfer complete, rename from resource id to actual filename
-            tus_file.rename()
-            tus_file.clean()
-
-            self.send_signal(tus_file)
-            self.finished()
-
-        return TusResponse(status=204, extra_headers={'Upload-Offset': tus_file.offset})
-
-    def post(self, request, *args, **kwargs):
-        # adapted from django_tus TusUpload.post
-        # in order to handle missing HTTP_UPLOAD_LENGTH header
-        # https://github.com/alican/django-tus/blob/2aac2e7c0e6bac79a1cb07721947a48d9cc40ec8/django_tus/views.py#L56-L75
-
-        metadata = self.get_metadata(request)
-
-        metadata["filename"] = self.validate_filename(metadata)
-
-        message_id = request.META.get("HTTP_MESSAGE_ID")
-        if message_id:
-            metadata["message_id"] = base64.b64decode(message_id)
-
-        existing = TusFile.check_existing_file(metadata.get("filename", False))
-
-        if settings.TUS_EXISTING_FILE == 'error' and settings.TUS_FILE_NAME_FORMAT == 'keep' and existing:
-            return TusResponse(status=409, reason="File = with same name already exists")
-
-        # set the filesize from HTTP header if it exists, otherwise set it from the metadata
-        file_size = int(request.META.get("HTTP_UPLOAD_LENGTH", "0"))
-        meta_file_size = metadata.get("file_size", None)
-        if meta_file_size and meta_file_size != 'null':
-            file_size = meta_file_size
-
-        tus_file = TusFile.create_initial_file(metadata, file_size)
-
-        return TusResponse(
-            status=201,
-            extra_headers={'Location': '{}{}'.format(request.build_absolute_uri(), tus_file.resource_id)})

--- a/hs_rest_api/urls.py
+++ b/hs_rest_api/urls.py
@@ -245,6 +245,4 @@ urlpatterns = [
 
     re_path(r'^resource/(?P<resource_id>[0-9a-f]+)/quota_holder_bucket_name/$', get_quota_holder_bucket),
 
-    path("tus/", core_views.resource_rest_api.CustomTusUpload.as_view(), name='tus_upload'),
-    path("tus/<uuid:resource_id>", core_views.resource_rest_api.CustomTusUpload.as_view(), name='tus_upload_chunks'),
 ]

--- a/hydroshare/local_settings.template
+++ b/hydroshare/local_settings.template
@@ -170,7 +170,6 @@ using a OneToOneField.
 # SILENCED_SYSTEM_CHECKS = ["mezzanine.core.W03", "fields.W342"]
 
 COMPANION_URL = 'https://localhost/companion'
-UPPY_UPLOAD_PATH = '/hsapi/tus/'
 
 # Intentionally added to repo for testing purposes
 GOOGLE_PICKER_CLIENT_ID = '737951655407-p3d2b2bl2ln90g5plfj09e98bprk42da.apps.googleusercontent.com'

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -454,7 +454,6 @@ INSTALLED_APPS = (
     "health_check.contrib.psutil",
     "health_check.contrib.rabbitmq",
     "mozilla_django_oidc",
-    'django_tus',
 )
 
 TUS_UPLOAD_DIR = '/tmp/tus_upload'
@@ -465,7 +464,6 @@ TUS_EXISTING_FILE = 'error'  # Other options are: 'overwrite',  'error', 'rename
 # the url for the uppy companion server
 # https://uppy.io/docs/companion/
 COMPANION_URL = 'https://companion.hydroshare.org'
-UPPY_UPLOAD_PATH = '/hsapi/tus/'
 MAX_NUMBER_OF_FILES_IN_SINGLE_LOCAL_UPLOAD = 50
 PARALLEL_UPLOADS_LIMIT = 10
 

--- a/local-dev.yml
+++ b/local-dev.yml
@@ -16,6 +16,7 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
       MINIO_BROWSER_REDIRECT: "false"
       MINIO_SCANNER_SPEED: "fastest"
+      # MINIO_API_CORS_ALLOW_ORIGIN: "*"
     command: server --console-address ":9001" /data
   postgis:
     image: postgis/postgis:15-3.3
@@ -170,7 +171,7 @@ services:
       COMPANION_CLIENT_ORIGINS: 'https://localhost'
       # when testing 3rd party services like google drive, you will access hydroshare at http://host.docker.internal:8000
       # you will need to add a line in your /etc/hosts file to map host.docker.internal to localhost
-      COMPANION_UPLOAD_URLS: 'https://localhost/hsapi/tus/*'
+      COMPANION_UPLOAD_URLS: 'https://localhost/*'
       COMPANION_DATADIR: '/mnt/companion-data'
       COMPANION_DOMAIN: 'localhost'
       COMPANION_PATH: '/companion'
@@ -186,6 +187,19 @@ services:
       COMPANION_GOOGLE_SECRET: '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'
       # https://uppy.io/docs/companion/#enablegooglepickerendpoint-companion_enable_google_picker_endpoint
       COMPANION_ENABLE_GOOGLE_PICKER_ENDPOINT: 'true'
+      # https://uppy.io/docs/companion/#s3
+      # https://uppy.io/docs/companion/#s3getkey-filename-metadata-req-
+      COMPANION_AWS_KEY: 'minioadmin'
+      # same as AWS_S3_ACCESS_KEY_ID
+      COMPANION_AWS_SECRET: 'minioadmin'
+      # same as AWS_S3_SECRET_ACCESS_KEY
+      # COMPANION_AWS_ENDPOINT: 'http://minio:9000'
+      COMPANION_AWS_ENDPOINT: 'https://localhost/minio'
+      # COMPANION_AWS_ENDPOINT: 'http://localhost:9000'
+      # same as AWS_S3_ENDPOINT_URL
+      COMPANION_AWS_BUCKET: 'tmp'
+      COMPANION_AWS_REGION: 'us-east-1'
+
     ports:
       - "3020:3020"
     volumes:


### PR DESCRIPTION
Resolves #5686
Requires https://github.com/CUAHSI/platform-recipes/pull/115

The idea here is that we are using Companion to sign urls so that Uppy can use the signed urls to POST files directly into minio: https://uppy.io/docs/aws-s3/#use-with-companion

Also summarized nicely here:
https://uppy.io/docs/companion/#s3

> Companion comes with signature endpoints for AWS S3. These can be used by the Uppy client to sign requests to upload files directly to S3, without exposing secret S3 keys in the browser. Companion also supports uploading files from providers like Dropbox and Instagram directly into S3.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

### Positive Test Case
1. [Enter positive test case here]
