### PR TITLE
[#5964] - strip / in zip file contents filenames

### DIFF
--- a/django_s3/storage.py
+++ b/django_s3/storage.py
@@ -120,7 +120,7 @@ class S3Storage(S3Storage):
                         if not in_prefix:
                             in_prefix = os.path.dirname(in_path) if self.isDir(in_name) else in_path
                         for file_key in filesCollection:
-                            relative_path = file_key.key[len(in_prefix):]
+                            relative_path = file_key.key[len(in_prefix):].strip("/")
                             with zip_archive.open(relative_path, 'w', force_zip64=True) as zip_archive_file:
                                 chunk_request(zip_archive_file, in_bucket_name, file_key.key)
         except ClientError as e:

--- a/hs_composite_resource/tests/test_composite_resource.py
+++ b/hs_composite_resource/tests/test_composite_resource.py
@@ -4140,6 +4140,7 @@ class CompositeResourceTest(
             files = zipfile.namelist()
             self.assertEqual(len(files), len(aggr_files))
             for f in files:
+                self.assertFalse(f.startswith("/"))
                 # strip out the additional folder path in the zip file
                 f = os.path.basename(f)
                 self.assertIn(f, aggr_files)

--- a/hs_core/tests/test_update_quota_usage.py
+++ b/hs_core/tests/test_update_quota_usage.py
@@ -161,7 +161,7 @@ class UpdateQuotaUsageTestCase(TestCase):
 
         # Assert that the quota has been updated correctly
         dz = self.convert_gb_to_bytes(user_quota.data_zone_value)
-        size_of_zip = 215
+        size_of_zip = 213
         expected = self.single_file_size * 3 + size_of_zip
         self.assertAlmostEqual(dz, expected, places=5)
 


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Download a zip on a windows machine and verify it unzips correctly. If you don't have a windows machine, you can download the zip and use zipinfo to ensure there is not a `/` at the beginning of the file content filenames.
