### PR TITLE
[#6033] Restrict file size in uppy dashboard, for Google Drive transfers

### DIFF
--- a/hs_core/static/js/hs_uppy.mjs
+++ b/hs_core/static/js/hs_uppy.mjs
@@ -126,8 +126,6 @@ else{
       }
       
       const file_size = currentFile.data.size;
-      // check file size against RESTRICTED_SIZE
-      // this is because the Google Drive Picker does not natively enforce the maxFileSize restriction
       if (file_size > RESTRICTED_SIZE) {
         uppy.info(
           `File ${currentFile.name} exceeds the maximum file size of ${formatBytes(parseInt(RESTRICTED_SIZE))}.`,


### PR DESCRIPTION
Resolves #6033
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Attempt to upload a file from Google Drive that exceeds your current quota
2. See that your upload is denied
