### PR TITLE
[NO MERGE!] run task every minute for testing celery/flower/eventing

### DIFF
--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -116,6 +116,9 @@ def setup_periodic_tasks(sender, **kwargs):
     if (hasattr(settings, 'DISABLE_PERIODIC_TASKS') and settings.DISABLE_PERIODIC_TASKS):
         logger.debug("Periodic tasks are disabled in SETTINGS")
     else:
+        # every min for testing
+        sender.add_periodic_task(crontab(minute='*'), nightly_repair_resource_files.s(),
+                                 options={'queue': 'periodic'})
         # Hourly
         sender.add_periodic_task(crontab(minute=0), check_bucket_names.s(), options={'queue': 'periodic'})
 
@@ -131,8 +134,8 @@ def setup_periodic_tasks(sender, **kwargs):
                                  options={'queue': 'periodic'})
         sender.add_periodic_task(crontab(minute=0, hour=5), check_geoserver_registrations.s(),
                                  options={'queue': 'periodic'})
-        sender.add_periodic_task(crontab(minute=30, hour=5), nightly_repair_resource_files.s(),
-                                 options={'queue': 'periodic'})
+        # sender.add_periodic_task(crontab(minute=30, hour=5), nightly_repair_resource_files.s(),
+        #                          options={'queue': 'periodic'})
         sender.add_periodic_task(crontab(minute=0, hour=6), nightly_cache_file_system_metadata.s(),
                                  options={'queue': 'periodic'})
         sender.add_periodic_task(crontab(minute=30, hour=6), nightly_periodic_task_check.s(),


### PR DESCRIPTION
testing for 
https://github.com/hydroshare/hydroshare/pull/6106#discussion_r2469916998

> @sblack-usu in testing this PR locally, attempted to kick off async tasks every minute. When I look at Flower, I don't see that any tasks get started. When I look at redPanda console, I can see that the `periodic` topic has been created, but there aren't any messages in the topic.
> 
> When I manually kick off an async task: `nightly_repair_resource_files.apply_async(())` It gets created in its own topic in RPC, that's fine. It still doesn't show up in FLOWER fyi so we might just want to get rid of flower...?
> 
> But I'm bringing this to your attention because it really seems to me that the periodic tasks might not be running which is relevant as we test [3.11.0](https://github.com/hydroshare/hydroshare/issues/6100)

Build this PR locally
Check out:
* http://localhost:8080/topics
* http://localhost:5555/tasks
