### PR TITLE
Moving same behaviour from celery

### DIFF
--- a/django_s3/views.py
+++ b/django_s3/views.py
@@ -35,7 +35,7 @@ from hs_core.signals import (pre_check_bag_flag, pre_download_file,
 from hs_core.task_utils import (get_or_create_task_notification,
                                 get_resource_bag_task, get_task_notification,
                                 get_task_user_id)
-from hs_core.tasks import create_bag_by_s3, create_temp_zip, set_resource_files_system_metadata
+from hs_core.tasks import create_bag_by_s3, create_temp_zip
 from hs_core.views.utils import ACTION_TO_AUTHORIZE, authorize, is_ajax
 from hs_file_types.enums import AggregationMetaFilePath
 
@@ -608,7 +608,8 @@ class CustomTusUpload(TusUpload):
             resource_modified(resource, user, overwrite_bag=False)
 
             # store file level system metadata in Django DB (async task)
-            set_resource_files_system_metadata.apply_async((resource.short_id,))
+            # Migrated to s3_event new architecture, so this is no longer needed here
+            # set_resource_files_system_metadata.apply_async((resource.short_id,))
 
             # signal is not consumed at this point, but we keep it for future use
             # https://github.com/alican/django-tus/blob/2aac2e7c0e6bac79a1cb07721947a48d9cc40ec8/django_tus/views.py#L112

--- a/hs_core/hydroshare/resource.py
+++ b/hs_core/hydroshare/resource.py
@@ -662,8 +662,6 @@ def add_resource_files(pk, *files, **kwargs):
     This does **not** handle mutability; changes to immutable resources should be denied elsewhere.
 
     """
-    from hs_core.tasks import set_resource_files_system_metadata
-
     resource = kwargs.pop("resource", None)
     if resource is None:
         resource = utils.get_resource_by_shortkey(pk)
@@ -735,7 +733,8 @@ def add_resource_files(pk, *files, **kwargs):
         utils.resource_modified(resource, user, overwrite_bag=False)
 
         # store file level system metadata in Django DB (async task)
-        set_resource_files_system_metadata.apply_async((resource.short_id,))
+        # moved to new s3_event, so no longer needed here
+        # set_resource_files_system_metadata.apply_async((resource.short_id,))
 
     return uploaded_res_files
 

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -1141,23 +1141,6 @@ def move_aggregation_task(res_id, file_type_id, file_type, tgt_path):
     return res.get_absolute_url()
 
 
-@shared_task
-def set_resource_files_system_metadata(resource_id):
-    """
-    Sets size, checksum, and modified time for resource files by getting these values
-    from S3 and stores in db
-    :param resource_id: the id of the resource for which to set system metadata for all files currently missing
-    these metadata in db
-    """
-    resource = utils.get_resource_by_shortkey(resource_id)
-    res_files = resource.files.exclude(_size__gte=0).all()
-    for res_file in res_files:
-        res_file.set_system_metadata(resource=resource, save=False)
-
-    ResourceFile.objects.bulk_update(res_files, ResourceFile.system_meta_fields(),
-                                     batch_size=settings.BULK_UPDATE_CREATE_BATCH_SIZE)
-
-
 @celery_app.task(ignore_result=True, base=HydroshareTask, time_limit=NIGHTLY_GENERATE_FILESYSTEM_METADATA_DURATION)
 def nightly_cache_file_system_metadata():
     """

--- a/hs_core/tasks.py
+++ b/hs_core/tasks.py
@@ -1104,15 +1104,6 @@ def get_non_preferred_paths(resource_id):
 
 
 @shared_task
-def unzip_task(user_pk, res_id, zip_with_rel_path, bool_remove_original, overwrite=False, auto_aggregate=False,
-               ingest_metadata=False, unzip_to_folder=False):
-    from hs_core.views.utils import unzip_file
-    user = User.objects.get(pk=user_pk)
-    unzip_file(user, res_id, zip_with_rel_path, bool_remove_original, overwrite, auto_aggregate, ingest_metadata,
-               unzip_to_folder)
-
-
-@shared_task
 def move_aggregation_task(res_id, file_type_id, file_type, tgt_path):
     from hs_core.views.utils import rename_s3_file_or_folder_in_django
     res = utils.get_resource_by_shortkey(res_id)
@@ -1141,7 +1132,9 @@ def move_aggregation_task(res_id, file_type_id, file_type, tgt_path):
     return res.get_absolute_url()
 
 
-@celery_app.task(ignore_result=True, base=HydroshareTask, time_limit=NIGHTLY_GENERATE_FILESYSTEM_METADATA_DURATION)
+@celery_app.task(
+    ignore_result=True, base=HydroshareTask, time_limit=NIGHTLY_GENERATE_FILESYSTEM_METADATA_DURATION
+)
 def nightly_cache_file_system_metadata():
     """
     Generate and store file checksums and modified times for a subset of resources

--- a/hs_core/views/resource_folder_hierarchy.py
+++ b/hs_core/views/resource_folder_hierarchy.py
@@ -19,7 +19,7 @@ from hs_core.hydroshare.utils import (QuotaException, get_file_mime_type,
                                       resolve_request)
 from hs_core.models import ResourceFile
 from hs_core.task_utils import get_or_create_task_notification
-from hs_core.tasks import FileOverrideException, unzip_task
+from hs_core.tasks import FileOverrideException
 from hs_core.views import utils as view_utils
 from hs_core.views.utils import (ACTION_TO_AUTHORIZE,
                                  add_reference_url_to_resource, authorize,
@@ -472,13 +472,36 @@ def data_store_folder_unzip(request, **kwargs):
     unzip_to_folder = request.POST.get('unzip_to_folder', 'false').lower() == 'true'
 
     if is_ajax(request):
-        task = unzip_task.apply_async((user.pk, res_id, zip_with_rel_path, remove_original_zip, overwrite,
-                                       auto_aggregate, ingest_metadata, unzip_to_folder))
-        task_id = task.task_id
-        task_dict = get_or_create_task_notification(task_id, name='file unzip', username=request.user.username,
-                                                    payload=resource.get_absolute_url())
+        import threading
+        from uuid import uuid4
+
+        job_id = str(uuid4())
+        task_dict = get_or_create_task_notification(
+            job_id,
+            name='file unzip',
+            username=request.user.username,
+            payload=resource.get_absolute_url()
+        )
+
+        def extract_async():
+            try:
+                unzip_file(user, res_id, zip_with_rel_path, remove_original_zip, overwrite,
+                           auto_aggregate, ingest_metadata, unzip_to_folder)
+                get_or_create_task_notification(
+                    job_id, status='completed', payload=resource.get_absolute_url()
+                )
+            except Exception as ex:
+                get_or_create_task_notification(
+                    job_id, status='failed', payload=str(ex)
+                )
+
+        thread = threading.Thread(target=extract_async)
+        thread.daemon = True
+        thread.start()
+
         return JsonResponse(task_dict)
     else:
+        # Synchronous unzip (non-AJAX requests)
         try:
             unzip_file(user, res_id, zip_with_rel_path, remove_original_zip, overwrite, auto_aggregate,
                        ingest_metadata, unzip_to_folder)

--- a/hs_event_s3/hsevent/processors/hs_django_s3_processor.py
+++ b/hs_event_s3/hsevent/processors/hs_django_s3_processor.py
@@ -19,6 +19,7 @@ s3 = boto3.client('s3')
 def link_s3_files_to_resource(resource, fullpath):
     try:
         res_file = link_s3_file_to_django(resource, fullpath)
+        res_file.set_system_metadata(resource=resource, save=True)
         # Create required logical files as necessary
         if resource.resource_type == "CompositeResource":
             file_type = get_logical_file_type(res=resource, file_id=res_file.pk, fail_feedback=False)

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -939,7 +939,6 @@ HSWS_GEOSERVER_URL = "https://geoserver.hydroshare.org/geoserver"
 TASK_NAME_LIST = [
     "hs_core.tasks.create_bag_by_s3",
     "hs_core.tasks.create_temp_zip",
-    "hs_core.tasks.unzip_task",
     "hs_core.tasks.copy_resource_task",
     "hs_core.tasks.create_new_version_resource_task",
     "hs_core.tasks.delete_resource_task",


### PR DESCRIPTION
## Commit - 1 :

This change removes the Celery task set_resource_files_system_metadata and moves the same behavior into the S3 event pipeline.

set_resource_files_system_metadata fits Category 2 , triggered by a system event

_Local verification:_

- I tested on the branch containing this change (the Celery task set_resource_files_system_metadata is removed and the logic now lives in the S3 processor).
- I used an existing local resource: 279b70d3919f4d70b53bb95095d8b118 (already had timeseries.csv).
- After applying the new code changes, I uploaded one more file: data (4).csv.

**Before applying changes 
Only the original file (timeseries.csv) exists.**

<img width="1225" height="774" alt="Screenshot 2026-02-15 at 10 23 06 PM" src="https://github.com/user-attachments/assets/fb5ba420-a21c-45e5-8bab-b776efdabd40" />


**After applying chnages and uploading data (4).csv:
Both files appear**

<img width="1228" height="802" alt="Screenshot 2026-02-15 at 10 24 17 PM" src="https://github.com/user-attachments/assets/34f7e4d8-4741-463e-aea4-14bb06ef8344" />




## Commit - 2 :

Ignore the thread based approach here, Refer this for Aysnc user tracking using RP Connect https://github.com/hydroshare/hydroshare/pull/6222