### PR TITLE
fix: workaround for broken marker icon

### DIFF
--- a/discovery-atlas/frontend/src/components/search-results/cd.spatial-coverage-map.vue
+++ b/discovery-atlas/frontend/src/components/search-results/cd.spatial-coverage-map.vue
@@ -8,6 +8,17 @@
 import { Component, Vue, Prop, Ref, toNative } from "vue-facing-decorator";
 import L from "leaflet";
 import "leaflet.fullscreen";
+import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerShadow from "leaflet/dist/images/marker-shadow.png";
+
+// Fix Leaflet's broken default icon paths when bundled with Vite
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow,
+});
 
 const coverageMapBoxMaxZoom = 18;
 const coverageMapPointMaxZoom = 7;


### PR DESCRIPTION
[#6242] Workaround for broken marker icon.

See https://github.com/Leaflet/Leaflet/issues/4968

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Go to the new Discover page at '/atlas'
2. Perform a search for a dataset with point spatial coverage.
3. Verify that the marker icon is rendered.
