### PR TITLE
Render show more button only when clamped text

### DIFF
--- a/discovery-atlas/frontend/src/components/search-results/cd.search-results.vue
+++ b/discovery-atlas/frontend/src/components/search-results/cd.search-results.vue
@@ -252,10 +252,11 @@
                               stacked
                               class="pa-0 pb-4"
                               :border="0"
-                              ref="el"
+                              :ref="(el) => setBannerRef(el, item)"
                             >
                               <template v-slot:actions>
                                 <v-btn
+                                  v-if="item._isClamped || item._showMore"
                                   @click="item._showMore = !item._showMore"
                                   size="x-small"
                                   >{{
@@ -676,6 +677,18 @@ class CdSearchResults extends Vue {
 
   public get results(): IResult[] {
     return Search.$state.results;
+  }
+
+  public setBannerRef(el: any, item: IResult) {
+    if (el && !item._showMore) {
+      this.$nextTick(() => {
+        const bannerEl = el.$el || el;
+        const textEl = bannerEl.querySelector(".v-banner-text");
+        if (textEl) {
+          item._isClamped = textEl.scrollHeight > textEl.clientHeight;
+        }
+      });
+    }
   }
 
   public get isSomeFilterActive() {

--- a/discovery-atlas/frontend/src/types.ts
+++ b/discovery-atlas/frontend/src/types.ts
@@ -31,6 +31,7 @@ export interface IResult {
   views: number;
   temporalCoverage?: { startDate: string, endDate: string }
   _showMore?: boolean; // Used to toggle 'show more...' button
+  _isClamped?: boolean; // True when the description is visually clamped
   _paginationToken: string;
 }
 


### PR DESCRIPTION
[#6240] Makes the 'show more' and 'show less' buttons show only when the text is actually clamped.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

### Positive Test Case
1. Go to the new Discovery page at '/atlas'.
2. Expand a result with a long abstract.
3. Verify that the 'show more' button only appears when the abstract is clamped.
