### PR TITLE
Omit bucket name in s3 path to avoid duplicate discoverable records after publish

### DIFF
--- a/hs_core/hydroshare_atlas_discovery_collection.py
+++ b/hs_core/hydroshare_atlas_discovery_collection.py
@@ -40,7 +40,7 @@ def collect_file_to_catalog(filepath: str):
                     # skip adding replaced resources to the catalog
                     return
 
-    metadata_json['_s3_filepath'] = filepath
+    metadata_json['_s3_filepath'] = object_key
     metadata_json['first_creator'] = (
         metadata_json['creator'][0]
         if 'creator' in metadata_json and metadata_json['creator']
@@ -65,4 +65,5 @@ def collect_file_to_catalog(filepath: str):
 
 def delete_file_from_catalog(filepath: str):
     print("Deleting file from catalog:", filepath)
-    hydroshare_atlas_db["discovery"].delete_one({"_s3_filepath": filepath})
+    _, object_key = filepath.split('/', 1)
+    hydroshare_atlas_db["discovery"].delete_one({"_s3_filepath": object_key})

--- a/hs_core/hydroshare_atlas_discovery_collection.py
+++ b/hs_core/hydroshare_atlas_discovery_collection.py
@@ -40,6 +40,7 @@ def collect_file_to_catalog(filepath: str):
                     # skip adding replaced resources to the catalog
                     return
 
+    metadata_json['_s3_filepath'] = filepath
     metadata_json['first_creator'] = (
         metadata_json['creator'][0]
         if 'creator' in metadata_json and metadata_json['creator']
@@ -58,10 +59,10 @@ def collect_file_to_catalog(filepath: str):
     #         content_types.append(json_dict.get('additionalType'))
     #     metadata_json['content_types'] = list(set(content_types))
 
-    hydroshare_atlas_db["discovery"].find_one_and_replace({"url": metadata_json["url"]},
+    hydroshare_atlas_db["discovery"].find_one_and_replace({"_s3_filepath": metadata_json["_s3_filepath"]},
                                                           metadata_json, upsert=True)
 
 
 def delete_file_from_catalog(filepath: str):
     print("Deleting file from catalog:", filepath)
-    hydroshare_atlas_db["discovery"].delete_one({"url": filepath})
+    hydroshare_atlas_db["discovery"].delete_one({"_s3_filepath": filepath})

--- a/hs_core/hydroshare_atlas_discovery_collection.py
+++ b/hs_core/hydroshare_atlas_discovery_collection.py
@@ -40,7 +40,6 @@ def collect_file_to_catalog(filepath: str):
                     # skip adding replaced resources to the catalog
                     return
 
-    metadata_json['_s3_filepath'] = filepath
     metadata_json['first_creator'] = (
         metadata_json['creator'][0]
         if 'creator' in metadata_json and metadata_json['creator']
@@ -59,10 +58,10 @@ def collect_file_to_catalog(filepath: str):
     #         content_types.append(json_dict.get('additionalType'))
     #     metadata_json['content_types'] = list(set(content_types))
 
-    hydroshare_atlas_db["discovery"].find_one_and_replace({"_s3_filepath": metadata_json["_s3_filepath"]},
+    hydroshare_atlas_db["discovery"].find_one_and_replace({"url": metadata_json["url"]},
                                                           metadata_json, upsert=True)
 
 
 def delete_file_from_catalog(filepath: str):
     print("Deleting file from catalog:", filepath)
-    hydroshare_atlas_db["discovery"].delete_one({"_s3_filepath": filepath})
+    hydroshare_atlas_db["discovery"].delete_one({"url": filepath})


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

Fixes an issue where duplicate discovery records end up in the discovery collection after a resource is published. This was due to _s3_filepath changing after publish. The url property does not change and prevents duplicate records from persisting after publish.

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

### Positive Test Case
1. Verify discoverable records _s3_filepath property begins with resource id
