### PR TITLE
[#6354] Optimize user resource permission check

### DIFF
--- a/hs_access_control/models/resource.py
+++ b/hs_access_control/models/resource.py
@@ -469,6 +469,8 @@ class ResourceAccess(models.Model):
             raise PermissionDenied("Grantee user is not active")
 
         user_priv = self.get_effective_user_privilege(this_user, ignore_superuser=ignore_superuser)
+        if user_priv in (PC.OWNER, PC.CHANGE):
+            return user_priv  # user privilege is highest, no need to check group or community
         group_priv = self.get_effective_group_privilege(this_user)
         # community_priv = self.get_effective_community_privilege(this_user)
         return min(user_priv, group_priv)  # , community_priv)

--- a/hs_access_control/models/user.py
+++ b/hs_access_control/models/user.py
@@ -1170,6 +1170,31 @@ class UserAccess(models.Model):
     # PUBLIC METHODS: resources
     ##########################################
 
+    def __resource_view_q(self):
+        return (
+            Q(r2urp__user=self.user)
+            | Q(r2grp__group__gaccess__active=True, r2grp__group__g2ugp__user=self.user)
+        )
+
+    def __resource_edit_q(self):
+        return (
+            # user owns resource invariant of immutable flag 4/9/2021
+            Q(r2urp__user=self.user, r2urp__privilege=PrivilegeCodes.OWNER)
+            # user has direct access and resource is not immutable
+            | Q(
+                raccess__immutable=False,
+                r2urp__user=self.user,
+                r2urp__privilege__lte=PrivilegeCodes.CHANGE,
+            )
+            # user has direct access through being a member of a group
+            | Q(
+                raccess__immutable=False,
+                r2grp__group__gaccess__active=True,
+                r2grp__group__g2ugp__user=self.user,
+                r2grp__privilege=PrivilegeCodes.CHANGE,
+            )
+        )
+
     @property
     def view_resources(self):
         """
@@ -1183,12 +1208,7 @@ class UserAccess(models.Model):
         if not self.user.is_active:
             raise PermissionDenied("Requesting user is not active")
 
-        return BaseResource.objects.filter(
-            # direct access
-            Q(r2urp__user=self.user)
-            # access via a group share
-            | Q(r2grp__group__gaccess__active=True, r2grp__group__g2ugp__user=self.user)
-        ).distinct()
+        return BaseResource.objects.filter(self.__resource_view_q()).distinct()
 
     @property
     def owned_resources(self):
@@ -1228,23 +1248,7 @@ class UserAccess(models.Model):
         # 1. it's shared with the user and editable.
         # 2. it's shared with a group that has edit privilege and contains the user,
 
-        return BaseResource.objects.filter(
-            # user owns resource invariant of immutable flag 4/9/2021
-            Q(r2urp__user=self.user, r2urp__privilege=PrivilegeCodes.OWNER)
-            # user has direct access and resource is not immutable
-            | Q(
-                raccess__immutable=False,
-                r2urp__user=self.user,
-                r2urp__privilege__lte=PrivilegeCodes.CHANGE,
-            )
-            # user has direct access through being a member of a group
-            | Q(
-                raccess__immutable=False,
-                r2grp__group__gaccess__active=True,
-                r2grp__group__g2ugp__user=self.user,
-                r2grp__privilege=PrivilegeCodes.CHANGE,
-            )
-        ).distinct()
+        return BaseResource.objects.filter(self.__resource_edit_q()).distinct()
 
     def get_resources_with_explicit_access(self, this_privilege,
                                            via_user=True, via_group=False):
@@ -1473,10 +1477,11 @@ class UserAccess(models.Model):
         if access_resource.immutable:
             return False
 
-        if self.edit_resources.filter(id=this_resource.id).exists():
-            return True
+        can_change = BaseResource.objects.filter(
+            Q(id=this_resource.id) & self.__resource_edit_q()
+        ).exists()
 
-        return False
+        return can_change
 
     def can_change_resource_shareable_flag(self, this_resource):
         """
@@ -1562,10 +1567,11 @@ class UserAccess(models.Model):
         if self.user.is_superuser:
             return True
 
-        if self.view_resources.filter(id=this_resource.id).exists():
-            return True
+        can_view = BaseResource.objects.filter(
+            Q(id=this_resource.id) & self.__resource_view_q()
+        ).exists()
 
-        return False
+        return can_view
 
     def can_view_resources_owned_by(self, owner):
         """


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [ ] Sufficient User and Developer Documentation

### Positive Test Case
1. [Enter positive test case here]

### PR Summary:
The main change is that permission evaluation now short-circuits when a user already has owner or change-level access, avoiding extra group/community lookups that cannot change the result. This should reduce redundant database work and improve performance for permission-heavy code paths, while preserving the existing access rules
