### PR TITLE
6351: Fix discovery sort overridden when no filters present

### DIFF
--- a/hs_rest_api/discovery_atlas.py
+++ b/hs_rest_api/discovery_atlas.py
@@ -358,10 +358,8 @@ class SearchQuery(BaseModel):
         order = 1 if self.order == "asc" else -1
 
         # These sorts can occur inside the $search stage
-        if not self.term and not self.has_filters:
-            # override search to most recently modified if no search criteria is provided
-            search_stage["$search"]['sort'] = {"dateModified": -1}
-        elif self.sortBy == "name":
+
+        if self.sortBy == "name":
             search_stage["$search"]['sort'] = {"name": order}
         elif self.sortBy == "dateCreated":
             search_stage["$search"]['sort'] = {"dateCreated": order}
@@ -371,6 +369,9 @@ class SearchQuery(BaseModel):
             search_stage["$search"]['sort'] = {"first_creator.name": order}
         elif self.sortBy == "viewCount":
             search_stage["$search"]['sort'] = {"viewCount": order}
+        # If no sort is provided, default to sort by dateModified descending
+        else:
+            search_stage["$search"]['sort'] = {"dateModified": -1}
 
         stages.append(search_stage)
 

--- a/hs_rest_api/tests/http/test_discovery_atlas.py
+++ b/hs_rest_api/tests/http/test_discovery_atlas.py
@@ -292,6 +292,28 @@ class TestSearchQuery(ParametrizedTestCase):
 
         self.assertFalse(any("fuzzy" in clause["autocomplete"] for clause in should_clauses))
 
+    @parametrize(
+        "sort_by,order,expected_sort",
+        [
+            param(None, None, {"dateModified": -1}, id="default_sort"),
+            param("name", "asc", {"name": 1}, id="name_asc"),
+            param("dateCreated", "asc", {"dateCreated": 1}, id="date_created_asc"),
+            param("lastModified", "desc", {"dateModified": -1}, id="last_modified_desc"),
+            param("creatorName", "asc", {"first_creator.name": 1}, id="creator_name_asc"),
+            param("viewCount", "desc", {"viewCount": -1}, id="view_count_desc"),
+        ],
+    )
+    def test_stages_respects_sort_(self, sort_by, order, expected_sort):
+        search_query = SearchQuery(
+            sortBy=sort_by,
+            order=order,
+            paginationToken=None,
+        )
+
+        stages = search_query.stages
+
+        self.assertEqual(stages[0]["$search"]["sort"], expected_sort)
+
     def test_stages_multiple_content_types(self):
         content_types = ["CSVLogicalFile", "CollectionResource"]
 


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

Fixes a bug where caller-specified sort order was being overridden when no query params were passed in the search request.  

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Run app locally from this branch
2. View discovery page
3. Query for results without specifying any filters or search term but a specific sort order

Before (user-specified sort ignored -- sorting by Title asc, "Groundwater" should come first):
<img width="1320" height="833" alt="Screenshot 2026-07-13 at 10 55 28 AM" src="https://github.com/user-attachments/assets/b4defc4f-df57-42fd-91b7-981f0c308d84" />

After (user-specified sort respected):
<img width="1309" height="819" alt="Screenshot 2026-07-13 at 10 51 41 AM" src="https://github.com/user-attachments/assets/2a5eb97c-8680-4cb9-9691-04dafda7c840" />

Resolves #6351 
