### PR TITLE
6347: Don't update modified timestamp when system-managed relation metadata changes

### DIFF
--- a/hs_core/management/commands/seed_dev_resources.py
+++ b/hs_core/management/commands/seed_dev_resources.py
@@ -213,7 +213,7 @@ def _stagger_dates(resource, index):
 
     # 3. Sync cached_metadata JSON from the updated Date elements
     resource.refresh_from_db()
-    resource.update_cached_metadata_field(field_name='all')
+    resource.update_cached_metadata_field(field_name='all', update_modified_date=True)
 
 
 def _base_metadata(owner, index):

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2201,7 +2201,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
         # using update query api to update instead of self.save() to avoid triggering search index update
         type(self).objects.filter(id=self.id).update(download_count=self.download_count)
 
-    def update_cached_metadata_field(self, field_name, relation_type=None):
+    def update_cached_metadata_field(self, field_name: str, update_modified_date: bool):
         """
         Update a specific field in the cached metadata or all fields if 'all' is specified
 
@@ -2257,13 +2257,9 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
                 copied_metadata['modified'] = modified_date.start_date.isoformat()
             else:
                 copied_metadata['modified'] = self.updated.isoformat()
-        # Skip bumping 'modified' for system-managed relation types (hasPart, isPartOf, etc.) —
-        # those are managed via update_collection which calls resource_modified() explicitly.
-        # User-editable relation types (isDescribedBy, references, etc.) still bump modified.
-        elif field_name != 'relation' or (
-            relation_type is not None
-            and relation_type not in {r.value for r in Relation.NOT_USER_EDITABLE}
-        ):
+        # Optionally update the modified date if specified -- some metadata element changes represent
+        # internal system and not user changes, therefore may not trigger modified date change
+        if update_modified_date:
             copied_metadata['modified'] = now().isoformat()
             if modified_date:
                 # this update won't trigger the post_save signal for Date model since we are using update query api
@@ -2594,7 +2590,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
         Update all fields in the cached metadata
         This method is primarily for use in management commands to refresh cached metadata
         """
-        self.update_cached_metadata_field(field_name='all')
+        self.update_cached_metadata_field(field_name='all', update_modified_date=True)
 
     # definition of resource logic
     @property

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -45,6 +45,9 @@ from rdflib.namespace import DC, DCTERMS, RDF
 from spam_patterns.worst_patterns_re import patterns
 
 from django_s3.storage import S3Storage
+
+# Matches the 32-char hex resource short_id in a HydroShare resource URL.
+RESOURCE_ID_RE = re.compile(r'/resource/([0-9a-f]{32})\b')
 from hs_core.enums import (DataciteSubmissionStatus, RelationTypes)
 from hs_core.s3 import ResourceFileS3Mixin, ResourceS3Mixin
 
@@ -4912,8 +4915,9 @@ class BaseResource(Page, AbstractResource):
             replace_relation_meta = resource.metadata.relations.all().filter(type=RelationTypes.isReplacedBy).first()
             if replace_relation_meta is not None:
                 version_citation = replace_relation_meta.value
-                if '/resource/' in version_citation:
-                    version_res_id = version_citation.split('/resource/')[-1]
+                match = RESOURCE_ID_RE.search(version_citation)
+                if match:
+                    version_res_id = match.group(1)
                     try:
                         new_version_res = get_resource_by_shortkey(version_res_id, or_404=False)
                         replaced_by_resources.append(new_version_res)
@@ -5004,10 +5008,25 @@ class BaseResource(Page, AbstractResource):
             relation_updated = False
             if relation_meta_obj.value and '/resource/' in relation_meta_obj.value:
                 version_citation = relation_meta_obj.value
-                version_res_id = version_citation.split('/resource/')[-1]
+                match = RESOURCE_ID_RE.search(version_citation)
+                if not match:
+                    logger = logging.getLogger(__name__)
+                    logger.warning(
+                        f"update_relation_meta: skipping {relation_meta_obj.type} relation "
+                        f"(id={relation_meta_obj.id}) on resource {self.short_id} — "
+                        f"could not extract resource ID from stored value: {relation_meta_obj.value[:200]!r}"
+                    )
+                    return relation_updated
+                version_res_id = match.group(1)
                 try:
                     version_res = get_resource_by_shortkey(version_res_id, or_404=False)
                 except BaseResource.DoesNotExist:
+                    logger = logging.getLogger(__name__)
+                    logger.warning(
+                        f"update_relation_meta: deleting {relation_meta_obj.type} relation "
+                        f"(id={relation_meta_obj.id}) on resource {self.short_id} — "
+                        f"linked resource id '{version_res_id}' does not exist."
+                    )
                     relation_meta_obj.delete()
                     relation_updated = True
                     return relation_updated
@@ -5017,7 +5036,7 @@ class BaseResource(Page, AbstractResource):
                     relation_meta_obj.save()
                     relation_updated = True
             return relation_updated
-
+        
         relations = self.metadata.relations.all()
         replace_relation = [rel for rel in relations if rel.type == RelationTypes.isReplacedBy]
         replace_relation_updated = False

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -3089,11 +3089,13 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
         return str(self.metadata.citation.first())
 
     def get_citation(self, forceHydroshareURI=True):
-        """Get citation or citations from resource metadata using cached_metadata."""
+        """Get citation string from resource metadata using cached_metadata.
 
+        Format: Author, A., Author2, B. (year). Title, HydroShare, url
+        """
         logger = logging.getLogger(__name__)
-        citation_str_lst = []
         CITATION_ERROR = "Failed to generate citation."
+        CITATION_TEMPLATE = "{authors} ({year}). {title}, HydroShare, {url}{pending_suffix}"
 
         # Get creators from cached_metadata
         self.refresh_from_db(fields=['cached_metadata'])
@@ -3108,42 +3110,33 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
             logger.error(f"{CITATION_ERROR} No first creator found in cached_metadata for resource {self.short_id}")
             return CITATION_ERROR
 
-        # Format first creator name
-        creator_name = first_creator.get('name', '')
-        creator_name = creator_name.strip() if creator_name else ''  # No Nonetype
-        if first_creator.get('organization', '') and not creator_name:
-            citation_str_lst.append(first_creator['organization'] + ", ")
+        # Build authors string — each parse_citation_name call appends ', '; trim the last one
+        author_parts = []
+        creator_name = (first_creator.get('name') or '').strip()
+        if first_creator.get('organization') and not creator_name:
+            author_parts.append(first_creator['organization'] + ", ")
         else:
             is_non_hs_user = not first_creator.get('hs_user_id')
-            citation_str_lst.append(self.parse_citation_name(creator_name, is_non_hs_user=is_non_hs_user))
+            author_parts.append(self.parse_citation_name(creator_name, is_non_hs_user=is_non_hs_user))
 
-        # Add other creators
-        other_creators = [c for c in cached_creators if c.get('order', 0) > 1]
-        for author in other_creators:
-            author_name = author.get('name', '')
-            author_name = author_name.strip() if author_name else ''  # No Nonetype
-            if author.get('organization', '') and not author_name:
-                citation_str_lst.append(author['organization'] + ", ")
-            elif author_name and len(author_name) != 0:
-                # Check if this is a non-HydroShare user who might have entered name incorrectly
+        for author in [c for c in cached_creators if c.get('order', 0) > 1]:
+            author_name = (author.get('name') or '').strip()
+            if author.get('organization') and not author_name:
+                author_parts.append(author['organization'] + ", ")
+            elif author_name:
                 is_non_hs_user = not author.get('hs_user_id')
-                citation_str_lst.append(self.parse_citation_name(author_name, is_non_hs_user=is_non_hs_user))
+                author_parts.append(self.parse_citation_name(author_name, is_non_hs_user=is_non_hs_user))
 
-        # Remove the last added comma and space
-        if len(citation_str_lst[-1]) > 2:
-            citation_str_lst[-1] = citation_str_lst[-1][:-2]
+        if len(author_parts[-1]) > 2:
+            author_parts[-1] = author_parts[-1][:-2]  # strip trailing ', '
         else:
-            err_msg = f"No valid creator names found in cached_metadata for resource {self.short_id}"
-            logger.error(f"{CITATION_ERROR} {err_msg}")
+            logger.error(f"{CITATION_ERROR} No valid creator names found in cached_metadata for resource {self.short_id}")
             return CITATION_ERROR
 
-        # Get citation date from cached_metadata
-        citation_date = None
-        if self.cached_metadata.get('published', ''):
-            citation_date = self.cached_metadata['published']
-        elif self.cached_metadata.get('modified'):
-            citation_date = self.cached_metadata['modified']
+        authors = "".join(author_parts)
 
+        # Get citation year
+        citation_date = self.cached_metadata.get('published') or self.cached_metadata.get('modified')
         if not citation_date:
             err_msg = f"No published or modified date found in cached_metadata for resource {self.short_id}"
             logger.error(f"{CITATION_ERROR} {err_msg}")
@@ -3154,10 +3147,10 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
             citation_date_obj = parser.parse(citation_date)
             citation_year = citation_date_obj.year
         except (ValueError, TypeError):
-            logger.error(f"{CITATION_ERROR} Invalid date found in cached_metadata for resource {self.short_id}")
+            logger.error(f"{CITATION_ERROR} Invalid date in cached_metadata for resource {self.short_id}")
             return CITATION_ERROR
 
-        citation_str_lst.append(" ({year}). ".format(year=citation_year))
+        # Get title
         title = self.cached_metadata.get('title', {})
         if not title:
             logger.error(f"{CITATION_ERROR} No title found in cached_metadata for resource {self.short_id}")
@@ -3166,33 +3159,35 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
         if not title_value:
             logger.error(f"{CITATION_ERROR} No title value found in cached_metadata for resource {self.short_id}")
             return CITATION_ERROR
-        citation_str_lst.append(title_value)
 
         # Check for DOI identifier
         isPendingActivation = False
         identifiers = self.cached_metadata.get('identifiers', [])
-        doi = [idn for idn in identifiers if idn.get('name') == "doi"]
+        doi_list = [idn for idn in identifiers if idn.get('name') == "doi"]
 
-        if doi and not forceHydroshareURI:
-            hs_identifier = doi[0]
+        if doi_list and not forceHydroshareURI:
+            identifier = doi_list[0]
             if (self.doi.find(DataciteSubmissionStatus.PENDING.value) >= 0
                     or self.doi.find(DataciteSubmissionStatus.FAILURE.value) >= 0):
                 isPendingActivation = True
         else:
-            hs_identifier = [idn for idn in identifiers if idn.get('name') == "hydroShareIdentifier"]
-            if hs_identifier:
-                hs_identifier = hs_identifier[0]
-            else:
-                err_msg = f"No hydroShareIdentifier found in cached_metadata for resource {self.short_id}"
-                logger.error(f"{CITATION_ERROR} {err_msg}")
+            hs_id_list = [idn for idn in identifiers if idn.get('name') == 'hydroShareIdentifier']
+            if not hs_id_list:
+                logger.error(f"{CITATION_ERROR} No hydroShareIdentifier found for resource {self.short_id}")
                 return CITATION_ERROR
+            identifier = hs_id_list[0]
 
-        citation_str_lst.append(", HydroShare, {url}".format(url=hs_identifier.get('url', '')))
+        url = identifier.get('url', '')
+        pending_suffix = ", DOI for this published resource is pending activation." \
+            if isPendingActivation and not forceHydroshareURI else ""
 
-        if isPendingActivation and not forceHydroshareURI:
-            citation_str_lst.append(", DOI for this published resource is pending activation.")
-
-        return ''.join(citation_str_lst)
+        return CITATION_TEMPLATE.format(
+            authors=authors,
+            year=citation_year,
+            title=title_value,
+            url=url,
+            pending_suffix=pending_suffix,
+        )
 
     @classmethod
     def get_supported_upload_file_types(cls):

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2200,7 +2200,7 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
         # using update query api to update instead of self.save() to avoid triggering search index update
         type(self).objects.filter(id=self.id).update(download_count=self.download_count)
 
-    def update_cached_metadata_field(self, field_name):
+    def update_cached_metadata_field(self, field_name, relation_type=None):
         """
         Update a specific field in the cached metadata or all fields if 'all' is specified
 
@@ -2250,18 +2250,23 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
 
         # Update the modified date every time a metadata element is updated/deleted, or when 'all' is specified
         modified_date = metadata.dates.filter(type='modified').first()
-        if field_name != 'all':
-            # this is the case of updating cached metadata as part of metadata save/delete signal handler
-            copied_metadata['modified'] = now().isoformat()
-            if modified_date:
-                # this update won't trigger the post_save signal for Date model since we are using update query api
-                type(modified_date).objects.filter(id=modified_date.id).update(start_date=copied_metadata['modified'])
-        else:
+        if field_name == 'all':
             # this is the case of updating cached metadata as part of management command
             if modified_date:
                 copied_metadata['modified'] = modified_date.start_date.isoformat()
             else:
                 copied_metadata['modified'] = self.updated.isoformat()
+        # Skip bumping 'modified' for system-managed relation types (hasPart, isPartOf, etc.) —
+        # those are managed via update_collection which calls resource_modified() explicitly.
+        # User-editable relation types (isDescribedBy, references, etc.) still bump modified.
+        elif field_name != 'relation' or (
+            relation_type is not None
+            and relation_type not in {r.value for r in Relation.NOT_USER_EDITABLE}
+        ):
+            copied_metadata['modified'] = now().isoformat()
+            if modified_date:
+                # this update won't trigger the post_save signal for Date model since we are using update query api
+                type(modified_date).objects.filter(id=modified_date.id).update(start_date=copied_metadata['modified'])
 
         type(self).objects.filter(id=self.id).update(cached_metadata=copied_metadata)
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -9,6 +9,7 @@ from tempfile import NamedTemporaryFile
 import unicodedata
 import urllib.parse
 from uuid import uuid4
+
 import requests
 from dateutil import parser
 from django.conf import settings
@@ -45,15 +46,15 @@ from rdflib.namespace import DC, DCTERMS, RDF
 from spam_patterns.worst_patterns_re import patterns
 
 from django_s3.storage import S3Storage
-
-# Matches the 32-char hex resource short_id in a HydroShare resource URL.
-RESOURCE_ID_RE = re.compile(r'/resource/([0-9a-f]{32})\b')
 from hs_core.enums import (DataciteSubmissionStatus, RelationTypes)
 from hs_core.s3 import ResourceFileS3Mixin, ResourceS3Mixin
-
 from .hs_rdf import (HSTERMS, RDFS1, RDF_MetaData_Mixin, RDF_Term_MixIn,
                      rdf_terms)
 from .languages_iso import languages as iso_languages
+
+
+# Matches the 32-char hex resource short_id in a HydroShare resource URL.
+RESOURCE_ID_RE = re.compile(r'/resource/([0-9a-f]{32})\b')
 
 
 def clean_abstract(original_string):
@@ -3135,7 +3136,10 @@ class AbstractResource(ResourcePermissionsMixin, ResourceS3Mixin):
         if len(author_parts[-1]) > 2:
             author_parts[-1] = author_parts[-1][:-2]  # strip trailing ', '
         else:
-            logger.error(f"{CITATION_ERROR} No valid creator names found in cached_metadata for resource {self.short_id}")
+            logger.error(
+                f"{CITATION_ERROR} No valid creator names found in "
+                f"cached_metadata for resource {self.short_id}"
+            )
             return CITATION_ERROR
 
         authors = "".join(author_parts)
@@ -5036,7 +5040,7 @@ class BaseResource(Page, AbstractResource):
                     relation_meta_obj.save()
                     relation_updated = True
             return relation_updated
-        
+
         relations = self.metadata.relations.all()
         replace_relation = [rel for rel in relations if rel.type == RelationTypes.isReplacedBy]
         replace_relation_updated = False

--- a/hs_core/receivers.py
+++ b/hs_core/receivers.py
@@ -242,7 +242,7 @@ def resource_access_post_save_handler(sender, instance, **kwargs):
     # the post_save signal is sent for ResourceAccess
     if resource is not None and hasattr(resource, 'raccess') and resource.raccess is not None:
         try:
-            resource.update_cached_metadata_field('status')
+            resource.update_cached_metadata_field('status', update_modified_date=True)
         except Exception as ex:
             logger.error(f"Error updating status in cached metadata for resource {resource.short_id}: {str(ex)}")
 
@@ -259,9 +259,16 @@ def metadata_element_saved(sender, instance, **kwargs):
             if hasattr(instance.metadata, 'resource') and instance.metadata.resource is not None:
                 resource = instance.metadata.resource
                 meta_field_name = instance.__class__.__name__.lower()
+
+                # Don't update modified date for system-managed relation types (hasPart, isPartOf, etc.)
                 relation_type = instance.type if isinstance(instance, Relation) else None
+                update_modified_date = (
+                    relation_type is None
+                    or relation_type not in {r.value for r in Relation.NOT_USER_EDITABLE}
+                )
+
                 try:
-                    resource.update_cached_metadata_field(meta_field_name, relation_type=relation_type)
+                    resource.update_cached_metadata_field(meta_field_name, update_modified_date=update_modified_date)
                 except Exception as ex:
                     # NOTE: The error may not be related to the field that is logged here as
                     # we update other fields that might be missing in the cache as part of caching the specified field
@@ -283,9 +290,16 @@ def metadata_element_deleted(sender, instance, **kwargs):
             if hasattr(instance.metadata, 'resource') and instance.metadata.resource is not None:
                 resource = instance.metadata.resource
                 meta_field_name = instance.__class__.__name__.lower()
+
+                # Don't update modified date for system-managed relation types (hasPart, isPartOf, etc.)
                 relation_type = instance.type if isinstance(instance, Relation) else None
+                update_modified_date = (
+                    relation_type is None
+                    or relation_type not in {r.value for r in Relation.NOT_USER_EDITABLE}
+                )
+
                 try:
-                    resource.update_cached_metadata_field(meta_field_name, relation_type=relation_type)
+                    resource.update_cached_metadata_field(meta_field_name, update_modified_date=update_modified_date)
                 except Exception as ex:
                     logger.error(f"Error updating cached metadata for resource {resource.short_id}: {str(ex)}")
                     # NOTE: The error may not be related to the field that is logged here as

--- a/hs_core/receivers.py
+++ b/hs_core/receivers.py
@@ -10,7 +10,7 @@ from hs_core.signals import pre_metadata_element_create, pre_metadata_element_up
     post_add_reftimeseries_aggregation, post_remove_file_aggregation, post_raccess_change, \
     post_delete_file_from_resource, post_add_csv_aggregation
 from hs_core.tasks import update_web_services
-from hs_core.models import BaseResource, Creator, Contributor, Party, AbstractMetaDataElement
+from hs_core.models import BaseResource, Creator, Contributor, Party, AbstractMetaDataElement, Relation
 from django.conf import settings
 
 from .forms import SubjectsForm, AbstractValidationForm, CreatorValidationForm, \
@@ -259,8 +259,9 @@ def metadata_element_saved(sender, instance, **kwargs):
             if hasattr(instance.metadata, 'resource') and instance.metadata.resource is not None:
                 resource = instance.metadata.resource
                 meta_field_name = instance.__class__.__name__.lower()
+                relation_type = instance.type if isinstance(instance, Relation) else None
                 try:
-                    resource.update_cached_metadata_field(meta_field_name)
+                    resource.update_cached_metadata_field(meta_field_name, relation_type=relation_type)
                 except Exception as ex:
                     # NOTE: The error may not be related to the field that is logged here as
                     # we update other fields that might be missing in the cache as part of caching the specified field
@@ -282,8 +283,9 @@ def metadata_element_deleted(sender, instance, **kwargs):
             if hasattr(instance.metadata, 'resource') and instance.metadata.resource is not None:
                 resource = instance.metadata.resource
                 meta_field_name = instance.__class__.__name__.lower()
+                relation_type = instance.type if isinstance(instance, Relation) else None
                 try:
-                    resource.update_cached_metadata_field(meta_field_name)
+                    resource.update_cached_metadata_field(meta_field_name, relation_type=relation_type)
                 except Exception as ex:
                     logger.error(f"Error updating cached metadata for resource {resource.short_id}: {str(ex)}")
                     # NOTE: The error may not be related to the field that is logged here as

--- a/hs_core/tests/test_resource_cached_metadata_sync.py
+++ b/hs_core/tests/test_resource_cached_metadata_sync.py
@@ -1014,7 +1014,7 @@ class TestDenormalizedMetadataSync(TestCase):
         modified_date2 = datetime.fromisoformat(modified_date2)
         # Modified date should not change for isPartOf relation since it is not user-editable
         self.assertEqual(modified_date2, modified_date1)
-    
+
     def test_delete_user_managed_relation_updates_cached_metadata(self):
         """Test that deleting a user-managed Relation element triggers cached metadata update."""
         # Create relation first

--- a/hs_core/tests/test_resource_cached_metadata_sync.py
+++ b/hs_core/tests/test_resource_cached_metadata_sync.py
@@ -952,6 +952,7 @@ class TestDenormalizedMetadataSync(TestCase):
         self.assertEqual(relations[0]['value'], 'https://www.hydroshare.org/resource/12345')
         modified_date2 = self.resource.cached_metadata['modified']
         modified_date2 = datetime.fromisoformat(modified_date2)
+        # Modified date should change for isDescribedBy relation since it is user-editable
         self.assertGreater(modified_date2, modified_date1)
 
         # Update the relation
@@ -973,7 +974,8 @@ class TestDenormalizedMetadataSync(TestCase):
         self.assertEqual(relations[0]['value'], 'https://www.hydroshare.org/resource/67890')
         modified_date3 = self.resource.cached_metadata['modified']
         modified_date3 = datetime.fromisoformat(modified_date3)
-        self.assertGreater(modified_date3, modified_date2)
+        # Modified date should not change for isPartOf relation since it is not user-editable
+        self.assertEqual(modified_date3, modified_date2)
 
     def test_relation_post_delete_updates_cached_metadata(self):
         """Test that deleting a Relation element triggers cached metadata update."""
@@ -1008,6 +1010,34 @@ class TestDenormalizedMetadataSync(TestCase):
         self.assertEqual(relations[0]['type_description'], 'This resource includes')
         self.assertFalse(relations[0]['is_user_editable'])
         self.assertEqual(relations[0]['value'], 'https://www.hydroshare.org/resource/67890')
+        modified_date2 = self.resource.cached_metadata['modified']
+        modified_date2 = datetime.fromisoformat(modified_date2)
+        # Modified date should not change for isPartOf relation since it is not user-editable
+        self.assertEqual(modified_date2, modified_date1)
+    
+    def test_delete_user_managed_relation_updates_cached_metadata(self):
+        """Test that deleting a user-managed Relation element triggers cached metadata update."""
+        # Create relation first
+        relation = self.resource.metadata.create_element(
+            'relation',
+            type='references',
+            value='https://www.hydroshare.org/resource/12345'
+        )
+
+        # Verify relations are in cached metadata
+        self.resource.refresh_from_db()
+        relations = self.resource.cached_metadata.get('relations', [])
+        self.assertEqual(len(relations), 1)
+        modified_date1 = self.resource.cached_metadata['modified']
+        modified_date1 = datetime.fromisoformat(modified_date1)
+
+        # Delete relation
+        relation.delete()
+
+        # Verify cached metadata was updated
+        self.resource.refresh_from_db()
+        relations = self.resource.cached_metadata.get('relations', [])
+        self.assertEqual(len(relations), 0)
         modified_date2 = self.resource.cached_metadata['modified']
         modified_date2 = datetime.fromisoformat(modified_date2)
         self.assertGreater(modified_date2, modified_date1)


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
Two bugs were reported around this issue:
- When a resource is added to a collection, it's modified timestamp is updated even though the resource itself didn't change. Demo of reproduced bug:
https://github.com/user-attachments/assets/5f82fa07-3211-4d61-b8d2-f94e7fb38f88


- When a citation on a related resource changed (in this case, due to [this citation formatting change](https://github.com/hydroshare/hydroshare/pull/6181)), the resource's modified timestamp is updated when the resource landing page is visited even though the resource itself didn't change. Demo of reproduced bug:
https://github.com/user-attachments/assets/78a229a4-0bcb-4da7-a52e-2db66c4407ca

There is a common call site causing this for both bugs -- when a resource is added to a collection, a relation metadata element is saved, and when the resource landing page loads, we call `update_relation_meta()`, both of which end up modifying the resources relation metadata and triggering `update_cached_metadata_field()` which updates the cached metadata as well as the modified timestamp.

The fix is to update the cached metadata but not the modified timestamp when the metadata element being updated is a `relation` and the relation is not user-editable.  User-editable relations should still update the modified timestamp.

A couple other small refactors were implemented due to unexpected side effects of changing the citation format when testing:
- Refactor `get_citation()` to use a clear template so the expected format is obvious and changing the citation format is less prone to unintended side effects.
- Use a regex to parse the resource ID from the citation string when we fetch a related resource from a relation value.  We were previously relying the ID's position in the string which is brittle.

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Resource added to collection does not have its modified timestamp changed (but collection does have its modified timestamp changed):
https://github.com/user-attachments/assets/39040452-6cf5-4b77-9b57-7238af0adff5
2. When collection citation changes, child resource does not have its modified timestamp changed on load:
https://github.com/user-attachments/assets/bb4ed1fa-1b09-4bc2-9285-c4e527387a2f
3. User-editable relation does cause modified timestamp to change:
https://github.com/user-attachments/assets/5231af57-36d6-4e21-bc2d-bb05a0db8fd3

Resolves #6347 