### PR TITLE
chore: Add GH workflow to sync parent issue deliverable to sub-issue

### DIFF
--- a/.github/workflows/sync-parent-deliverable-to-sub-issue.yml
+++ b/.github/workflows/sync-parent-deliverable-to-sub-issue.yml
@@ -1,0 +1,80 @@
+name: Sync Parent DELIVERABLE to Sub-Issues
+
+on:
+  issues:
+    types: [opened, edited]
+  workflow_dispatch:
+    inputs:
+      issue_node_id:
+        description: 'The node ID of the sub-issue to test'
+        required: true
+        type: string
+
+jobs:
+  sync-deliverable:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.issue.parent != null }} # {Link: GitHub Docs on automating projects https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions}
+    
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Inherit Deliverable Select Field
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PROJECT_ID: PVT_kwDOADSPDc4AiwwP
+          TARGET_FIELD_NAME: Deliverable
+          FIELD_ID: PVTSSF_lADOADSPDc4AiwwPzhX0UJo
+          SUB_ISSUE_NODE_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.issue_node_id || github.event.issue.node_id }}
+        run: |
+          # 1. Fetch parent and child project items via GraphQL
+          gh api graphql -f query='
+            query($issueId: ID!, $fieldName: String!) {
+              node(id: $issueId) {
+                ... on Issue {
+                  parent {
+                    projectItems(first: 5) {
+                      nodes {
+                        project { id }
+                        fieldValueByName(name: $fieldName) {
+                          ... on ProjectV2ItemFieldSingleSelectValue { optionId }
+                          ... on ProjectV2ItemFieldTextValue { text }
+                          ... on ProjectV2ItemFieldNumberValue { number }
+                        }
+                      }
+                    }
+                  }
+                  projectItems(first: 5) {
+                    nodes { id, project { id } }
+                  }
+                }
+              }
+            }' -f issueId="$SUB_ISSUE_NODE_ID" -f fieldName="$TARGET_FIELD_NAME" > raw_payload.json
+
+          # 2. Extract IDs and Values
+          SUB_ITEM_ID=$(jq -r --arg projId "$PROJECT_ID" '.data.node.projectItems.nodes[] | select(.project.id == $projId) | .id // empty' raw_payload.json)
+
+          if [ -z "$SUB_ITEM_ID" ]; then
+            # The issue may not have inherited the project yet, so add it explicitly and use the returned item ID.
+            gh api graphql -f query='
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                  item { id }
+                }
+              }' -f projectId="$PROJECT_ID" -f contentId="$SUB_ISSUE_NODE_ID" > add_item.json
+
+            SUB_ITEM_ID=$(jq -r '.data.addProjectV2ItemById.item.id // empty' add_item.json)
+          fi
+          
+          # ... (jq parsing of values, similar to original) ...
+          OPTION_ID=$(jq -r '.data.node.parent.projectItems.nodes[0].fieldValueByName.optionId // empty' raw_payload.json)
+
+          # 3. Update the sub-issue's Deliverable field to match the parent.
+          if [ -n "$OPTION_ID" ]; then
+            VALUE_INPUT="{ singleSelectOptionId: \"$OPTION_ID\" }"
+            gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$SUB_ITEM_ID\", fieldId: \"$FIELD_ID\", value: $VALUE_INPUT }) { projectV2Item { id } } }"
+          fi

--- a/.github/workflows/update-start-date-when-in-progress.yml
+++ b/.github/workflows/update-start-date-when-in-progress.yml
@@ -1,0 +1,76 @@
+name: update-start-date-when-in-progress
+
+on:
+  issues:
+    types: [field_added]
+  # Manual entry point for testing this workflow against a specific issue node ID.
+  workflow_dispatch:
+    inputs:
+      issue_node_id:
+        description: 'The node ID of the issue to test'
+        required: true
+        type: string
+
+jobs:
+  update-start-date:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.issue != null }}
+
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Set Start Date when issue moves to In Progress
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PROJECT_ID: PVT_kwDOADSPDc4AiwwP
+          FIELD_ID: PVTF_lADOADSPDc4AiwwPzg09nX8
+          TARGET_STATUS: In Progress
+          ISSUE_NODE_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.issue_node_id || github.event.issue.node_id }}
+        run: |
+          set -euo pipefail
+
+          TODAY=$(date -u +%F)
+
+          # Read the issue's projects and the Status field from the target project.
+          gh api graphql -f query='
+            query($issueId: ID!, $fieldName: String!) {
+              node(id: $issueId) {
+                ... on Issue {
+                  projectItems(first: 20) {
+                    nodes {
+                      id
+                      project { id }
+                      fieldValueByName(name: $fieldName) {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f issueId="$ISSUE_NODE_ID" -f fieldName="Status" > issue_payload.json
+
+          # Resolve the item's ProjectV2 item ID and the current Status name for this project.
+          ITEM_ID=$(jq -r --arg projId "$PROJECT_ID" '.data.node.projectItems.nodes | map(select(.project.id == $projId) | .id) | .[0] // empty' issue_payload.json)
+          CURRENT_STATUS=$(jq -r --arg projId "$PROJECT_ID" '.data.node.projectItems.nodes | map(select(.project.id == $projId) | .fieldValueByName.name // empty) | .[0] // empty' issue_payload.json)
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue is not in the Hydroshare project. Skipping update."
+            exit 0
+          fi
+
+          # Skip if this issue is not in the target status.
+          if [ "$CURRENT_STATUS" != "$TARGET_STATUS" ]; then
+            echo "Issue status is '$CURRENT_STATUS'; expected '$TARGET_STATUS'. Skipping update."
+            exit 0
+          fi
+
+          # Write today's date into the Start Date field.
+          gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$FIELD_ID\", value: { date: \"$TODAY\" } }) { projectV2Item { id } } }"
+          

--- a/.github/workflows/update-target-date-when-done.yml
+++ b/.github/workflows/update-target-date-when-done.yml
@@ -1,0 +1,77 @@
+name: update-target-date-when-done
+
+on:
+  issues:
+    types: [field_added]
+  # Manual entry point for testing this workflow against a specific issue node ID.
+  workflow_dispatch:
+    inputs:
+      issue_node_id:
+        description: 'The node ID of the issue to test'
+        required: true
+        type: string
+
+jobs:
+  update-target-date:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.issue != null }}
+
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Set Target Date when issue moves to Done
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PROJECT_ID: PVT_kwDOADSPDc4AiwwP
+          FIELD_ID: PVTF_lADOADSPDc4AiwwPzg09ncw
+          TARGET_STATUS: Done
+          ISSUE_NODE_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.issue_node_id || github.event.issue.node_id }}
+        run: |
+          set -euo pipefail
+
+          # Use the current UTC date so the workflow is deterministic regardless of runner locale.
+          TODAY=$(date -u +%F)
+
+          # Read the issue's project items and the Status field from the target project.
+          gh api graphql -f query='
+            query($issueId: ID!, $fieldName: String!) {
+              node(id: $issueId) {
+                ... on Issue {
+                  projectItems(first: 20) {
+                    nodes {
+                      id
+                      project { id }
+                      fieldValueByName(name: $fieldName) {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f issueId="$ISSUE_NODE_ID" -f fieldName="Status" > issue_payload.json
+
+          # Resolve the item's ProjectV2 item ID and the current Status name for this project.
+          ITEM_ID=$(jq -r --arg projId "$PROJECT_ID" '.data.node.projectItems.nodes | map(select(.project.id == $projId) | .id) | .[0] // empty' issue_payload.json)
+          CURRENT_STATUS=$(jq -r --arg projId "$PROJECT_ID" '.data.node.projectItems.nodes | map(select(.project.id == $projId) | .fieldValueByName.name // empty) | .[0] // empty' issue_payload.json)
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue is not in the Hydroshare project. Skipping update."
+            exit 0
+          fi
+
+          # Skip if this issue is not in the target status.
+          if [ "$CURRENT_STATUS" != "$TARGET_STATUS" ]; then
+            echo "Issue status is '$CURRENT_STATUS'; expected '$TARGET_STATUS'. Skipping update."
+            exit 0
+          fi
+
+          # Write today's date into the Target Date field.
+          gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"$PROJECT_ID\", itemId: \"$ITEM_ID\", fieldId: \"$FIELD_ID\", value: { date: \"$TODAY\" } }) { projectV2Item { id } } }"
+          


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
New GH actions workflow to:

1. Sync a sub-issue's "Deliverable" field to the parent's value when a sub-issue is opened or edited.  This will ensure we don't have to set this manually.
2.  Set the "Start Date" on an issue when it moves to "In Progress" to ensure we can accurately track work timelines
3.  Set the "Target Date" on an issue when it moves to "Done" to ensure we can accurately track work timelines

Unfortunately I can't test these until the workflows exists on the default branch so this may not work as-is, but once this is merged, I can run the actions from a feature branch to further iterate.  The workflows include a manual trigger for now for testing -- this will be removed once tested.

