### PR TITLE
6410: Fix relation URL parsing when generating pydantic schema.org model

### DIFF
--- a/hs_core/hydroshare_schemaorg_adapter.py
+++ b/hs_core/hydroshare_schemaorg_adapter.py
@@ -162,7 +162,14 @@ class Relation(BaseModel):
             url = ""
         url_str = url.strip()
         relation.description = description.strip()
-        relation.url = HttpUrl(url_str) if url_str else None
+        parsed_url = None
+        if url_str:
+            try:
+                parsed_url = HttpUrl(url_str)
+            except Exception:
+                # url_str is not a valid URL — treat as part of the description
+                relation.description = f"{relation.description}, {url_str}".strip(", ")
+        relation.url = parsed_url
         return relation
 
 

--- a/hs_core/tests/test_hydroshare_schemaorg_adapter.py
+++ b/hs_core/tests/test_hydroshare_schemaorg_adapter.py
@@ -1,0 +1,81 @@
+from unittest_parametrize import ParametrizedTestCase, parametrize, param
+
+from hs_cloudnative_schemas.schema import base as schema
+from hs_core.hydroshare_schemaorg_adapter import Relation
+
+
+class TestRelationToDatasetPartRelation(ParametrizedTestCase):
+    """Tests for Relation.to_dataset_part_relation() — specifically the URL/description
+    parsing logic that splits on the last comma of the relation value."""
+
+    @parametrize(
+        "value,expected_description,expected_url",
+        [
+            param(
+                "Smith, J. (2020). A paper, https://doi.org/10.1234/abc",
+                "Smith, J. (2020). A paper",
+                "https://doi.org/10.1234/abc",
+                id="valid_url_after_last_comma",
+            ),
+            param(
+                "Smith, J. (2020). A paper ending with nationalmap.gov/viewer/).",
+                "Smith, J. (2020). A paper ending with nationalmap.gov/viewer/).",
+                None,
+                id="no_comma_no_url",
+            ),
+            param(
+                "Smith, J. (2020). A paper, nationalmap.gov/viewer/).",
+                "Smith, J. (2020). A paper, nationalmap.gov/viewer/).",
+                None,
+                id="non_url_after_last_comma",
+            ),
+            param(
+                "Smith, J. (2020). A paper, available at https://nationalmap.gov/viewer/",
+                "Smith, J. (2020). A paper, available at https://nationalmap.gov/viewer/",
+                None,
+                id="url_with_text_in_front",
+            ),
+        ],
+    )
+    def test_description_and_url_parsing(self, value, expected_description, expected_url):
+        """URL is only set when the text after the last comma is a valid URL; otherwise
+        it is folded back into the description."""
+        relation = Relation(type="The content of this resource references", value=value)
+        result = relation.to_dataset_part_relation("Other")
+
+        self.assertEqual(result.description, expected_description)
+        if expected_url is None:
+            self.assertIsNone(result.url)
+        else:
+            self.assertIsNotNone(result.url)
+            self.assertEqual(str(result.url), expected_url)
+
+    def test_is_part_of_relation_type(self):
+        """A relation whose type ends with 'is part of' yields an IsPartOf schema object."""
+        relation = Relation(
+            type="The content of this resource is part of",
+            value="Some collection, https://www.hydroshare.org/resource/abc123",
+        )
+        result = relation.to_dataset_part_relation("IsPartOf")
+        self.assertEqual(str(result.url), "https://www.hydroshare.org/resource/abc123")
+        self.assertIsInstance(result, schema.IsPartOf)
+        self.assertEqual(result.description, "Some collection")
+
+    def test_has_part_relation_type(self):
+        """A relation whose type ends with 'resource includes' yields a HasPart schema object."""
+        relation = Relation(
+            type="This resource includes",
+            value="A contained resource, https://www.hydroshare.org/resource/def456",
+        )
+        result = relation.to_dataset_part_relation("HasPart")
+        self.assertEqual(str(result.url), "https://www.hydroshare.org/resource/def456")
+        self.assertIsInstance(result, schema.HasPart)
+        self.assertEqual(result.description, "A contained resource")
+
+    def test_other_relation_type_sets_name(self):
+        """Any relation_type other than HasPart or IsPartOf yields a Relation schema object with name set."""
+        rel_type = "The content of this resource references"
+        relation = Relation(type=rel_type, value="Some value")
+        result = relation.to_dataset_part_relation("Other")
+        self.assertIsInstance(result, schema.Relation)
+        self.assertEqual(result.name, rel_type)


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
We when we update file-based metadata, our Pydantic models expect the relation value (citation) to have the URL after the last comma, but we have resources with relations that do not meet this expectation (see 2nd relation [here](https://www.hydroshare.org/resource/a1858e309b3b421695c3cf32d8a44ced/)).  

This updates the parsing function to try parse the URL string as a Pydantic HttpUrl, and falls back to appending the value to the description if if fails.

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Run Hydroshare locally
2. Add a reference with an invalid URL at the end of the citation to an existing resource
3. Run `docker exec hydroshare python manage.py update_discovery_index <resource_id>`
4. Result before fix (see URL validation error):
<img width="1130" height="214" alt="Screenshot 2026-07-22 at 4 04 18 PM" src="https://github.com/user-attachments/assets/6ff3093f-4d65-41e7-978c-6b303fbd7f4e" />

5. After fix:
<img width="1133" height="232" alt="Screenshot 2026-07-22 at 4 05 09 PM" src="https://github.com/user-attachments/assets/e6652b91-5172-45ab-8f75-04259ce79b02" />

Resolves #6410