### PR TITLE
fix: Relevance sort order being overridden for search endpoint

### DIFF
--- a/hs_rest_api/discovery_atlas.py
+++ b/hs_rest_api/discovery_atlas.py
@@ -359,7 +359,11 @@ class SearchQuery(BaseModel):
 
         # These sorts can occur inside the $search stage
 
-        if self.sortBy == "name":
+        # MongoDB Atlas uses score order by default
+        # so don't set a sort on the query when specified sort is relevance
+        if self.sortBy == "relevance":
+            pass
+        elif self.sortBy == "name":
             search_stage["$search"]['sort'] = {"name": order}
         elif self.sortBy == "dateCreated":
             search_stage["$search"]['sort'] = {"dateCreated": order}
@@ -369,8 +373,8 @@ class SearchQuery(BaseModel):
             search_stage["$search"]['sort'] = {"first_creator.name": order}
         elif self.sortBy == "viewCount":
             search_stage["$search"]['sort'] = {"viewCount": order}
-        # If no sort is provided, default to sort by dateModified descending
-        else:
+        # If no sort is provided, default to sort by dateModified descending.
+        elif self.sortBy is None:
             search_stage["$search"]['sort'] = {"dateModified": -1}
 
         stages.append(search_stage)

--- a/hs_rest_api/tests/http/test_discovery_atlas.py
+++ b/hs_rest_api/tests/http/test_discovery_atlas.py
@@ -314,6 +314,16 @@ class TestSearchQuery(ParametrizedTestCase):
 
         self.assertEqual(stages[0]["$search"]["sort"], expected_sort)
 
+    def test_stages_relevance_leaves_sort_unset(self):
+        search_query = SearchQuery(
+            sortBy="relevance",
+            paginationToken=None,
+        )
+
+        stages = search_query.stages
+
+        self.assertNotIn("sort", stages[0]["$search"])
+
     def test_stages_multiple_content_types(self):
         content_types = ["CSVLogicalFile", "CollectionResource"]
 


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
My fix in [this PR](https://github.com/hydroshare/hydroshare/pull/6362/changes) introduced a bug where we are overriding a specified sort of `relevance` with [this else statement](https://github.com/hydroshare/hydroshare/pull/6362/changes#diff-6d4b172042087591816a0cbc28b09c3ffa13224964a1ffc46ec3b2b46c93aaf1R372-R374).  MongoDB Atlas sorts by score by default, so when sort = relevance we don't want to specify any sort in the query.

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Run locally
2. Search by a term and sort by relevance
3. Before fix (results are sorted by last modified instead of score relevance):
<img width="1289" height="799" alt="Screenshot 2026-07-22 at 5 44 21 PM" src="https://github.com/user-attachments/assets/a1c90ad5-d5cd-4be4-8113-ac54731f30d0" />

4. After fix (relevance sort is respected):
<img width="1266" height="788" alt="Screenshot 2026-07-22 at 5 44 56 PM" src="https://github.com/user-attachments/assets/9408ac47-ef7d-4556-868a-445904eea74c" />

