### PR TITLE
[#6016] Integrate zipped folder download endpoint

### DIFF
--- a/discovery-atlas/frontend/src/components/landing-page/edit-dataset.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/edit-dataset.vue
@@ -397,7 +397,8 @@
                   :is-read-only="false"
                   :has-file-metadata="() => false"
                   :folder-name-regex="folderNameRegex"
-                  :canDownloadItem="() => true"
+                  :canDownloadItem="(item: IFile | IFolder) => !isFolder(item)"
+                  :download-zipped="(item: IFile | IFolder) => onZippedDownload(item, resourceId)"
                   :upload="uploadFiles"
                   :delete-file-or-folder="deleteFileOrFolder"
                   :rename-file-or-folder="renameFileOrFolder"
@@ -860,7 +861,13 @@ import {
   DeleteObjectCommand,
   CopyObjectCommand,
 } from "@aws-sdk/client-s3";
-import { fetchResource, onFileDownload, readRootFolder } from "./shared";
+import {
+  fetchResource,
+  onFileDownload,
+  onZippedDownload,
+  readRootFolder,
+} from "./shared";
+import { isFolder } from "./zip-download";
 import { createCookieS3Client } from "./cookie-s3-client";
 import HsUppy from "./hs-uppy.vue";
 import CdSpatialCoverageMap from "@/components/search-results/cd.spatial-coverage-map.vue";

--- a/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
@@ -408,8 +408,9 @@
                 :has-folders="fileExplorerConfig.hasFolders"
                 :is-read-only="true"
                 :has-file-metadata="() => true"
-                :canDownloadItem="() => true"
+                :canDownloadItem="(item: IFile | IFolder) => !isFolder(item)"
                 :load-file-preview="(item) => loadFilePreview(item)"
+                :download-zipped="onZippedDownload"
                 @download="
                   onFileDownload($event, resourceId, s3Client, s3Info.bucket)
                 "
@@ -779,9 +780,10 @@ import {
   CzFileExplorer,
   Notifications,
 } from "@cznethub/cznet-vue-core";
-import type { IFolder } from "@cznethub/cznet-vue-core/dist/types";
+import type { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
 import { GetObjectCommand, S3Client, _Object } from "@aws-sdk/client-s3";
 import { fetchResource, onFileDownload } from "./shared";
+import { downloadZipped, isFolder, ZipDownloadError } from "./zip-download";
 import { loadReadme } from "./readme-s3";
 import { createCookieS3Client } from "./cookie-s3-client";
 import User from "@/models/user.model";
@@ -928,6 +930,26 @@ const headingAttr = {
 function onShowMetadata(item: any) {
   selectedMetadata.value = item;
   showMetadata.value = true;
+}
+
+async function onZippedDownload(item: IFile | IFolder) {
+  try {
+    // "notified" means the navbar bell is tracking it and will deliver the file.
+    if ((await downloadZipped(resourceId.value, item)) === "downloaded") {
+      Notifications.toast({
+        title: "Success",
+        message: "Download started.",
+        type: "success",
+      });
+    }
+  } catch (error: any) {
+    const message =
+      error instanceof ZipDownloadError
+        ? error.message
+        : "Failed to download the zip file.";
+    console.error("Zipped download failed:", error);
+    Notifications.toast({ title: "Error", message, type: "error" });
+  }
 }
 
 function onCopy(text: string) {

--- a/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
@@ -410,7 +410,7 @@
                 :has-file-metadata="() => true"
                 :canDownloadItem="(item: IFile | IFolder) => !isFolder(item)"
                 :load-file-preview="(item) => loadFilePreview(item)"
-                :download-zipped="onZippedDownload"
+                :download-zipped="(item: IFile | IFolder) => onZippedDownload(item, resourceId)"
                 @download="
                   onFileDownload($event, resourceId, s3Client, s3Info.bucket)
                 "
@@ -782,8 +782,8 @@ import {
 } from "@cznethub/cznet-vue-core";
 import type { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
 import { GetObjectCommand, S3Client, _Object } from "@aws-sdk/client-s3";
-import { fetchResource, onFileDownload } from "./shared";
-import { downloadZipped, isFolder, ZipDownloadError } from "./zip-download";
+import { fetchResource, onFileDownload, onZippedDownload } from "./shared";
+import { isFolder } from "./zip-download";
 import { loadReadme } from "./readme-s3";
 import { createCookieS3Client } from "./cookie-s3-client";
 import User from "@/models/user.model";
@@ -930,19 +930,6 @@ const headingAttr = {
 function onShowMetadata(item: any) {
   selectedMetadata.value = item;
   showMetadata.value = true;
-}
-
-async function onZippedDownload(item: IFile | IFolder) {
-  try {
-    await downloadZipped(resourceId.value, item);
-  } catch (error: any) {
-    const message =
-      error instanceof ZipDownloadError
-        ? error.message
-        : "Failed to download the zip file.";
-    console.error("Zipped download failed:", error);
-    Notifications.toast({ title: "Error", message, type: "error" });
-  }
 }
 
 function onCopy(text: string) {

--- a/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
@@ -934,14 +934,7 @@ function onShowMetadata(item: any) {
 
 async function onZippedDownload(item: IFile | IFolder) {
   try {
-    // "notified" means the navbar bell is tracking it and will deliver the file.
-    if ((await downloadZipped(resourceId.value, item)) === "downloaded") {
-      Notifications.toast({
-        title: "Success",
-        message: "Download started.",
-        type: "success",
-      });
-    }
+    await downloadZipped(resourceId.value, item);
   } catch (error: any) {
     const message =
       error instanceof ZipDownloadError

--- a/discovery-atlas/frontend/src/components/landing-page/notifications-app.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/notifications-app.ts
@@ -1,0 +1,29 @@
+/** Task notification handed to the navbar notification app. */
+export interface NotificationTask {
+  id: string;
+  name: string;
+  status: string;
+  payload: string;
+}
+
+interface NotificationsApp {
+  registerTask: (_task: NotificationTask) => void;
+  show: () => void;
+}
+
+/**
+ * The navbar task-notification app, which lives on the parent window because
+ * the landing page runs in a same-origin iframe.
+ */
+export const getNotificationsApp = (): NotificationsApp | null => {
+  try {
+    for (const w of [window.parent, window] as any[]) {
+      if (typeof w?.notificationsApp?.registerTask === "function") {
+        return w.notificationsApp;
+      }
+    }
+  } catch {
+    // cross-origin parent
+  }
+  return null;
+};

--- a/discovery-atlas/frontend/src/components/landing-page/shared.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/shared.ts
@@ -2,6 +2,30 @@ import { _Object, CommonPrefix, GetObjectCommand, ListObjectsV2Command, S3Client
 import { Notifications } from "@cznethub/cznet-vue-core";
 import { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
 import { S3_PROXY_URL } from "@/constants";
+import { downloadZipped, ZipDownloadError } from "./zip-download";
+
+export const onZippedDownload = async (item: IFile | IFolder, resourceId: string) => {
+  // Edit mode can hold staged items that are not in S3 yet.
+  if (item.isUploaded === false) {
+    Notifications.toast({
+      title: "Error",
+      message: "Upload this item before downloading it.",
+      type: "error",
+    });
+    return;
+  }
+
+  try {
+    await downloadZipped(resourceId, item);
+  } catch (error: any) {
+    const message =
+      error instanceof ZipDownloadError
+        ? error.message
+        : "Failed to download the zip file.";
+    console.error("Zipped download failed:", error);
+    Notifications.toast({ title: "Error", message, type: "error" });
+  }
+}
 
 export const onFileDownload = async (items: (IFile | IFolder)[], resourceId: string, s3Client: S3Client, bucket: string) => {
   try {

--- a/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
@@ -1,0 +1,148 @@
+import type { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
+
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 10 * 60 * 1000;
+
+export interface WaitOptions {
+  intervalMs?: number;
+  timeoutMs?: number;
+  now?: () => number;
+}
+
+/** Task notification returned by the download endpoint. */
+export interface ZipTask {
+  id: string;
+  name: string;
+  status: string;
+  payload: string;
+}
+
+interface NotificationsApp {
+  registerTask: (_task: ZipTask) => void;
+  show: () => void;
+}
+
+export class ZipDownloadError extends Error { }
+
+/**
+ * The navbar task-notification app, which lives on the parent window because
+ * the landing page runs in a same-origin iframe.
+ */
+export const getNotificationsApp = (): NotificationsApp | null => {
+  try {
+    for (const w of [window.parent, window] as any[]) {
+      if (typeof w?.notificationsApp?.registerTask === "function") {
+        return w.notificationsApp;
+      }
+    }
+  } catch {
+    // cross-origin parent
+  }
+  return null;
+};
+
+export const isFolder = (item: IFile | IFolder): boolean =>
+  Object.prototype.hasOwnProperty.call(item, "children");
+
+export const zipRequestUrl = (
+  resourceId: string,
+  item: IFile | IFolder,
+): string => {
+  const url = `/django_s3/download/${resourceId}/data/contents/${item.path}`;
+  // Folders are zipped server-side automatically; single files need the flag.
+  return isFolder(item) ? url : `${url}?zipped=true`;
+};
+
+export const requestZip = async (
+  resourceId: string,
+  item: IFile | IFolder,
+): Promise<ZipTask> => {
+  const res = await fetch(zipRequestUrl(resourceId, item), {
+    credentials: "include",
+  });
+
+  if (res.status === 401) {
+    throw new ZipDownloadError(
+      "You do not have permission to download this resource.",
+    );
+  }
+  if (!res.ok) {
+    throw new ZipDownloadError("Failed to start the zip download.");
+  }
+
+  const task = await res.json();
+  // registerTask ignores anything without both id and name.
+  if (!task?.id || !task?.name) {
+    throw new ZipDownloadError("Failed to start the zip download.");
+  }
+  return task;
+};
+
+export const waitForZip = async (
+  taskId: string,
+  opts: WaitOptions = {},
+): Promise<string> => {
+  const {
+    intervalMs = POLL_INTERVAL_MS,
+    timeoutMs = POLL_TIMEOUT_MS,
+    now = () => Date.now(),
+  } = opts;
+  const deadline = now() + timeoutMs;
+
+  while (now() < deadline) {
+    const res = await fetch(`/django_s3/rest_check_task_status/${taskId}`, {
+      credentials: "include",
+    });
+    if (!res.ok) {
+      throw new ZipDownloadError("Failed to create the zip file.");
+    }
+
+    const body = await res.json();
+    if (body?.status === "true") {
+      return body.payload;
+    }
+    // Anything other than an explicit "still running" is terminal.
+    if (body?.status !== "false") {
+      throw new ZipDownloadError("Failed to create the zip file.");
+    }
+
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+
+  throw new ZipDownloadError(
+    "The zip is taking too long to prepare. Please try again later.",
+  );
+};
+
+export const triggerDownload = (url: string) => {
+  const a = document.createElement("a");
+  a.href = url;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+};
+
+/**
+ * Kick off a zipped download. Preferred path hands the task to the navbar
+ * notification app, which owns polling and delivery exactly as the legacy
+ * landing page does — that keeps the bell in sync and preserves the server's
+ * filename. Falls back to polling here when the bell is unreachable.
+ */
+export const downloadZipped = async (
+  resourceId: string,
+  item: IFile | IFolder,
+  opts: WaitOptions = {},
+): Promise<"notified" | "downloaded"> => {
+  const task = await requestZip(resourceId, item);
+
+  const notifications = getNotificationsApp();
+  if (notifications) {
+    notifications.registerTask(task);
+    notifications.show();
+    return "notified";
+  }
+
+  triggerDownload(await waitForZip(task.id, opts));
+  return "downloaded";
+};

--- a/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
@@ -1,14 +1,5 @@
 import type { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
 
-const POLL_INTERVAL_MS = 3000;
-const POLL_TIMEOUT_MS = 10 * 60 * 1000;
-
-export interface WaitOptions {
-  intervalMs?: number;
-  timeoutMs?: number;
-  now?: () => number;
-}
-
 /** Task notification returned by the download endpoint. */
 export interface ZipTask {
   id: string;
@@ -78,71 +69,21 @@ export const requestZip = async (
   return task;
 };
 
-export const waitForZip = async (
-  taskId: string,
-  opts: WaitOptions = {},
-): Promise<string> => {
-  const {
-    intervalMs = POLL_INTERVAL_MS,
-    timeoutMs = POLL_TIMEOUT_MS,
-    now = () => Date.now(),
-  } = opts;
-  const deadline = now() + timeoutMs;
-
-  while (now() < deadline) {
-    const res = await fetch(`/django_s3/rest_check_task_status/${taskId}`, {
-      credentials: "include",
-    });
-    if (!res.ok) {
-      throw new ZipDownloadError("Failed to create the zip file.");
-    }
-
-    const body = await res.json();
-    if (body?.status === "true") {
-      return body.payload;
-    }
-    // Anything other than an explicit "still running" is terminal.
-    if (body?.status !== "false") {
-      throw new ZipDownloadError("Failed to create the zip file.");
-    }
-
-    await new Promise(resolve => setTimeout(resolve, intervalMs));
-  }
-
-  throw new ZipDownloadError(
-    "The zip is taking too long to prepare. Please try again later.",
-  );
-};
-
-export const triggerDownload = (url: string) => {
-  const a = document.createElement("a");
-  a.href = url;
-  a.style.display = "none";
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-};
-
 /**
- * Kick off a zipped download. Preferred path hands the task to the navbar
- * notification app, which owns polling and delivery exactly as the legacy
- * landing page does — that keeps the bell in sync and preserves the server's
- * filename. Falls back to polling here when the bell is unreachable.
+ * Kick off a zipped download. The navbar notification app owns polling and
+ * delivery, exactly as the legacy landing page does — that keeps the bell in
+ * sync and preserves the server's filename.
  */
 export const downloadZipped = async (
   resourceId: string,
   item: IFile | IFolder,
-  opts: WaitOptions = {},
-): Promise<"notified" | "downloaded"> => {
-  const task = await requestZip(resourceId, item);
-
+): Promise<void> => {
   const notifications = getNotificationsApp();
-  if (notifications) {
-    notifications.registerTask(task);
-    notifications.show();
-    return "notified";
+  if (!notifications) {
+    throw new ZipDownloadError("Failed to start the zip download.");
   }
 
-  triggerDownload(await waitForZip(task.id, opts));
-  return "downloaded";
+  const task = await requestZip(resourceId, item);
+  notifications.registerTask(task);
+  notifications.show();
 };

--- a/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
@@ -1,36 +1,7 @@
 import type { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
-
-/** Task notification returned by the download endpoint. */
-export interface ZipTask {
-  id: string;
-  name: string;
-  status: string;
-  payload: string;
-}
-
-interface NotificationsApp {
-  registerTask: (_task: ZipTask) => void;
-  show: () => void;
-}
+import { getNotificationsApp, type NotificationTask } from "./notifications-app";
 
 export class ZipDownloadError extends Error { }
-
-/**
- * The navbar task-notification app, which lives on the parent window because
- * the landing page runs in a same-origin iframe.
- */
-export const getNotificationsApp = (): NotificationsApp | null => {
-  try {
-    for (const w of [window.parent, window] as any[]) {
-      if (typeof w?.notificationsApp?.registerTask === "function") {
-        return w.notificationsApp;
-      }
-    }
-  } catch {
-    // cross-origin parent
-  }
-  return null;
-};
 
 export const isFolder = (item: IFile | IFolder): boolean =>
   Object.prototype.hasOwnProperty.call(item, "children");
@@ -47,7 +18,7 @@ export const zipRequestUrl = (
 export const requestZip = async (
   resourceId: string,
   item: IFile | IFolder,
-): Promise<ZipTask> => {
+): Promise<NotificationTask> => {
   const res = await fetch(zipRequestUrl(resourceId, item), {
     credentials: "include",
   });

--- a/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/zip-download.ts
@@ -10,9 +10,8 @@ export const zipRequestUrl = (
   resourceId: string,
   item: IFile | IFolder,
 ): string => {
-  const url = `/django_s3/download/${resourceId}/data/contents/${item.path}`;
-  // Folders are zipped server-side automatically; single files need the flag.
-  return isFolder(item) ? url : `${url}?zipped=true`;
+  const path = item.path?.split("/").map(encodeURIComponent).join("/");
+  return `/resource/${resourceId}/data/contents/${path}/?zipped=true`;
 };
 
 export const requestZip = async (

--- a/discovery-atlas/frontend/test/notifications-app.test.ts
+++ b/discovery-atlas/frontend/test/notifications-app.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from "vitest";
+import { getNotificationsApp } from "@/components/landing-page/notifications-app";
+
+describe("getNotificationsApp", () => {
+  it("returns null when no notification app is present", () => {
+    expect(getNotificationsApp()).toBeNull();
+  });
+
+  it("ignores a global that lacks registerTask", () => {
+    vi.stubGlobal("notificationsApp", { show: () => {} });
+    expect(getNotificationsApp()).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});

--- a/discovery-atlas/frontend/test/zip-download.test.ts
+++ b/discovery-atlas/frontend/test/zip-download.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ZipDownloadError,
+  isFolder,
+  zipRequestUrl,
+  requestZip,
+  waitForZip,
+  downloadZipped,
+  getNotificationsApp,
+} from "@/components/landing-page/zip-download";
+
+const folder = { name: "f", children: [], key: 1, path: "top/f" } as any;
+const file = { name: "a.txt", file: null, isUploaded: true, key: 2, path: "top/a.txt" } as any;
+
+const jsonRes = (body: any, ok = true, status = 200) => ({
+  ok,
+  status,
+  json: async () => body,
+});
+
+describe("isFolder", () => {
+  it("distinguishes folders from files by the children property", () => {
+    expect(isFolder(folder)).toBe(true);
+    expect(isFolder(file)).toBe(false);
+  });
+});
+
+describe("zipRequestUrl", () => {
+  it("omits zipped=true for folders, which the server zips automatically", () => {
+    expect(zipRequestUrl("abc", folder)).toBe(
+      "/django_s3/download/abc/data/contents/top/f",
+    );
+  });
+
+  it("adds zipped=true for single files", () => {
+    expect(zipRequestUrl("abc", file)).toBe(
+      "/django_s3/download/abc/data/contents/top/a.txt?zipped=true",
+    );
+  });
+});
+
+describe("requestZip", () => {
+  it("sends cookies and returns the task notification", async () => {
+    const fetchMock = vi.fn(async (_url: string, _opts: RequestInit) =>
+      jsonRes({ id: "task-1", name: "zip download", status: "progress", payload: "" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(requestZip("abc", folder)).resolves.toMatchObject({
+      id: "task-1",
+      name: "zip download",
+    });
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/django_s3/download/abc/data/contents/top/f");
+    expect(opts).toMatchObject({ credentials: "include" });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reports a permission problem on 401", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({}, false, 401)));
+    await expect(requestZip("abc", folder)).rejects.toThrow(/permission/i);
+    vi.unstubAllGlobals();
+  });
+
+  it("fails when the response carries no task id", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({ status: "progress" })));
+    await expect(requestZip("abc", folder)).rejects.toThrow(ZipDownloadError);
+    vi.unstubAllGlobals();
+  });
+
+  it("fails when the response has no name, which registerTask requires", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({ id: "task-1" })));
+    await expect(requestZip("abc", folder)).rejects.toThrow(ZipDownloadError);
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("waitForZip", () => {
+  it("polls until the task reports ready and returns the payload", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ status: "false" }))
+      .mockResolvedValueOnce(jsonRes({ status: "false" }))
+      .mockResolvedValueOnce(
+        jsonRes({ status: "true", payload: "/django_s3/rest_download/zips/x.zip" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(waitForZip("task-1", { intervalMs: 0 })).resolves.toBe(
+      "/django_s3/rest_download/zips/x.zip",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/django_s3/rest_check_task_status/task-1",
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("fails on a 500 from the status endpoint", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({ status: "false" }, false, 500)));
+    await expect(waitForZip("task-1", { intervalMs: 0 })).rejects.toThrow(
+      ZipDownloadError,
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("fails instead of polling forever when the notification is missing", async () => {
+    const fetchMock = vi.fn(async () => jsonRes({ status: null }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(waitForZip("task-1", { intervalMs: 0 })).rejects.toThrow(
+      ZipDownloadError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("gives up once the deadline passes", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({ status: "false" })));
+    let t = 0;
+    const now = () => (t += 60_000);
+
+    await expect(
+      waitForZip("task-1", { intervalMs: 0, timeoutMs: 120_000, now }),
+    ).rejects.toThrow(/too long/i);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+const startedTask = {
+  id: "task-1",
+  name: "zip download",
+  status: "progress",
+  payload: "/dl",
+};
+
+describe("downloadZipped", () => {
+  it("hands the task to the navbar bell and does not poll or download itself", async () => {
+    const fetchMock = vi.fn(async () => jsonRes(startedTask));
+    vi.stubGlobal("fetch", fetchMock);
+    const registerTask = vi.fn();
+    const show = vi.fn();
+    vi.stubGlobal("notificationsApp", { registerTask, show });
+
+    await expect(downloadZipped("abc", folder)).resolves.toBe("notified");
+
+    expect(registerTask).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "task-1", name: "zip download" }),
+    );
+    expect(show).toHaveBeenCalledOnce();
+    // Only the initial request — the bell owns polling and delivery.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to polling and delivering itself when the bell is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(jsonRes(startedTask))
+        .mockResolvedValueOnce(jsonRes({ status: "true", payload: "/zip/url" })),
+    );
+    const click = vi.fn();
+    const created = document.createElement("a");
+    created.click = click;
+    vi.spyOn(document, "createElement").mockReturnValueOnce(created as any);
+
+    await expect(downloadZipped("abc", folder, { intervalMs: 0 })).resolves.toBe(
+      "downloaded",
+    );
+
+    expect(click).toHaveBeenCalledOnce();
+    expect(created.getAttribute("href")).toBe("/zip/url");
+    expect(document.body.contains(created)).toBe(false);
+
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("getNotificationsApp", () => {
+  it("returns null when no notification app is present", () => {
+    expect(getNotificationsApp()).toBeNull();
+  });
+
+  it("ignores a global that lacks registerTask", () => {
+    vi.stubGlobal("notificationsApp", { show: () => {} });
+    expect(getNotificationsApp()).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});

--- a/discovery-atlas/frontend/test/zip-download.test.ts
+++ b/discovery-atlas/frontend/test/zip-download.test.ts
@@ -4,7 +4,6 @@ import {
   isFolder,
   zipRequestUrl,
   requestZip,
-  waitForZip,
   downloadZipped,
   getNotificationsApp,
 } from "@/components/landing-page/zip-download";
@@ -77,61 +76,6 @@ describe("requestZip", () => {
   });
 });
 
-describe("waitForZip", () => {
-  it("polls until the task reports ready and returns the payload", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonRes({ status: "false" }))
-      .mockResolvedValueOnce(jsonRes({ status: "false" }))
-      .mockResolvedValueOnce(
-        jsonRes({ status: "true", payload: "/django_s3/rest_download/zips/x.zip" }),
-      );
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(waitForZip("task-1", { intervalMs: 0 })).resolves.toBe(
-      "/django_s3/rest_download/zips/x.zip",
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      "/django_s3/rest_check_task_status/task-1",
-    );
-
-    vi.unstubAllGlobals();
-  });
-
-  it("fails on a 500 from the status endpoint", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({ status: "false" }, false, 500)));
-    await expect(waitForZip("task-1", { intervalMs: 0 })).rejects.toThrow(
-      ZipDownloadError,
-    );
-    vi.unstubAllGlobals();
-  });
-
-  it("fails instead of polling forever when the notification is missing", async () => {
-    const fetchMock = vi.fn(async () => jsonRes({ status: null }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(waitForZip("task-1", { intervalMs: 0 })).rejects.toThrow(
-      ZipDownloadError,
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    vi.unstubAllGlobals();
-  });
-
-  it("gives up once the deadline passes", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => jsonRes({ status: "false" })));
-    let t = 0;
-    const now = () => (t += 60_000);
-
-    await expect(
-      waitForZip("task-1", { intervalMs: 0, timeoutMs: 120_000, now }),
-    ).rejects.toThrow(/too long/i);
-
-    vi.unstubAllGlobals();
-  });
-});
-
 const startedTask = {
   id: "task-1",
   name: "zip download",
@@ -147,7 +91,7 @@ describe("downloadZipped", () => {
     const show = vi.fn();
     vi.stubGlobal("notificationsApp", { registerTask, show });
 
-    await expect(downloadZipped("abc", folder)).resolves.toBe("notified");
+    await expect(downloadZipped("abc", folder)).resolves.toBeUndefined();
 
     expect(registerTask).toHaveBeenCalledWith(
       expect.objectContaining({ id: "task-1", name: "zip download" }),
@@ -159,28 +103,13 @@ describe("downloadZipped", () => {
     vi.unstubAllGlobals();
   });
 
-  it("falls back to polling and delivering itself when the bell is unreachable", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn()
-        .mockResolvedValueOnce(jsonRes(startedTask))
-        .mockResolvedValueOnce(jsonRes({ status: "true", payload: "/zip/url" })),
-    );
-    const click = vi.fn();
-    const created = document.createElement("a");
-    created.click = click;
-    vi.spyOn(document, "createElement").mockReturnValueOnce(created as any);
+  it("fails without requesting a zip it could not deliver when the bell is missing", async () => {
+    const fetchMock = vi.fn(async () => jsonRes(startedTask));
+    vi.stubGlobal("fetch", fetchMock);
 
-    await expect(downloadZipped("abc", folder, { intervalMs: 0 })).resolves.toBe(
-      "downloaded",
-    );
+    await expect(downloadZipped("abc", folder)).rejects.toThrow(ZipDownloadError);
+    expect(fetchMock).not.toHaveBeenCalled();
 
-    expect(click).toHaveBeenCalledOnce();
-    expect(created.getAttribute("href")).toBe("/zip/url");
-    expect(document.body.contains(created)).toBe(false);
-
-    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 });

--- a/discovery-atlas/frontend/test/zip-download.test.ts
+++ b/discovery-atlas/frontend/test/zip-download.test.ts
@@ -5,7 +5,6 @@ import {
   zipRequestUrl,
   requestZip,
   downloadZipped,
-  getNotificationsApp,
 } from "@/components/landing-page/zip-download";
 
 const folder = { name: "f", children: [], key: 1, path: "top/f" } as any;
@@ -110,18 +109,6 @@ describe("downloadZipped", () => {
     await expect(downloadZipped("abc", folder)).rejects.toThrow(ZipDownloadError);
     expect(fetchMock).not.toHaveBeenCalled();
 
-    vi.unstubAllGlobals();
-  });
-});
-
-describe("getNotificationsApp", () => {
-  it("returns null when no notification app is present", () => {
-    expect(getNotificationsApp()).toBeNull();
-  });
-
-  it("ignores a global that lacks registerTask", () => {
-    vi.stubGlobal("notificationsApp", { show: () => {} });
-    expect(getNotificationsApp()).toBeNull();
     vi.unstubAllGlobals();
   });
 });

--- a/discovery-atlas/frontend/test/zip-download.test.ts
+++ b/discovery-atlas/frontend/test/zip-download.test.ts
@@ -24,15 +24,22 @@ describe("isFolder", () => {
 });
 
 describe("zipRequestUrl", () => {
-  it("omits zipped=true for folders, which the server zips automatically", () => {
+  it("matches the path the legacy file browser uses, trailing slash included", () => {
     expect(zipRequestUrl("abc", folder)).toBe(
-      "/django_s3/download/abc/data/contents/top/f",
+      "/resource/abc/data/contents/top/f/?zipped=true",
     );
   });
 
-  it("adds zipped=true for single files", () => {
+  it("builds the same path for single files", () => {
     expect(zipRequestUrl("abc", file)).toBe(
-      "/django_s3/download/abc/data/contents/top/a.txt?zipped=true",
+      "/resource/abc/data/contents/top/a.txt/?zipped=true",
+    );
+  });
+
+  it("encodes each segment but keeps the separators", () => {
+    const spaced = { name: "New folder", children: [], key: 3, path: "top/New folder" } as any;
+    expect(zipRequestUrl("abc", spaced)).toBe(
+      "/resource/abc/data/contents/top/New%20folder/?zipped=true",
     );
   });
 });
@@ -50,7 +57,7 @@ describe("requestZip", () => {
     });
 
     const [url, opts] = fetchMock.mock.calls[0];
-    expect(url).toBe("/django_s3/download/abc/data/contents/top/f");
+    expect(url).toBe("/resource/abc/data/contents/top/f/?zipped=true");
     expect(opts).toMatchObject({ credentials: "include" });
 
     vi.unstubAllGlobals();

--- a/hs_core/templates/pages/search.html
+++ b/hs_core/templates/pages/search.html
@@ -29,6 +29,12 @@
     });
 
     resizeObserver.observe(iframe.contentWindow.document.body);
+
+    // Clicks inside the iframe never reach this document, so Bootstrap's
+    // dropdown auto-close never fires. Forward them to close open menus.
+    iframe.contentWindow.document.addEventListener("click", () => {
+      $(document).trigger("click.bs.dropdown.data-api");
+    });
   });
 
   function receiveMessage(event) {


### PR DESCRIPTION
Adds zipped folder download to the resource-v2 file browser, matching legacy behavior.

New `zip-download.ts` hits `/django_s3/download/` (folders auto-zip server-side), then hands the task to the navbar `notificationsApp` on the parent window.

Plain **Download** is now hidden for folders, but will be added for aggregations later on when implemented.

Requires https://github.com/cznethub/cznet-vue-core/pull/896