### PR TITLE
6016: RLP POC -- make name field on relation use enum for non-editable types

### DIFF
--- a/hs_cloudnative_schemas/schema/base.py
+++ b/hs_cloudnative_schemas/schema/base.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from enum import Enum
+from enum import Enum, Enum as PyEnum
 from typing import Any, List, Optional, Union, Literal, Annotated
 
 from pydantic import (
@@ -17,6 +17,14 @@ from pydantic import (
     WithJsonSchema,
 )
 from pydantic.json_schema import JsonSchemaValue
+
+from hsmodels.schemas.enums import RelationType as HSRelationType
+from hs_core.enums import NOT_USER_EDITABLE_RELATION_TYPES
+
+UserEditableRelationType = PyEnum(
+    'UserEditableRelationType',
+    {m.name: m.value for m in HSRelationType if m.name not in NOT_USER_EDITABLE_RELATION_TYPES},
+)
 
 
 orcid_pattern = "\\b\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]\\b"
@@ -387,6 +395,10 @@ class IsPartOf(CreativeWork):
 
 
 class Relation(CreativeWork):
+    name: Optional[UserEditableRelationType] = Field(  # type: ignore[assignment]
+        default=None,
+        json_schema_extra=remove_none_default,
+    )
     url: Optional[HttpUrl] = Field(
         title="URL",
         description="The URL address to the data resource.",

--- a/hs_cloudnative_schemas/schema/json_schemas/resource_edit_schema.json
+++ b/hs_cloudnative_schemas/schema/json_schemas/resource_edit_schema.json
@@ -1230,9 +1230,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Submission's name or title",
-          "title": "Name or title",
-          "type": "string"
+          "$ref": "#/definitions/UserEditableRelationType"
         },
         "url": {
           "description": "The URL address to the data resource.",
@@ -1382,6 +1380,24 @@
       ],
       "title": "TemporalCoverage",
       "type": "object"
+    },
+    "UserEditableRelationType": {
+      "enum": [
+        "The content of this resource can be executed by",
+        "The content of this resource was created by a related App or software program",
+        "This resource is described by",
+        "This resource conforms to established standard described by",
+        "This resource has a related resource in another format",
+        "This resource is a different format of",
+        "This resource is required by",
+        "This resource requires",
+        "This resource is referenced by",
+        "The content of this resource references",
+        "The content of this resource is derived from",
+        "The content of this resource is similar to"
+      ],
+      "title": "Type of relationship",
+      "type": "string"
     },
     "VideoObject": {
       "additionalProperties": true,

--- a/hs_cloudnative_schemas/schema/scripts/generate_resource_edit_schema_json.py
+++ b/hs_cloudnative_schemas/schema/scripts/generate_resource_edit_schema_json.py
@@ -91,7 +91,11 @@ def convert_defs_to_definitions(schema: dict[str, Any]) -> dict[str, Any]:
 def build_resource_edit_schema() -> dict[str, Any]:
     """Build the JSON schema for the CoreMetadataEdit model."""
     schema = CoreMetadataEdit.model_json_schema(schema_generator=_GenerateJsonSchemaNoNullableAnyOf)
-    return convert_defs_to_definitions(schema)
+    normalized = convert_defs_to_definitions(schema)
+    # Set a human-readable title for the relation type enum definition.
+    if "UserEditableRelationType" in normalized.get("definitions", {}):
+        normalized["definitions"]["UserEditableRelationType"]["title"] = "Type of relationship"
+    return normalized
 
 
 def write_resource_edit_schema(output_path: Path = OUTPUT_FILE) -> Path:

--- a/hs_cloudnative_schemas/tests/test_core_metadata_edit.py
+++ b/hs_cloudnative_schemas/tests/test_core_metadata_edit.py
@@ -1,4 +1,11 @@
+import pytest
+from pydantic import ValidationError
+
+from hsmodels.schemas.enums import RelationType as HSRelationType
+
+from hs_cloudnative_schemas.schema.base import Relation
 from hs_cloudnative_schemas.schema.core import CoreMetadataEdit
+from hs_core.enums import NOT_USER_EDITABLE_RELATION_TYPES
 
 
 def _get_property(properties: dict, field_name: str) -> dict:
@@ -126,3 +133,17 @@ def test_core_metadata_edit_marks_only_non_editable_fields_as_read_only():
 
     for field_name in read_only_fields:
         assert _get_property(properties, field_name).get("readOnly") is True
+
+
+def test_relation_name_enum_contains_only_user_editable_types():
+    # All user-editable relation types should be accepted
+    for m in HSRelationType:
+        if m.name not in NOT_USER_EDITABLE_RELATION_TYPES:
+            relation = Relation.model_validate({"name": m.value})
+            assert relation.name is not None
+
+    # All non-user-editable relation types should be rejected
+    for m in HSRelationType:
+        if m.name in NOT_USER_EDITABLE_RELATION_TYPES:
+            with pytest.raises(ValidationError):
+                Relation.model_validate({"name": m.value})

--- a/hs_core/enums.py
+++ b/hs_core/enums.py
@@ -26,6 +26,16 @@ class RelationTypes(str, enum.Enum):
     relation = 'relation'
 
 
+# Relation types managed automatically by HydroShare that users cannot manually set
+NOT_USER_EDITABLE_RELATION_TYPES = frozenset({
+    RelationTypes.isVersionOf,
+    RelationTypes.isReplacedBy,
+    RelationTypes.isPartOf,
+    RelationTypes.hasPart,
+    RelationTypes.replaces,
+})
+
+
 class DataciteSubmissionStatus(str, enum.Enum):
     """Datacite metadata deposit submission status"""
 

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -46,7 +46,7 @@ from rdflib.namespace import DC, DCTERMS, RDF
 from spam_patterns.worst_patterns_re import patterns
 
 from django_s3.storage import S3Storage
-from hs_core.enums import (DataciteSubmissionStatus, RelationTypes)
+from hs_core.enums import (DataciteSubmissionStatus, NOT_USER_EDITABLE_RELATION_TYPES, RelationTypes)
 from hs_core.s3 import ResourceFileS3Mixin, ResourceS3Mixin
 from .hs_rdf import (HSTERMS, RDFS1, RDF_MetaData_Mixin, RDF_Term_MixIn,
                      rdf_terms)
@@ -1208,8 +1208,7 @@ class Relation(AbstractRelation):
     # these are hydroshare custom terms that are not Dublin Core terms
     HS_RELATION_TERMS = (RelationTypes.isExecutedBy, RelationTypes.isCreatedBy, RelationTypes.isDescribedBy,
                          RelationTypes.isSimilarTo)
-    NOT_USER_EDITABLE = (RelationTypes.isVersionOf, RelationTypes.isReplacedBy,
-                         RelationTypes.isPartOf, RelationTypes.hasPart, RelationTypes.replaces)
+    NOT_USER_EDITABLE = NOT_USER_EDITABLE_RELATION_TYPES
     term = 'Relation'
     type = models.CharField(max_length=100, choices=SOURCE_TYPES)
     value = models.TextField()


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
Makes the `name` field for Relation use an enum, to match the values we accept in the current landing page form:
<img width="625" height="437" alt="Screenshot 2026-08-06 at 2 34 45 PM" src="https://github.com/user-attachments/assets/f3e8a9ca-fa43-4b0b-8c29-f06833a37158" />

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Run branch locally and view a resource at http://localhost/resource-v2/<id>
2. Edit resource
3. See add relation form has Relation type constrained to a set of values instead of free text:
<img width="968" height="659" alt="Screenshot 2026-08-06 at 2 07 16 PM" src="https://github.com/user-attachments/assets/9369a7a0-806e-4e1a-ac4b-8ab8142c8c7e" />

