### PR TITLE
6425: Refactor relation generation to remove duplicated passes over list and resulting duplicated relation entries

### DIFF
--- a/hs_core/hydroshare_schemaorg_adapter.py
+++ b/hs_core/hydroshare_schemaorg_adapter.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any, List, Optional, Union, Literal
 
 from pydantic import BaseModel, HttpUrl, ConfigDict, model_validator
+from hsmodels.schemas.enums import RelationType
 
 from hs_cloudnative_schemas.schema import base as schema
 from hs_cloudnative_schemas.schema.dataset import ScientificDataset, AdditionalType
@@ -139,18 +140,17 @@ class ContentFile(BaseModel):
 
 
 class Relation(BaseModel):
-    type: str
+    type: RelationType
     value: str
 
-    def to_dataset_part_relation(self, relation_type: str):
-        relation = None
-        if relation_type == "IsPartOf" and self.type.endswith("is part of"):
+    def to_dataset_relation(self):
+        if self.type == RelationType.isPartOf:
             relation = schema.IsPartOf.construct()
-        elif relation_type == "HasPart" and self.type.endswith("resource includes"):
+        elif self.type == RelationType.hasPart:
             relation = schema.HasPart.construct()
         else:
             relation = schema.Relation.construct()
-            relation.name = self.type
+            relation.name = self.type.value
 
         if ',' in self.value:
             description, url = self.value.rsplit(',', 1)
@@ -223,9 +223,9 @@ class _HydroshareResourceMetadata(BaseModel):
     def set_extra_columns(cls, data: Any):
         if isinstance(data, dict):
             extra_fields = data.keys() - cls.model_fields.keys()
+            if "extra_columns" not in data:
+                data["extra_columns"] = {}
             if extra_fields:
-                if "extra_columns" not in data:
-                    data["extra_columns"] = {}
                 data["extra_columns"].update(
                     {field_name: data[field_name] for field_name in extra_fields}
                 )
@@ -252,22 +252,17 @@ class _HydroshareResourceMetadata(BaseModel):
     def to_dataset_associated_media(self):
         return self.associatedMedia
 
-    def to_dataset_is_part_of(self):
-        return self._to_dataset_part_relations("IsPartOf")
-
-    def to_dataset_has_part(self):
-        return self._to_dataset_part_relations("HasPart")
-
-    def to_dataset_relations(self):
-        return self._to_dataset_part_relations("Other")
-
-    def _to_dataset_part_relations(self, relation_type: str):
-        part_relations = []
+    def _partition_relations_by_type(self):
+        is_part_of, has_part, other = [], [], []
         for relation in self.relations:
-            part_relation = relation.to_dataset_part_relation(relation_type)
-            if part_relation:
-                part_relations.append(part_relation)
-        return part_relations
+            result = relation.to_dataset_relation()
+            if relation.type == RelationType.isPartOf:
+                is_part_of.append(result)
+            elif relation.type == RelationType.hasPart:
+                has_part.append(result)
+            else:
+                other.append(result)
+        return is_part_of, has_part, other
 
     def to_dataset_spatial_coverage(self):
         if self.spatial_coverage:
@@ -320,6 +315,7 @@ class _HydroshareResourceMetadata(BaseModel):
 
     def to_catalog_dataset(self):
         dataset = ScientificDataset.model_construct(**self.extra_columns)
+        is_part_of, has_part, other_relations = self._partition_relations_by_type()
         dataset.additionalType = self.to_additional_type(self.type) if self.type else None
         dataset.provider = self.to_dataset_provider()
         dataset.name = self.title
@@ -337,10 +333,10 @@ class _HydroshareResourceMetadata(BaseModel):
         dataset.spatialCoverage = self.to_dataset_spatial_coverage()
         dataset.temporalCoverage = self.to_dataset_period_coverage()
         dataset.associatedMedia = self.to_dataset_associated_media()
-        dataset.isPartOf = self.to_dataset_is_part_of()
-        dataset.hasPart = self.to_dataset_has_part()
+        dataset.isPartOf = is_part_of
+        dataset.hasPart = has_part
+        dataset.relations = other_relations
         dataset.license = self.to_dataset_license()
         dataset.citation = [self.citation]
         dataset.creativeWorkStatus = self.to_dataset_creative_work_status()
-        dataset.relations = self.to_dataset_relations()
         return dataset

--- a/hs_core/tests/test_hydroshare_schemaorg_adapter.py
+++ b/hs_core/tests/test_hydroshare_schemaorg_adapter.py
@@ -1,12 +1,22 @@
+import unittest
 from unittest_parametrize import ParametrizedTestCase, parametrize, param
 
 from hs_cloudnative_schemas.schema import base as schema
-from hs_core.hydroshare_schemaorg_adapter import Relation
+from hs_core.hydroshare_schemaorg_adapter import HydroshareMetadataAdapter, Relation
 
 
-class TestRelationToDatasetPartRelation(ParametrizedTestCase):
-    """Tests for Relation.to_dataset_part_relation() — specifically the URL/description
-    parsing logic that splits on the last comma of the relation value."""
+IS_PART_OF_VALUE = "The content of this resource is part of"
+HAS_PART_VALUE = "This resource includes"
+REFERENCES_VALUE = "The content of this resource references"
+
+MINIMAL_METADATA = {
+    "type": "CompositeResource",
+    "title": "Test Resource",
+}
+
+
+class TestRelationToDatasetRelation(ParametrizedTestCase):
+    """Tests for Relation.to_dataset_relation() — URL/description parsing and schema object type."""
 
     @parametrize(
         "value,expected_description,expected_url",
@@ -40,8 +50,8 @@ class TestRelationToDatasetPartRelation(ParametrizedTestCase):
     def test_description_and_url_parsing(self, value, expected_description, expected_url):
         """URL is only set when the text after the last comma is a valid URL; otherwise
         it is folded back into the description."""
-        relation = Relation(type="The content of this resource references", value=value)
-        result = relation.to_dataset_part_relation("Other")
+        relation = Relation(type=REFERENCES_VALUE, value=value)
+        result = relation.to_dataset_relation()
 
         self.assertEqual(result.description, expected_description)
         if expected_url is None:
@@ -51,31 +61,81 @@ class TestRelationToDatasetPartRelation(ParametrizedTestCase):
             self.assertEqual(str(result.url), expected_url)
 
     def test_is_part_of_relation_type(self):
-        """A relation whose type ends with 'is part of' yields an IsPartOf schema object."""
+        """An isPartOf relation yields an IsPartOf schema object with description set."""
         relation = Relation(
-            type="The content of this resource is part of",
+            type=IS_PART_OF_VALUE,
             value="Some collection, https://www.hydroshare.org/resource/abc123",
         )
-        result = relation.to_dataset_part_relation("IsPartOf")
+        result = relation.to_dataset_relation()
         self.assertEqual(str(result.url), "https://www.hydroshare.org/resource/abc123")
         self.assertIsInstance(result, schema.IsPartOf)
         self.assertEqual(result.description, "Some collection")
 
     def test_has_part_relation_type(self):
-        """A relation whose type ends with 'resource includes' yields a HasPart schema object."""
+        """A hasPart relation yields a HasPart schema object with description set."""
         relation = Relation(
-            type="This resource includes",
+            type=HAS_PART_VALUE,
             value="A contained resource, https://www.hydroshare.org/resource/def456",
         )
-        result = relation.to_dataset_part_relation("HasPart")
+        result = relation.to_dataset_relation()
         self.assertEqual(str(result.url), "https://www.hydroshare.org/resource/def456")
         self.assertIsInstance(result, schema.HasPart)
         self.assertEqual(result.description, "A contained resource")
 
     def test_other_relation_type_sets_name(self):
         """Any relation_type other than HasPart or IsPartOf yields a Relation schema object with name set."""
-        rel_type = "The content of this resource references"
-        relation = Relation(type=rel_type, value="Some value")
-        result = relation.to_dataset_part_relation("Other")
+        relation = Relation(type=REFERENCES_VALUE, value="Some value")
+        result = relation.to_dataset_relation()
         self.assertIsInstance(result, schema.Relation)
-        self.assertEqual(result.name, rel_type)
+        self.assertEqual(result.name, REFERENCES_VALUE)
+
+
+class TestToCatalogRecordRelationPartitioning(unittest.TestCase):
+    """Tests that relations are routed to the correct fields and are not duplicated."""
+
+    def test_is_part_of_only_appears_in_is_part_of(self):
+        metadata = {
+            **MINIMAL_METADATA,
+            "relations": [{"type": IS_PART_OF_VALUE, "value": "A collection, https://www.hydroshare.org/resource/abc"}],
+        }
+        dataset = HydroshareMetadataAdapter.to_catalog_record(metadata)
+        self.assertEqual(len(dataset.isPartOf), 1)
+        self.assertEqual(len(dataset.hasPart), 0)
+        self.assertEqual(len(dataset.relations), 0)
+
+    def test_has_part_only_appears_in_has_part(self):
+        metadata = {
+            **MINIMAL_METADATA,
+            "relations": [{
+                "type": HAS_PART_VALUE,
+                "value": "A child resource, https://www.hydroshare.org/resource/def"
+            }],
+        }
+        dataset = HydroshareMetadataAdapter.to_catalog_record(metadata)
+        self.assertEqual(len(dataset.hasPart), 1)
+        self.assertEqual(len(dataset.isPartOf), 0)
+        self.assertEqual(len(dataset.relations), 0)
+
+    def test_other_relation_only_appears_in_relations(self):
+        metadata = {
+            **MINIMAL_METADATA,
+            "relations": [{"type": REFERENCES_VALUE, "value": "A paper, https://doi.org/10.1234/abc"}],
+        }
+        dataset = HydroshareMetadataAdapter.to_catalog_record(metadata)
+        self.assertEqual(len(dataset.relations), 1)
+        self.assertEqual(len(dataset.isPartOf), 0)
+        self.assertEqual(len(dataset.hasPart), 0)
+
+    def test_mixed_relations_assigned_correctly(self):
+        metadata = {
+            **MINIMAL_METADATA,
+            "relations": [
+                {"type": IS_PART_OF_VALUE, "value": "A collection, https://www.hydroshare.org/resource/abc"},
+                {"type": HAS_PART_VALUE, "value": "A child, https://www.hydroshare.org/resource/def"},
+                {"type": REFERENCES_VALUE, "value": "A paper, https://doi.org/10.1234/abc"},
+            ],
+        }
+        dataset = HydroshareMetadataAdapter.to_catalog_record(metadata)
+        self.assertEqual(len(dataset.isPartOf), 1)
+        self.assertEqual(len(dataset.hasPart), 1)
+        self.assertEqual(len(dataset.relations), 1)


### PR DESCRIPTION
Refactors the schema.org adapter slightly to use the enum `RelationType` for the Relation class's type attribute (which Pydantic will coerce to from the string value), and then instantiate the relation objects and partition into separate lists (isPartOf, hasPart, and all others) based on that type.

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Run app locally
2. Add a resource to a collection
3. See generated metadata for the resource is now correct and not duplicated across fields:
<img width="971" height="454" alt="Screenshot 2026-08-06 at 3 49 25 PM" src="https://github.com/user-attachments/assets/d0c639bb-402f-43a8-80a1-d5a91f1a1acf" />


Resolves #6425 