### PR TITLE
fix: Exclude the same files client-side that data_store_structure does

### DIFF
--- a/discovery-atlas/frontend/src/components/landing-page/shared.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/shared.ts
@@ -3,6 +3,20 @@ import { Notifications } from "@cznethub/cznet-vue-core";
 import { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
 import { S3_PROXY_URL } from "@/constants";
 
+const hiddenFileSuffixes = [
+  "_meta.xml",
+  "_resmap.xml",
+  "hs_user_metadata.json",
+  ".hs_user_metadata.json",
+  "_schema.json",
+  "_schema_values.json",
+];
+
+function shouldHideFileName(name: string): boolean {
+  const lowerName = name.toLowerCase();
+  return hiddenFileSuffixes.some((suffix) => lowerName.endsWith(suffix));
+}
+
 export const onFileDownload = async (items: (IFile | IFolder)[], resourceId: string, s3Client: S3Client, bucket: string) => {
   try {
     for (let item of items) {
@@ -61,6 +75,10 @@ export const _readFolderRecursive = async (
     if (s3Response.Contents) {
       files = s3Response.Contents
         .filter(f => f.Key !== path)  // Filter out current directory file marker
+        .filter((f) => {
+          const fileName = f.Key?.replace(path, "") || "";
+          return fileName.length > 0 && !shouldHideFileName(fileName);
+        })
         .map((f: _Object, _index: number) => {
           return {
             name: f.Key?.replace(path, ""),

--- a/discovery-atlas/frontend/test/landing-page-shared.test.ts
+++ b/discovery-atlas/frontend/test/landing-page-shared.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { readRootFolder } from "@/components/landing-page/shared";
+
+function makeClient() {
+  return {
+    send: vi.fn()
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: "abc/data/contents/visible.txt", Size: 10 },
+          { Key: "abc/data/contents/resourcemap.xml", Size: 10 },
+          { Key: "abc/data/contents/test_meta.xml", Size: 11 },
+          { Key: "abc/data/contents/test_resmap.xml", Size: 12 },
+          { Key: "abc/data/contents/hs_user_metadata.json", Size: 13 },
+          { Key: "abc/data/contents/test_schema.json", Size: 14 },
+          { Key: "abc/data/contents/test_schema_values.json", Size: 15 },
+        ],
+        CommonPrefixes: [{ Prefix: "abc/data/contents/folder1/" }],
+      })
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: "abc/data/contents/folder1/child.csv", Size: 20 },
+          { Key: "abc/data/contents/folder1/child_meta.xml", Size: 21 },
+          { Key: "abc/data/contents/folder1/child_resmap.xml", Size: 22 },
+        ],
+        CommonPrefixes: [],
+      }),
+  } as any;
+}
+
+describe("readRootFolder", () => {
+  it("prunes metadata sidecar files from the recursive S3 tree", async () => {
+    const client = makeClient();
+    const tree = await readRootFolder("abc/data/contents/", client, "bucket");
+
+    expect(tree.map((item: any) => item.name)).toEqual([
+      "folder1",
+      "resourcemap.xml",
+      "visible.txt",
+    ]);
+
+    const folder = tree.find((item: any) => item.name === "folder1") as any;
+    expect(folder.children.map((item: any) => item.name)).toEqual(["child.csv"]);
+  });
+});


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
In the current RLP, we rely on the endpoint `/_internal/data-store-structure/` to build the file tree for the file browser, and it [excludes certain files](https://github.com/hydroshare/hydroshare/blob/develop/hs_core/views/resource_folder_hierarchy.py#L153-L160) [by suffix](https://github.com/hydroshare/hydroshare/blob/develop/hs_file_types/enums.py#L4-L10).  

This PR implements the same exclusion client-side in the Vue app.  The may be a better way to do this -- we could continue using the backend endpoint as the source of truth for what files to include (or a new internal endpoint that just returns file suffixes to exclude), or include some sort of app-specific manifest of what files should be visible.  But this works for now and is simple.  Open to other ideas!

Before:
<img width="569" height="527" alt="Screenshot 2026-08-07 at 2 05 23 PM" src="https://github.com/user-attachments/assets/cf97747c-e991-4ad5-a8f2-8f0f6df56b13" />

After:
<img width="569" height="519" alt="Screenshot 2026-08-07 at 2 05 36 PM" src="https://github.com/user-attachments/assets/a3059f4d-10d5-4f81-a3f0-644bb4052a4b" />

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. See new RLP file explorer
