### PR TITLE
fix: Update type filter to use aliased field name

### DIFF
--- a/hs_rest_api/discovery_atlas.py
+++ b/hs_rest_api/discovery_atlas.py
@@ -134,7 +134,7 @@ class SearchQuery(BaseModel):
             )
 
         filters.extend(date_filters)
-        filters.append({'term': {'path': 'type', 'query': "ScientificDataset"}})
+        filters.append({'term': {'path': '@type', 'query': "ScientificDataset"}})
 
         return filters
 

--- a/hs_rest_api/tests/http/test_discovery_atlas.py
+++ b/hs_rest_api/tests/http/test_discovery_atlas.py
@@ -91,7 +91,7 @@ class TestSearchQuery(ParametrizedTestCase):
                     "lt": datetime(data_coverage_end + 1, 1, 1),
                 }
             },
-            {"term": {"path": "type", "query": "ScientificDataset"}},
+            {"term": {"path": "@type", "query": "ScientificDataset"}},
         ]
         expected_must = [
             {


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

Updates search query to use `@type` as filter path since this field name has been changed in the jsonld metadata and therefore also in the Discovery collection documents.

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. See search query returns results when running locally:
<img width="1336" height="784" alt="Screenshot 2026-08-13 at 11 15 12 AM" src="https://github.com/user-attachments/assets/489b1fac-3901-4b8f-8d16-3018d35bef7c" />

