### PR TITLE
6386: Implement download bag

### DIFF
--- a/discovery-atlas/frontend/src/components/landing-page/bag-download.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/bag-download.ts
@@ -1,10 +1,10 @@
-import { getNotificationsApp, ZipTask } from "./shared";
+import { getNotificationsApp, type NotificationTask } from "./notifications-app";
 
 export class BagDownloadError extends Error { }
 
 export const requestBag = async (
   bagUrl: string,
-): Promise<ZipTask> => {
+): Promise<NotificationTask> => {
   const response = await fetch(bagUrl, {
     method: "GET",
     headers: {

--- a/discovery-atlas/frontend/src/components/landing-page/bag-download.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/bag-download.ts
@@ -1,0 +1,44 @@
+import { getNotificationsApp, ZipTask } from "./shared";
+
+export class BagDownloadError extends Error { }
+
+export const requestBag = async (
+  bagUrl: string,
+): Promise<ZipTask> => {
+  const response = await fetch(bagUrl, {
+    method: "GET",
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+      Accept: "application/json",
+    },
+    credentials: "include",
+  });
+
+  if (response.status === 401) {
+    throw new BagDownloadError(
+      "You do not have permission to download this resource.",
+    );
+  }
+  if (!response.ok) {
+    throw new BagDownloadError("Failed to start the bag download.");
+  }
+
+  const task = await response.json();
+  if (!task?.id || !task?.name) {
+    throw new BagDownloadError("Failed to start the bag download.");
+  }
+  return task;
+};
+
+export const downloadBag = async (
+  bagUrl: string,
+): Promise<void> => {
+  const notifications = getNotificationsApp();
+  if (!notifications) {
+    throw new BagDownloadError("Failed to start the bag download.");
+  }
+
+  const task = await requestBag(bagUrl);
+  notifications.registerTask(task);
+  notifications.show();
+};

--- a/discovery-atlas/frontend/src/components/landing-page/edit-dataset.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/edit-dataset.vue
@@ -525,9 +525,11 @@
                   :folder-name-regex="folderNameRegex"
                   :canDownloadItem="(item: IFile | IFolder) => !isFolder(item)"
                   :download-zipped="(item: IFile | IFolder) => onZippedDownload(item, resourceId)"
+                  :download-archive="() => onDownloadBag(resourceId, bagUrl)"
                   :upload="uploadFiles"
                   :delete-file-or-folder="deleteFileOrFolder"
                   :rename-file-or-folder="renameFileOrFolder"
+                  downloadArchiveHelpText="Download all content as Zipped BagIt Archive"
                   @download="
                     onFileDownload(
                       $event,
@@ -916,6 +918,7 @@ import {
 import {
   fetchResource,
   getStatusColor,
+  onDownloadBag,
   onFileDownload,
   onZippedDownload,
   parseDate,

--- a/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/landing-page.vue
@@ -411,9 +411,11 @@
                 :canDownloadItem="(item: IFile | IFolder) => !isFolder(item)"
                 :load-file-preview="(item) => loadFilePreview(item)"
                 :download-zipped="(item: IFile | IFolder) => onZippedDownload(item, resourceId)"
+                :download-archive="() => onDownloadBag(resourceId, bagUrl)"
                 @download="
                   onFileDownload($event, resourceId, s3Client, s3Info.bucket)
                 "
+                downloadArchiveHelpText="Download all content as Zipped BagIt Archive"
               >
                 <template #prepend>
                   <span />
@@ -781,6 +783,7 @@ import { GetObjectCommand, S3Client, _Object } from "@aws-sdk/client-s3";
 import {
   fetchResource,
   getStatusColor,
+  onDownloadBag,
   onFileDownload,
   onZippedDownload,
   parseDate,
@@ -852,6 +855,7 @@ const alerts = ref<{
   isPublished?: boolean;
   displayName?: string;
 }>({});
+const bagUrl = ref<string>("");
 const dismissedAlerts = ref<Record<string, boolean>>({});
 const onParentMessage = (event: MessageEvent) => {
   // search.html in the parent posts `{ parentSearch, owners }` after the
@@ -1168,6 +1172,9 @@ async function init() {
       }
       if (parentWin.HS_RESOURCE_ALERTS && typeof parentWin.HS_RESOURCE_ALERTS === "object") {
         alerts.value = parentWin.HS_RESOURCE_ALERTS;
+      }
+      if (parentWin.HS_BAG_URL && typeof parentWin.HS_BAG_URL === "string") {
+        bagUrl.value = parentWin.HS_BAG_URL;
       }
     }
   } catch {

--- a/discovery-atlas/frontend/src/components/landing-page/shared.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/shared.ts
@@ -2,6 +2,7 @@ import { _Object, CommonPrefix, GetObjectCommand, ListObjectsV2Command, S3Client
 import { Notifications } from "@cznethub/cznet-vue-core";
 import { IFile, IFolder } from "@cznethub/cznet-vue-core/dist/types";
 import { S3_PROXY_URL } from "@/constants";
+import { downloadBag, BagDownloadError } from "./bag-download";
 import { downloadZipped, ZipDownloadError } from "./zip-download";
 
 export const onZippedDownload = async (item: IFile | IFolder, resourceId: string) => {
@@ -39,6 +40,22 @@ const hiddenFileSuffixes = [
 function shouldHideFileName(name: string): boolean {
   const lowerName = name.toLowerCase();
   return hiddenFileSuffixes.some((suffix) => lowerName.endsWith(suffix));
+}
+
+export const onDownloadBag = async (resourceId: string, bagUrl: string | null) => {
+  const requestUrl = bagUrl || `/django_irods/download/bags/${resourceId}.zip`;
+
+  try {
+    await downloadBag(requestUrl);
+  }
+  catch (error: any) {
+    const message =
+      error instanceof BagDownloadError
+        ? error.message
+        : "Failed to download the bag.";
+    console.error("Bag download failed:", error);
+    Notifications.toast({ title: "Error", message, type: "error" });
+  }
 }
 
 export const onFileDownload = async (items: (IFile | IFolder)[], resourceId: string, s3Client: S3Client, bucket: string) => {
@@ -218,6 +235,7 @@ export const fetchResource = async (resourceId: string, s3Client: S3Client, buck
     return false
   }
 }
+
 /**
  * Sharing-status chip colour, shared by the landing page and the edit page.
  *

--- a/hs_core/templates/pages/search.html
+++ b/hs_core/templates/pages/search.html
@@ -22,6 +22,7 @@
   window.HS_RESOURCE_OWNERS = {{ owners_json|default:"null"|safe }};
   window.HS_RESOURCE_CREATOR_PROFILES = {{ creator_profiles_json|default:"null"|safe }};
   window.HS_RESOURCE_ALERTS = {{ alerts_json|default:"null"|safe }};
+  window.HS_BAG_URL = {{ bag_url|default:"null"|safe }};
 
   iframe.addEventListener("load", () => {
     const resizeObserver = new ResizeObserver((entries) => {

--- a/hs_discover/views.py
+++ b/hs_discover/views.py
@@ -112,5 +112,6 @@ class AtlasLandingView(TemplateView):
             "owners_json": json.dumps(owners),
             "creator_profiles_json": json.dumps(creator_profiles),
             "alerts_json": json.dumps(alerts),
+            "bag_url": json.dumps(resource.bag_url),
         }
         return render(request, 'pages/search.html', context)


### PR DESCRIPTION
<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->
Implements download Bag action on landing page in read and edit modes (follows pattern used for download zipped).
- If bag does not exist or is stale, endpoint returns a task payload, we then use the notifications app to poll for that task to complete.  When complete, we use the returned URL to download the file.
- If bag does exist and is not stale, the download URL is returned directly in the API response, which we can then use to fetch immediately.

### Pull Request Checklist: 
- [x] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [x] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation

### Positive Test Case
1. Demo:

https://github.com/user-attachments/assets/f41e3cf5-dffe-49b5-b81f-9c8cd5e5c29d

