### PR TITLE
[#6436] Improve file explorer upload

### DIFF
--- a/discovery-atlas/frontend/src/assets/css/host-dialogs.scss
+++ b/discovery-atlas/frontend/src/assets/css/host-dialogs.scss
@@ -21,4 +21,18 @@ html.hs-embedded {
     overflow: visible !important;
     padding-inline-end: 0 !important;
   }
+
+  // Uppy's modal is not a Vuetify overlay, so it needs the band treatment too.
+  .uppy-Dashboard--modal .uppy-Dashboard-inner {
+    top: var(--hs-dialog-top, 24px);
+    bottom: auto;
+    height: min(500px, var(--hs-dialog-max-h, 640px));
+  }
+
+  @media only screen and (min-width: 820px) {
+    .uppy-Dashboard--modal .uppy-Dashboard-inner {
+      // Undo the vertical half of Uppy's translate(-50%, -50%).
+      transform: translateX(-50%);
+    }
+  }
 }

--- a/discovery-atlas/frontend/src/components/landing-page/edit-dataset.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/edit-dataset.vue
@@ -526,6 +526,7 @@
                   :canDownloadItem="(item: IFile | IFolder) => !isFolder(item)"
                   :download-zipped="(item: IFile | IFolder) => onZippedDownload(item, resourceId)"
                   :upload="uploadFiles"
+                  :add-files="onAddFiles"
                   :delete-file-or-folder="deleteFileOrFolder"
                   :rename-file-or-folder="renameFileOrFolder"
                   @download="
@@ -540,17 +541,15 @@
                   <template #prepend>
                     <span />
                   </template>
-                  <template #drop-area>
-                    <HsUppy
-                      ref="hsUppyRef"
-                      :s3Info="s3Info"
-                      :s3Host="s3Host"
-                      :fileExplorer="fileExplorer"
-                      :upload-prefix="`${resourceId}/data/contents/`"
-                      @file-uploaded="onUppyFileUploaded"
-                    />
-                  </template>
                 </cz-file-explorer>
+
+                <HsUppy
+                  ref="hsUppyRef"
+                  :s3Info="s3Info"
+                  :s3Host="s3Host"
+                  :upload-prefix="`${resourceId}/data/contents/`"
+                  @file-uploaded="onUppyFileUploaded"
+                />
               </div>
               <v-skeleton-loader
                 v-else
@@ -1757,12 +1756,15 @@ function onReadmeChange(payload: {
   }
 }
 
+function onAddFiles(_folder: IFolder, path: string) {
+  hsUppyRef.value?.openDashboard(path);
+}
+
 /**
  * HsUppy emits this once per successfully uploaded file. We own the
- * file-explorer ref directly (vs. HsUppy, which only sees it as a prop and
- * can't react to its delayed binding) so we shape the item the same way
- * readRootFolder does and push it into the right folder. Idempotent — skips
- * if the name already exists in the target folder.
+ * file-explorer ref directly, so we shape the item the same way readRootFolder
+ * does and push it into the right folder. Idempotent: skips if the name
+ * already exists in the target folder.
  */
 function onUppyFileUploaded(file: any) {
   if (!fileExplorer.value || !file) return;
@@ -1932,7 +1934,6 @@ async function _uploadFiles(
         if (!uppy) {
           throw new Error("Uppy instance not available");
         }
-        uppy.getPlugin("Dashboard")?.openModal();
         const fileId = uppy.addFile({
           name: file.name,
           type: file.file?.type || "application/octet-stream",

--- a/discovery-atlas/frontend/src/components/landing-page/hs-uppy.vue
+++ b/discovery-atlas/frontend/src/components/landing-page/hs-uppy.vue
@@ -3,13 +3,13 @@
 </template>
 
 <script lang="ts">
-import { CzFileExplorer } from "@cznethub/cznet-vue-core";
 import Uppy from "@uppy/core";
 import GoldenRetriever from "@uppy/golden-retriever";
 import GoogleDrivePicker from "@uppy/google-drive-picker";
 import Dashboard from "@uppy/dashboard";
 import AwsS3 from "@uppy/aws-s3";
 import User from "@/models/user.model";
+import { buildUploadKey } from "./upload-key";
 import {
   COMPANION_URL,
   GOOGLE_PICKER_CLIENT_ID,
@@ -112,48 +112,16 @@ const props = withDefaults(
      * files wouldn't appear when readRootFolder walks `data/contents/`.
      */
     uploadPrefix?: string;
-    // `default: null` (not `false`) — the parent's `fileExplorer` ref is
-    // `undefined` until the explorer mounts, and HsUppy renders BEFORE that
-    // (it's now a slot child of cz-file-explorer). Falsy default + a non-Object
-    // value would trip Vue's prop validator with the boolean `false`. Allow
-    // both Object and null/undefined, since registerUploadedFile already
-    // guards against the falsy case at call time.
-    fileExplorer?: InstanceType<typeof CzFileExplorer> | null;
   }>(),
   {
     s3Host: "http://localhost:9000",
     uploadPrefix: "",
-    fileExplorer: null,
   },
 );
 
 const emit = defineEmits(["file-uploaded"]);
 
 const selectedFolder = ref<string | null>(null);
-
-watch(() => props.fileExplorer?.selected, onFileSelect);
-
-function onFileSelect() {
-  // if the selected is a folder, set selectedFolder
-  let selected = props.fileExplorer!.selected;
-  // if selected is an array, take the first element
-  if (Array.isArray(selected)) {
-    if (selected.length > 0) {
-      selected = selected[0];
-    } else {
-      selectedFolder.value = null;
-      return;
-    }
-  }
-  // const isFolder = Object.prototype.hasOwnProperty.call(selected, "children");
-  const isFolder = props.fileExplorer!.isFolder(selected);
-  if (isFolder) {
-    selectedFolder.value = props.fileExplorer!.getPathString(selected);
-  } else {
-    selectedFolder.value = null;
-  }
-  console.log("selectedFolder set to:", selectedFolder.value);
-}
 
 // Method to expose the Uppy instance
 function getUppyInstance(): Uppy | null {
@@ -180,7 +148,19 @@ function upload(): Promise<void> {
   return Promise.reject(new Error("Uppy instance not available"));
 }
 
-defineExpose({ getUppyInstance, addFile, upload });
+/** Opens the upload modal with `folderPath` as the destination ("" = root). */
+function openDashboard(folderPath: string) {
+  if (!uppyInstance) {
+    return;
+  }
+  selectedFolder.value = folderPath || null;
+  uppyInstance.setMeta({
+    existing_path_in_resource: folderPath || undefined,
+  });
+  uppyInstance.getPlugin("Dashboard")?.openModal();
+}
+
+defineExpose({ getUppyInstance, addFile, upload, openDashboard });
 
 onMounted(() => {
   initializeUppy();
@@ -216,37 +196,29 @@ function initializeUppy() {
       id: "uppy",
       autoProceed: true,
       onBeforeUpload: (files) => {
-        // Build the S3 key from `uploadPrefix` (e.g. `<id>/data/contents/`),
-        // any selected subfolder, and the filename. Falls back to s3Info.prefix
-        // only when uploadPrefix wasn't passed — preserves the old contract.
-        const basePrefix =
-          props.uploadPrefix || props.s3Info.prefix || "";
+        const basePrefix = props.uploadPrefix || props.s3Info.prefix || "";
         Object.keys(files).forEach((fileId) => {
           const file = files[fileId];
           file.meta.bucket_name =
             file?.meta?.bucket_name || props.s3Info.bucket;
           if (!file.meta.dynamic_key) {
-            const folder =
-              file.meta.existing_path_in_resource || selectedFolder.value || "";
-            const folderPart = folder ? `${folder.replace(/^\/+|\/+$/g, "")}/` : "";
-            file.meta.dynamic_key = `${basePrefix}${folderPart}${file.name}`;
+            file.meta.dynamic_key = buildUploadKey(
+              basePrefix,
+              file.meta.existing_path_in_resource || selectedFolder.value,
+              file.name,
+            );
           }
-          console.log(
-            "Uppy upload key:",
-            file.meta.dynamic_key,
-            "bucket:",
-            file.meta.bucket_name,
-          );
         });
         return files;
       },
     }).use(Dashboard, {
-      inline: true,
+      inline: false,
+      // `true` puts `height: 100vh` on <body>, collapsing the host iframe.
+      disablePageScrollWhenModalOpen: false,
       fileManagerSelectionType: "both",
       target: "#uppy",
       showProgressDetails: true,
       width: "100%",
-      height: 320,
       note: `TODO: quota?`,
     });
 
@@ -276,21 +248,8 @@ function initializeUppy() {
         },
         uploadPartBytes: cookieUploadPartBytes,
       })
-      .on("dashboard:modal-open", () => {
-        // this is a hack to set the folder when the modal is opened
-        // because the selectedFolder will change when the user clicks in the dashboard
-        if (selectedFolder.value) {
-          uppyInstance.setMeta({
-            existing_path_in_resource: selectedFolder.value,
-          });
-          console.log("Set dashboard folder state to:", selectedFolder.value);
-        }
-      })
       .on("upload-success", (file: any) => {
-        // Hand off to the parent (which owns the file-explorer ref directly).
-        // The `fileExplorer` prop passed in here doesn't reliably propagate
-        // as a reactive value, so accessing it from inside this Uppy handler
-        // is unsafe; an event side-steps that.
+        // The parent owns the file-explorer ref and adds the node to the tree.
         emit("file-uploaded", file);
       })
       .on("error", (errorMessage) => {

--- a/discovery-atlas/frontend/src/components/landing-page/upload-key.ts
+++ b/discovery-atlas/frontend/src/components/landing-page/upload-key.ts
@@ -1,0 +1,9 @@
+/** S3 key for an uploaded file. Segments stay unencoded; the request layer encodes them. */
+export function buildUploadKey(
+  basePrefix: string,
+  folderPath: string | null | undefined,
+  fileName: string,
+): string {
+  const folder = (folderPath || "").replace(/^\/+|\/+$/g, "");
+  return `${basePrefix}${folder ? `${folder}/` : ""}${fileName}`;
+}

--- a/discovery-atlas/frontend/test/upload-key.test.ts
+++ b/discovery-atlas/frontend/test/upload-key.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { buildUploadKey } from "@/components/landing-page/upload-key";
+
+const prefix = "abc123/data/contents/";
+
+describe("buildUploadKey", () => {
+  it("puts a file at the root of the prefix when no folder is given", () => {
+    expect(buildUploadKey(prefix, "", "readme.md")).toBe(
+      "abc123/data/contents/readme.md",
+    );
+  });
+
+  it("treats null and undefined folders as the root", () => {
+    expect(buildUploadKey(prefix, null, "readme.md")).toBe(
+      "abc123/data/contents/readme.md",
+    );
+    expect(buildUploadKey(prefix, undefined, "readme.md")).toBe(
+      "abc123/data/contents/readme.md",
+    );
+  });
+
+  it("nests the file under the target folder", () => {
+    expect(buildUploadKey(prefix, "docs", "readme.md")).toBe(
+      "abc123/data/contents/docs/readme.md",
+    );
+  });
+
+  it("preserves separators in a nested folder path", () => {
+    expect(buildUploadKey(prefix, "docs/deep", "readme.md")).toBe(
+      "abc123/data/contents/docs/deep/readme.md",
+    );
+  });
+
+  it("strips stray leading and trailing slashes from the folder", () => {
+    expect(buildUploadKey(prefix, "/docs/", "readme.md")).toBe(
+      "abc123/data/contents/docs/readme.md",
+    );
+  });
+
+  it("does not encode the segments; the caller encodes at request time", () => {
+    expect(buildUploadKey(prefix, "New folder", "my file.txt")).toBe(
+      "abc123/data/contents/New folder/my file.txt",
+    );
+  });
+
+  it("works with an empty prefix", () => {
+    expect(buildUploadKey("", "docs", "readme.md")).toBe("docs/readme.md");
+  });
+});


### PR DESCRIPTION
Closes #6436. Requires https://github.com/cznethub/cznet-vue-core/pull/909

- The Uppy dashboard below the file listing is gone. Uploading
  is now an "Add files" button in the toolbar that opens Uppy's modal, plus
  drag and drop straight onto the browser.
- Uploads land in the selected folder, or the root when nothing is selected.
- The Uppy modal is positioned inside the visible band of the HydroShare
  iframe, reusing the existing `--hs-dialog-top` mechanism.
- Hides the Discard All button, which does not apply here since uploads are
  immediate rather than staged.

Also fixes two upload indicator bugs on this page: uploading spinner and completion icon.

<!--

Please read, and add your text at the bottom of this message.

Thanks for contributing code to HydroShare. In order to maintain code quality and expedite this process, please assist the development team by making sure the following is present in this pull request.

For more information, see https://docs.google.com/document/d/1dzxqlZW5fKNEyQSeKiSFq-SmS-VOPCva95XXkBjPExs

-->

### Pull Request Checklist: 
- [ ] Positive Test Case Written by Dev

<!-- Enter steps that a QA engineer, stakeholder, or user documentation writer would follow to test the positive or "successful" case of the functionality your code provides or fixes -->

- [ ] Automated Testing

<!-- Our Jenkins Instance is set up to automatically test every commit from a pull request. Code coverage must not decrease so new functionality or code paths added during a bug fix must have appropriate tests written. Every test must pass, including PEP8 code formatting tests. -->

- [x] Sufficient User and Developer Documentation
